### PR TITLE
Fix texture compatibility with relative path

### DIFF
--- a/ydr/properties.py
+++ b/ydr/properties.py
@@ -238,7 +238,7 @@ def set_light_type(self, value):
 
 def get_texture_name(self):
     if self.image:
-        return basename(self.image.filepath.split('.')[0])
+        return basename(self.image.filepath).split('.')[0]
     return "None"
 
 


### PR DESCRIPTION
Hi,

I encountered a problem while exporting ydr files with the texture names.
This happened while using materials Asset Browser Library, so the texture path is referencing to another blend file.

Exported file screenshot : https://cdn.upload.systems/uploads/8yqnJPY4.png
Filepath of the texture : `//..\..\Blender Libraries\GTAV\doors\michael_doors.dds`

Here I printed the path of textures when exporting : https://cdn.upload.systems/uploads/ZmTsJbRa.png

It seems like using basename after splitting filepath defeat the point of this function.
It would probably be better to first basename() the filepath, and then split it to have the texture name.
We could also use splitext the filepath to remove the .dds extension while keeping any other dot in the file name, but having a dot in the file name would probably be a bad pratice anyway.
