### PR TITLE
Invert and transpose normal transformation matrix

### DIFF
--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -235,7 +235,7 @@ def get_mesh_buffers(obj, mesh, vertex_type, bones=None, export_settings=None):
             if "normal" in vertex_type._fields:
                 if loop.normal:
                     normal = float32_list(
-                        obj.matrix_world @ loop.normal if export_settings.use_transforms else obj.matrix_basis @ loop.normal)
+                        obj.matrix_world.inverted_safe().transposed().to_3x3() @ loop.normal if export_settings.use_transforms else obj.matrix_basis.inverted_safe().transposed().to_3x3() @ loop.normal)
                     kwargs["normal"] = tuple(normal)
                 else:
                     kwargs["normal"] = tuple([0, 0, 0])


### PR DESCRIPTION
Fixes #290 
Commit 6945a7d4b98ccba8b47ef08242113fdd51f46213 was handled incorrectly. The transformation matrix needs to be converted to a 3x3 and inverted and transposed before being applied to the normal vector. https://www.scratchapixel.com/lessons/mathematics-physics-for-computer-graphics/geometry/transforming-normals

