### PR TITLE
[YDR] New workflow for YDR creation and i/o with armatures

### DIFF
--- a/ydr/properties.py
+++ b/ydr/properties.py
@@ -19,7 +19,7 @@ class DrawableProperties(bpy.types.PropertyGroup):
 class DrawableModelProperties(bpy.types.PropertyGroup):
     render_mask: bpy.props.IntProperty(name="Render Mask", default=255)
     flags: bpy.props.IntProperty(name="Flags", default=0)
-    bone_index: bpy.props.IntProperty(name="Bone Index", default=0)
+    # bone_index: bpy.props.IntProperty(name="Bone Index", default=0)
     unknown_1: bpy.props.IntProperty(name="Unknown 1", default=0)
     sollum_lod: bpy.props.EnumProperty(
         items=items_from_enums(LODLevel),

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -22,7 +22,7 @@ def draw_drawable_model_properties(self, context):
     if obj and obj.sollum_type == SollumType.DRAWABLE_MODEL:
         layout = self.layout
         layout.prop(obj.drawable_model_properties, "render_mask")
-        layout.prop(obj.drawable_model_properties, "bone_index")
+        # layout.prop(obj.drawable_model_properties, "bone_index")
         layout.prop(obj.drawable_model_properties, "unknown_1")
         layout.prop(obj.drawable_model_properties, "flags")
         layout.prop(obj.drawable_model_properties, "sollum_lod")

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -396,7 +396,19 @@ def drawable_model_from_object(obj, bones=None, materials=None, export_settings=
 
     drawable_model.render_mask = obj.drawable_model_properties.render_mask
     drawable_model.flags = obj.drawable_model_properties.flags
-    drawable_model.bone_index = obj.drawable_model_properties.bone_index
+    # drawable_model.bone_index = obj.drawable_model_properties.bone_index
+
+    drawable_model_parent = obj.parent
+    if drawable_model_parent.type == 'ARMATURE':
+        parent_bone = obj.parent_bone
+        if parent_bone != None and parent_bone != '':
+            drawable_model_bone_index = drawable_model_parent.data.bones[parent_bone].bone_properties.tag
+            drawable_model.bone_index = drawable_model_bone_index
+        else:
+            drawable_model.bone_index = 0
+    else:
+        drawable_model.bone_index = 0
+
     drawable_model.unknown_1 = obj.drawable_model_properties.unknown_1
 
     if obj.children[0].vertex_groups:

--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -469,14 +469,32 @@ def geometry_to_obj_split_by_bone(model, materials, bones):
     return bobjs
 
 
-def drawable_model_to_obj(model, materials, name, lod, bones=None, import_settings=None):
+def drawable_model_to_obj(model, materials, name, lod, bones=None, import_settings=None, armatureName=None):
     dobj = bpy.data.objects.new(
         SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_MODEL], None)
     dobj.sollum_type = SollumType.DRAWABLE_MODEL
     dobj.empty_display_size = 0
     dobj.drawable_model_properties.sollum_lod = lod
     dobj.drawable_model_properties.render_mask = model.render_mask
-    dobj.drawable_model_properties.bone_index = model.bone_index
+    # dobj.drawable_model_properties.bone_index = model.bone_index
+    if bones != None and armatureName != None:
+        armature = bpy.data.objects[armatureName]
+        parent_bone_name = None 
+        for bone in armature.pose.bones[:]:
+            bone_index = armature.data.bones[bone.name].bone_properties.tag
+            if bone_index == model.bone_index:
+                parent_bone_name = bone.name
+                break
+        
+        if parent_bone_name != None:
+            bone = armature.pose.bones.get(parent_bone_name)
+            bpy.context.evaluated_depsgraph_get().update()
+            dobj.parent = armature
+            dobj.parent_type = "BONE"
+            dobj.parent_bone = parent_bone_name
+            vec = bone.head - bone.tail
+            trans = Matrix.Translation(vec)
+            dobj.matrix_parent_inverse = bone.matrix.inverted() @ trans
     dobj.drawable_model_properties.unknown_1 = model.unknown_1
     dobj.drawable_model_properties.flags = model.flags
 
@@ -563,22 +581,22 @@ def drawable_to_obj(drawable, filepath, name, bones_override=None, materials=Non
 
     for model in drawable.drawable_models_high:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.HIGH, bones, import_settings)
+            model, materials, drawable.name, LODLevel.HIGH, bones, import_settings, name)
         dobj.parent = obj
 
     for model in drawable.drawable_models_med:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.MEDIUM, bones, import_settings)
+            model, materials, drawable.name, LODLevel.MEDIUM, bones, import_settings, name)
         dobj.parent = obj
 
     for model in drawable.drawable_models_low:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.LOW, bones, import_settings)
+            model, materials, drawable.name, LODLevel.LOW, bones, import_settings, name)
         dobj.parent = obj
 
     for model in drawable.drawable_models_vlow:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.VERYLOW, bones, import_settings)
+            model, materials, drawable.name, LODLevel.VERYLOW, bones, import_settings, name)
         dobj.parent = obj
 
     for model in obj.children:


### PR DESCRIPTION
Existing YDR creation with bone comes out a bit difficult to navigate. We spent more than a week thinking Sollumz had bug when exporting ydr with multiple bones but upon going through the code, we finally found how Sollumz manages the drawable_model and bone parenting. It uses `Bone Index` which represents the `BoneTag` of bone which is used by drawable model to link itself to the bone. 

## Issue with existing workflow:
- Terms like `Bone Index` and `BoneTag` are not very familier to general users. These fields are also hard to navigate let alone having knowledge about them in Sollumz UI.
- `Bone Index` needs to be assigned manually under Object properties for `Drawable Model` in order to parent it to any armature bone. The assigned `Bone Index` value should be the `BoneTag` value of the bone of the armature. This causes a convoluted workflow of manually switching to `Pose Mode`, checking the `BoneTag` value of the selected bone, coming back to `Object Mode` and then assigning the value Bone Index value to the Drawable Model which gets tiring very fast when working with multiple bones.
- Repetitive action of assigning the `BoneTag` first and then assigning the `Bone Index` is very prone to user error.
- Drawable Model are not parented to the bones in viewport using existing method. Each drawable model needs to be parented manually to bone by checking the `Bone Index` value for drawable model. This poses a great inconvenience when ydr's with bones are imported using Sollumz cause they are not parented to the bones and require manual work to get the objects linked in the viewport.
- Parenting of lights to the armature bones uses a seperate workflow of using `Object Constraint`. Having two different methods of linking different objects hinder a smooth workflow.

## Advantages of new workflow:
- Users only need to assign the `BoneTag` value for each bone. No longer need to manually toggle through multiple models and fetch and assign the `Bone Index` value.
- Users can now directly parent the `Drawable Model` to any bone in viewport or under `Relations` panel in `Object Properties` and the rest is automatically handeled upon importing/exporting the model
![image](https://user-images.githubusercontent.com/43913907/166324860-485aa6ad-a517-4071-a74b-7835f42e0e15.png)

- More user friendly, less prone to user errors

## Changes to codebase:
- Removed `Bone Index` UI input field from `Drawable Model` properties
- Detect parent bone for the drawable model and assing the `bone_index` using the selected bone's `BoneTag` value
- Properly import and link the drawable model to bone in viewport