### PR TITLE
Prevent ".001" suffix when creating a Drawable/Bound Composites

### DIFF
--- a/tools/boundhelper.py
+++ b/tools/boundhelper.py
@@ -91,8 +91,7 @@ def convert_selected_to_bound(selected, use_name, multiple, bvhs, replace_origin
             dmobj.parent = dobj
 
         if obj.type == 'MESH':
-            if use_name:
-                dobj.name = obj.name
+            name = obj.name
 
             poly_mesh = obj if replace_original else create_mesh(
                 SollumType.BOUND_POLY_TRIANGLE)
@@ -106,3 +105,6 @@ def convert_selected_to_bound(selected, use_name, multiple, bvhs, replace_origin
             else:
                 poly_mesh.data = obj.data.copy()
                 poly_mesh.matrix_world = obj.matrix_world
+
+            if use_name:
+                dobj.name = name

--- a/tools/drawablehelper.py
+++ b/tools/drawablehelper.py
@@ -54,7 +54,6 @@ def convert_selected_to_drawable(objs, use_names=False, multiple=False):
         obj.parent = dmobj
 
         name = obj.name
-        obj.name = name + "_geom"
 
         if use_names:
             dobj.name = name
@@ -69,6 +68,7 @@ def convert_selected_to_drawable(objs, use_names=False, multiple=False):
         # add object to collection
         bpy.data.objects.remove(obj, do_unlink=True)
         bpy.context.collection.objects.link(new_obj)
+        new_obj.name = name + "_geom"    
 
 
 def join_drawable_geometries(drawable):


### PR DESCRIPTION
This will prevent *.001 suffix when creating a Drawable/Bound Composites from a selection