### PR TITLE
Dev

### DIFF
--- a/sollumz_properties.py
+++ b/sollumz_properties.py
@@ -255,7 +255,8 @@ class EntityProperties(bpy.types.PropertyGroup):
 
 
 def hide_obj_and_children(obj, value):
-    obj.hide_set(value)
+    if obj.name in bpy.context.view_layer.objects:
+        obj.hide_set(value)
     for child in obj.children:
         hide_obj_and_children(child, value)
 
@@ -274,9 +275,10 @@ def get_hide_collisions(self):
 def set_hide_collisions(self, value):
     self["hide_collision"] = value
 
-    for obj in bpy.context.collection.objects:
+    for obj in bpy.context.collection.all_objects:
         if(obj.sollum_type in BoundType._value2member_map_ or obj.sollum_type in PolygonType._value2member_map_):
-            obj.hide_set(value)
+            if obj.name in bpy.context.view_layer.objects:
+                obj.hide_set(value)
 
 
 def get_hide_high_lods(self):
@@ -286,7 +288,7 @@ def get_hide_high_lods(self):
 def set_hide_high_lods(self, value):
     self["hide_high_lods"] = value
 
-    for obj in bpy.context.collection.objects:
+    for obj in bpy.context.collection.all_objects:
         if(obj.sollum_type == DrawableType.DRAWABLE_MODEL):
             if(obj.drawable_model_properties.sollum_lod == LODLevel.HIGH):
                 hide_obj_and_children(obj, value)
@@ -299,7 +301,7 @@ def get_hide_medium_lods(self):
 def set_hide_medium_lods(self, value):
     self["hide_medium_lods"] = value
 
-    for obj in bpy.context.collection.objects:
+    for obj in bpy.context.collection.all_objects:
         if(obj.sollum_type == DrawableType.DRAWABLE_MODEL):
             if(obj.drawable_model_properties.sollum_lod == LODLevel.MEDIUM):
                 hide_obj_and_children(obj, value)
@@ -312,7 +314,7 @@ def get_hide_low_lods(self):
 def set_hide_low_lods(self, value):
     self["hide_low_lods"] = value
 
-    for obj in bpy.context.collection.objects:
+    for obj in bpy.context.collection.all_objects:
         if(obj.sollum_type == DrawableType.DRAWABLE_MODEL):
             if(obj.drawable_model_properties.sollum_lod == LODLevel.LOW):
                 hide_obj_and_children(obj, value)
@@ -325,7 +327,7 @@ def get_hide_very_low_lods(self):
 def set_hide_very_low_lods(self, value):
     self["hide_very_low_lods"] = value
 
-    for obj in bpy.context.collection.objects:
+    for obj in bpy.context.collection.all_objects:
         if(obj.sollum_type == DrawableType.DRAWABLE_MODEL):
             if(obj.drawable_model_properties.sollum_lod == LODLevel.VERYLOW):
                 hide_obj_and_children(obj, value)

--- a/tools/boundhelper.py
+++ b/tools/boundhelper.py
@@ -110,9 +110,9 @@ def convert_selected_to_bound(objs, use_name, multiple, bvhs):
         # Remove materials
         if new_obj.type == 'MESH':
             new_obj.data.materials.clear()
-
-        # add default collision mat
-        new_obj.data.materials.append(create_collision_material_from_index(0))
+            # add default collision mat
+            new_obj.data.materials.append(
+                create_collision_material_from_index(0))
 
         bpy.data.objects.remove(obj, do_unlink=True)
         bpy.context.collection.objects.link(new_obj)

--- a/ybn/ui.py
+++ b/ybn/ui.py
@@ -185,8 +185,6 @@ class SOLLUMZ_PT_CREATE_BOUND_PANEL(bpy.types.Panel):
         layout.separator()
         row = layout.row()
         row.operator(SOLLUMZ_OT_create_polygon_bound.bl_idname)
-        row = layout.row()
-        # grid = layout.grid_flow(columns=2)
         row.prop(context.scene, "poly_bound_type")
         if context.active_object and context.active_object.mode == 'EDIT':
             row.prop(context.scene, "poly_parent", expand=True)

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -112,21 +112,20 @@ def texture_dictionary_from_materials(obj, exportpath):
 
                     texture_dictionary.append(texture_item)
 
-                    # if(n.image != None):
                     foldername = obj.name
                     folderpath = os.path.join(exportpath, foldername)
-                    txtpath = n.image.filepath
+                    txtpath = bpy.path.abspath(n.image.filepath)
                     if os.path.isfile(txtpath):
                         if(os.path.isdir(folderpath) == False):
                             os.mkdir(folderpath)
                         dstpath = folderpath + "\\" + \
-                            os.path.basename(n.image.filepath)
+                            os.path.basename(txtpath)
                         # check if paths are the same because if they are no need to copy
                         if txtpath != dstpath:
                             shutil.copyfile(txtpath, dstpath)
                     else:
                         messages.append(
-                            f"Missing Embedded Texture: {texture_name} please supply texture! The texture will not be copied to the texture folder until entered!")
+                            f"Missing Embedded Texture: {txtpath} please supply texture! The texture will not be copied to the texture folder until entered!")
 
     if(has_td):
         return texture_dictionary, messages


### PR DESCRIPTION
ccfcacca9dd77ad3dc27dce56ac54e44c55f3f73: 
On export, the os.path.isfile(txtpath) would return False because txtpath is not an absolute path. This fixes that.

7b256ccbb603afbd63a4169fed409794254334fe:
Previously, the hide tools under "General Tools" would only hide objects directly under the "Scene Collection". They now hide all objects present in the view layer.