### PR TITLE
Ytyp bug-fixes

### DIFF
--- a/ytyp/gizmos.py
+++ b/ytyp/gizmos.py
@@ -189,8 +189,8 @@ class PortalNormalGizmo(bpy.types.Gizmo):
                 z = [p[2] for p in corners]
                 centroid = Vector(
                     (sum(x) / len(corners), sum(y) / len(corners), sum(z) / len(corners)))
-                normal = (corners[2] - corners[0]
-                          ).cross(corners[1] - corners[0]).normalized()
+                normal = -(corners[2] - corners[0]
+                           ).cross(corners[1] - corners[0]).normalized()
                 # Axis parameter for draw_preset_arrow is an enum ugh
                 axis = "POS_X"
                 if normal == Vector((-1, 0, 0)):

--- a/ytyp/gizmos.py
+++ b/ytyp/gizmos.py
@@ -99,6 +99,8 @@ class RoomGizmoGroup(bpy.types.GizmoGroup):
 
     @classmethod
     def poll(cls, context):
+        if not context.scene.show_room_gizmo:
+            return False
         if can_draw_gizmos(context):
             selected_ytyp = get_selected_ytyp(context)
             selected_archetype = selected_ytyp.selected_archetype
@@ -212,8 +214,10 @@ class PortalGizmoGroup(bpy.types.GizmoGroup):
     bl_region_type = 'WINDOW'
     bl_options = {'3D', 'PERSISTENT', 'SELECT'}
 
-    @ classmethod
+    @classmethod
     def poll(cls, context):
+        if not context.scene.show_portal_gizmo:
+            return False
         if can_draw_gizmos(context):
             selected_ytyp = get_selected_ytyp(context)
             selected_archetype = selected_ytyp.selected_archetype

--- a/ytyp/operators.py
+++ b/ytyp/operators.py
@@ -10,6 +10,7 @@ from ..resources.ymap import *
 from .properties import *
 from bpy_extras.io_utils import ImportHelper
 from bpy_extras.view3d_utils import location_3d_to_region_2d
+from .gizmos import PortalGizmoGroup
 
 import os
 import traceback
@@ -37,6 +38,8 @@ class SOLLUMZ_OT_delete_ytyp(SOLLUMZ_OT_base, bpy.types.Operator):
     def run(self, context):
         context.scene.ytyps.remove(context.scene.ytyp_index)
         context.scene.ytyp_index = max(context.scene.ytyp_index - 1, 0)
+        # Force redraw of gizmos
+        context.space_data.show_gizmo = context.space_data.show_gizmo
 
         return True
 
@@ -124,6 +127,8 @@ class SOLLUMZ_OT_delete_archetype(SOLLUMZ_OT_base, bpy.types.Operator):
         selected_ytyp.archetypes.remove(selected_ytyp.archetype_index)
         selected_ytyp.archetype_index = max(
             selected_ytyp.archetype_index - 1, 0)
+        # Force redraw of gizmos
+        context.space_data.show_gizmo = context.space_data.show_gizmo
 
         return True
 
@@ -211,6 +216,9 @@ class SOLLUMZ_OT_delete_room(SOLLUMZ_OT_base, bpy.types.Operator):
         selected_archetype.rooms.remove(selected_archetype.room_index)
         selected_archetype.room_index = max(
             selected_archetype.room_index - 1, 0)
+        # Force redraw of gizmos
+        context.space_data.show_gizmo = context.space_data.show_gizmo
+
         return True
 
 
@@ -300,6 +308,8 @@ class SOLLUMZ_OT_delete_portal(SOLLUMZ_OT_base, bpy.types.Operator):
         selected_archetype.portals.remove(selected_archetype.portal_index)
         selected_archetype.portal_index = max(
             selected_archetype.portal_index - 1, 0)
+        # Force redraw of gizmos
+        context.space_data.show_gizmo = context.space_data.show_gizmo
         return True
 
 


### PR DESCRIPTION
After deleting a portal or room, the gizmos would not disappear until moving the camera. 1caf58175f4e3c2a7a2adc82d8f2f2378c2b3970 fixes this by running ``context.space_data.show_gizmo = context.space_data.show_gizmo`` which forces a redraw. This is a hacky solution but I spent a lot of time searching the API and there seems to be no other way to redraw the gizmos. 

The "Show Room Gizmo" and "Show Portal Gizmo" options were doing nothing. Not sure how that happened, but commit b88770602a9ea0c50ab70d28662fd953d58320db fixes that.

837542f Flips the direction of the portal arrow to illustrate more clearly what the "room from" and "room to" should be. The MLO tutorial explains this more.: https://github.com/Skylumz/Sollumz/wiki/MLO-(Interior)-Tutorial#8-create-portals .