### PR TITLE
[YDR] New logic and workflow for YDR creation and i/o with armatures

### DIFF
--- a/ydr/properties.py
+++ b/ydr/properties.py
@@ -19,7 +19,7 @@ class DrawableProperties(bpy.types.PropertyGroup):
 class DrawableModelProperties(bpy.types.PropertyGroup):
     render_mask: bpy.props.IntProperty(name="Render Mask", default=255)
     flags: bpy.props.IntProperty(name="Flags", default=0)
-    bone_index: bpy.props.IntProperty(name="Bone Index", default=0)
+    # bone_index: bpy.props.IntProperty(name="Bone Index", default=0)
     unknown_1: bpy.props.IntProperty(name="Unknown 1", default=0)
     sollum_lod: bpy.props.EnumProperty(
         items=items_from_enums(LODLevel),

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -22,7 +22,7 @@ def draw_drawable_model_properties(self, context):
     if obj and obj.sollum_type == SollumType.DRAWABLE_MODEL:
         layout = self.layout
         layout.prop(obj.drawable_model_properties, "render_mask")
-        layout.prop(obj.drawable_model_properties, "bone_index")
+        # layout.prop(obj.drawable_model_properties, "bone_index")
         layout.prop(obj.drawable_model_properties, "unknown_1")
         layout.prop(obj.drawable_model_properties, "flags")
         layout.prop(obj.drawable_model_properties, "sollum_lod")

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -396,7 +396,24 @@ def drawable_model_from_object(obj, bones=None, materials=None, export_settings=
 
     drawable_model.render_mask = obj.drawable_model_properties.render_mask
     drawable_model.flags = obj.drawable_model_properties.flags
-    drawable_model.bone_index = obj.drawable_model_properties.bone_index
+    # drawable_model.bone_index = obj.drawable_model_properties.bone_index
+    drawable_constraints = obj.constraints
+    if len(drawable_constraints) > 0:
+        found_armature_constraint = False
+        for constraint in drawable_constraints:
+            if isinstance(constraint, bpy.types.ArmatureConstraint):
+                armature = constraint.targets[0].target
+                bone = constraint.targets[0].subtarget
+                bone_index = armature.data.bones[bone].bone_properties.tag
+                drawable_model.bone_index = bone_index
+                found_armature_constraint = True
+                break
+
+        if not found_armature_constraint:
+            drawable_model.bone_index = 0
+    else:
+        drawable_model.bone_index = 0
+
     drawable_model.unknown_1 = obj.drawable_model_properties.unknown_1
 
     if obj.children[0].vertex_groups:

--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -469,14 +469,26 @@ def geometry_to_obj_split_by_bone(model, materials, bones):
     return bobjs
 
 
-def drawable_model_to_obj(model, materials, name, lod, bones=None, import_settings=None):
+def drawable_model_to_obj(model, materials, name, lod, bones=None, import_settings=None, drawableName=None):
     dobj = bpy.data.objects.new(
         SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_MODEL], None)
     dobj.sollum_type = SollumType.DRAWABLE_MODEL
     dobj.empty_display_size = 0
     dobj.drawable_model_properties.sollum_lod = lod
     dobj.drawable_model_properties.render_mask = model.render_mask
-    dobj.drawable_model_properties.bone_index = model.bone_index
+    # dobj.drawable_model_properties.bone_index = model.bone_index
+    if bones != None and drawableName != None:
+        armature = bpy.data.objects[drawableName]
+        constraint = dobj.constraints.new('ARMATURE')
+        constraint.targets.new()
+        constraint.targets[0].target = armature
+
+        for bone in armature.pose.bones[:]:
+            bone_name = bone.name
+            bone_index = armature.data.bones[bone_name].bone_properties.tag
+            if bone_index == model.bone_index:
+                constraint.targets[0].subtarget = bone_name
+                break
     dobj.drawable_model_properties.unknown_1 = model.unknown_1
     dobj.drawable_model_properties.flags = model.flags
 
@@ -563,22 +575,22 @@ def drawable_to_obj(drawable, filepath, name, bones_override=None, materials=Non
 
     for model in drawable.drawable_models_high:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.HIGH, bones, import_settings)
+            model, materials, drawable.name, LODLevel.HIGH, bones, import_settings, name)
         dobj.parent = obj
 
     for model in drawable.drawable_models_med:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.MEDIUM, bones, import_settings)
+            model, materials, drawable.name, LODLevel.MEDIUM, bones, import_settings, name)
         dobj.parent = obj
 
     for model in drawable.drawable_models_low:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.LOW, bones, import_settings)
+            model, materials, drawable.name, LODLevel.LOW, bones, import_settings, name)
         dobj.parent = obj
 
     for model in drawable.drawable_models_vlow:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.VERYLOW, bones, import_settings)
+            model, materials, drawable.name, LODLevel.VERYLOW, bones, import_settings, name)
         dobj.parent = obj
 
     for model in obj.children:


### PR DESCRIPTION
Existing YDR creation with bone comes out a bit difficult to navigate. We spent more than a week thinking Sollumz had bug when exporting ydr with multiple bones but upon going through the code, we finally found how Sollumz manages the drawable_model and bone parenting. It uses `Bone Index` which represents the `BoneTag` of bone which is used by drawable model to link itself to the bone. 

## Issue with existing workflow:
- Terms like `Bone Index` and `BoneTag` are not very familier to general users. These fields are also hard to navigate let alone having knowledge about them in Sollumz UI.
- `Bone Index` needs to be assigned manually under Object properties for `Drawable Model` in order to parent it to any armature bone. The assigned `Bone Index` value should be the `BoneTag` value of the bone of the armature. This causes a convoluted workflow of manually switching to `Pose Mode`, checking the `BoneTag` value of the selected bone, coming back to `Object Mode` and then assigning the value Bone Index value to the Drawable Model which gets tiring very fast when working with multiple bones.
- Repetitive action of assigning the `BoneTag` first and then assigning the `Bone Index` is very prone to user error.
- Drawable Model are not parented to the bones in viewport using existing method. Each drawable model needs to be parented manually to bone by checking the `Bone Index` value for drawable model. This poses a great inconvenience when ydr's with bones are imported using Sollumz cause they are not parented to the bones and require manual work to get the objects linked in the viewport.
- Parenting of lights to the armature bones uses a seperate workflow of using `Object Constraint`. Having two different methods of linking different objects hinder a smooth workflow.

## Advantages of new workflow:
- Users only need to assign the `BoneTag` value for each bone. No longer need to manually toggle through multiple models and fetch and assign the `Bone Index` value.
- New workflow uses `Armature` constraint under `Object Constraint Properties` panel on `Drawable Model`. This provides a better user workflow and a proper UI to select the bone with which the Drawable Model needs to be parented to
- Using `Armature` constraint also automatically links the `Drawable Model` to the bone in the viewport which negates the process of manually parenting the drawble_model to bone. It is specially useful when ydr's are imported since they get automatically linked in viewport and are ready to be modified.
![image](https://user-images.githubusercontent.com/43913907/166207336-b4508f0b-2d8c-49b7-9198-f411a87b0adb.png)
- Makes the workflow in-line with the light-bone parenting

## Changes to codebase:
- Removed `Bone Index` UI input field from `Drawable Model` properties
- Detect constaints for the drawable model and assing the `bone_index` using the selected bone in Armature constraint
- Properly import and link the drawable model to bone using Armature constraint