### PR TITLE
Fix 'Volume Outer Color' color sliders + drawable names

### DIFF
--- a/tools/drawablehelper.py
+++ b/tools/drawablehelper.py
@@ -56,6 +56,7 @@ def convert_selected_to_drawable(objs, use_names=False, multiple=False):
         name = obj.name
 
         if use_names:
+            obj.name = name + '_old'
             dobj.name = name
 
         # set properties
@@ -68,7 +69,7 @@ def convert_selected_to_drawable(objs, use_names=False, multiple=False):
         # add object to collection
         bpy.data.objects.remove(obj, do_unlink=True)
         bpy.context.collection.objects.link(new_obj)
-        new_obj.name = name + "_geom"    
+        new_obj.name = name + "_geom"
 
 
 def join_drawable_geometries(drawable):

--- a/ydr/properties.py
+++ b/ydr/properties.py
@@ -112,7 +112,7 @@ class LightProperties(bpy.types.PropertyGroup):
     volume_intensity: bpy.props.FloatProperty(name="Volume Intensity")
     volume_size_scale: bpy.props.FloatProperty(name="Volume Size Scale")
     volume_outer_color: bpy.props.FloatVectorProperty(
-        name="Volume Outer Color", subtype='COLOR')
+        name="Volume Outer Color", subtype='COLOR', min=0.0, max=1.0)
     light_hash: bpy.props.IntProperty(name="Light Hash")
     volume_outer_intensity: bpy.props.FloatProperty(
         name="Volume Outer Intensity")


### PR DESCRIPTION
In sollumz light options, It was pretty much impossible to play with those sliders. Now it works like any other blender RGB picker
You can also set max='255' but since the light main color range is 0-1 in blender, its maybe easier like this.. idk

![image](https://user-images.githubusercontent.com/47056777/158133846-0fe1f5fb-1e52-4d0e-8d25-6e6141bd1c98.png)

Also fixed the names when creating drawables (Issue #278 )