### PR TITLE
Patch for broken YDD/YFT import/export

### DIFF
--- a/ydd/yddimport.py
+++ b/ydd/yddimport.py
@@ -23,8 +23,12 @@ def drawable_dict_to_obj(drawable_dict, filepath, import_settings):
             break
 
     for drawable in drawable_dict:
+        # Pass is_ydd=True in drawable_to_obj function to opt out the drawable_model and bone parenting. 
+        # If is_ydd is not passed or set to False in case of YDD,
+        # drawable_model and drawable_mesh are rotated by 180° on Z-axis
+
         drawable_obj = drawable_to_obj(
-            drawable, filepath, drawable.name, bones_override=drawable_with_skel.skeleton.bones if drawable_with_skel else None, import_settings=import_settings)
+            drawable, filepath, drawable.name, bones_override=drawable_with_skel.skeleton.bones if drawable_with_skel else None, import_settings=import_settings, is_ydd=True)
         if (armature_with_skel_obj is None and drawable_with_skel is not None and len(drawable.skeleton.bones) > 0):
             armature_with_skel_obj = drawable_obj
 

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -399,7 +399,7 @@ def drawable_model_from_object(obj, bones=None, materials=None, export_settings=
     # drawable_model.bone_index = obj.drawable_model_properties.bone_index
 
     drawable_model_parent = obj.parent
-    if drawable_model_parent.type == 'ARMATURE':
+    if drawable_model_parent.type == 'BONE':
         parent_bone = obj.parent_bone
         if parent_bone != None and parent_bone != '':
             drawable_model_bone_index = drawable_model_parent.data.bones[parent_bone].bone_properties.tag

--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -469,7 +469,7 @@ def geometry_to_obj_split_by_bone(model, materials, bones):
     return bobjs
 
 
-def drawable_model_to_obj(model, materials, name, lod, bones=None, import_settings=None, armatureName=None):
+def drawable_model_to_obj(model, materials, name, lod, bones=None, import_settings=None, armatureName=None, is_ydd=None):
     dobj = bpy.data.objects.new(
         SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_MODEL], None)
     dobj.sollum_type = SollumType.DRAWABLE_MODEL
@@ -477,24 +477,28 @@ def drawable_model_to_obj(model, materials, name, lod, bones=None, import_settin
     dobj.drawable_model_properties.sollum_lod = lod
     dobj.drawable_model_properties.render_mask = model.render_mask
     # dobj.drawable_model_properties.bone_index = model.bone_index
-    if bones != None and armatureName != None:
-        armature = bpy.data.objects[armatureName]
-        parent_bone_name = None 
-        for bone in armature.pose.bones[:]:
-            bone_index = armature.data.bones[bone.name].bone_properties.tag
-            if bone_index == model.bone_index:
-                parent_bone_name = bone.name
-                break
-        
-        if parent_bone_name != None:
-            bone = armature.pose.bones.get(parent_bone_name)
-            bpy.context.evaluated_depsgraph_get().update()
-            dobj.parent = armature
-            dobj.parent_type = "BONE"
-            dobj.parent_bone = parent_bone_name
-            vec = bone.head - bone.tail
-            trans = Matrix.Translation(vec)
-            dobj.matrix_parent_inverse = bone.matrix.inverted() @ trans
+    if (bones != None or armatureName != None) and (is_ydd == None or is_ydd == False):
+        does_armature_obj_exist = armatureName in bpy.data.objects
+        is_obj_armature = bpy.data.objects[armatureName].type
+        if does_armature_obj_exist == True and is_obj_armature == 'ARMATURE':
+            armature = bpy.data.objects[armatureName]
+            parent_bone_name = None 
+            for bone in armature.pose.bones[:]:
+                bone_index = armature.data.bones[bone.name].bone_properties.tag
+                if bone_index == model.bone_index:
+                    parent_bone_name = bone.name
+                    break
+            
+            if parent_bone_name != None:
+                bone = armature.pose.bones.get(parent_bone_name)
+                bpy.context.evaluated_depsgraph_get().update()
+                dobj.parent = armature
+                dobj.parent_type = "BONE"
+                dobj.parent_bone = parent_bone_name
+                vec = bone.head - bone.tail
+                trans = Matrix.Translation(vec)
+                dobj.matrix_parent_inverse = bone.matrix.inverted() @ trans
+
     dobj.drawable_model_properties.unknown_1 = model.unknown_1
     dobj.drawable_model_properties.flags = model.flags
 
@@ -532,7 +536,7 @@ def create_lights(lights, parent, armature_obj=None):
         lobj.parent = lights_parent
 
 
-def drawable_to_obj(drawable, filepath, name, bones_override=None, materials=None, import_settings=None):
+def drawable_to_obj(drawable, filepath, name, bones_override=None, materials=None, import_settings=None, is_ydd=None):
 
     if not materials:
         materials = shadergroup_to_materials(drawable.shader_group, filepath)
@@ -581,22 +585,22 @@ def drawable_to_obj(drawable, filepath, name, bones_override=None, materials=Non
 
     for model in drawable.drawable_models_high:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.HIGH, bones, import_settings, name)
+            model, materials, drawable.name, LODLevel.HIGH, bones, import_settings, name, is_ydd)
         dobj.parent = obj
 
     for model in drawable.drawable_models_med:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.MEDIUM, bones, import_settings, name)
+            model, materials, drawable.name, LODLevel.MEDIUM, bones, import_settings, name, is_ydd)
         dobj.parent = obj
 
     for model in drawable.drawable_models_low:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.LOW, bones, import_settings, name)
+            model, materials, drawable.name, LODLevel.LOW, bones, import_settings, name, is_ydd)
         dobj.parent = obj
 
     for model in drawable.drawable_models_vlow:
         dobj = drawable_model_to_obj(
-            model, materials, drawable.name, LODLevel.VERYLOW, bones, import_settings, name)
+            model, materials, drawable.name, LODLevel.VERYLOW, bones, import_settings, name, is_ydd)
         dobj.parent = obj
 
     for model in obj.children:

--- a/yft/yftexport.py
+++ b/yft/yftexport.py
@@ -117,7 +117,13 @@ def fragment_from_object(exportop, fobj, exportpath, export_settings=None):
     for idx in range(len(dobj.data.bones)):
         m = Matrix()
         for model in dobj.children:
-            if model.drawable_model_properties.bone_index == idx:
+            bone_index = 0
+            if model.parent_type == 'BONE':
+                parent_bone = model.parent_bone
+                if parent_bone != None and parent_bone != '':
+                    bone_index = model.parent.data.bones[parent_bone].bone_properties.tag
+
+            if bone_index == idx:
                 m = model.matrix_basis
         fragment.bones_transforms.append(
             BoneTransformItem("Item", m))

--- a/yft/yftimport.py
+++ b/yft/yftimport.py
@@ -223,8 +223,13 @@ def fragment_to_obj(fragment, filepath, import_settings=None):
             modeltransforms.append(transforms[i].value)
 
         for child in dobj.children:
-            boneidx = child.drawable_model_properties.bone_index
+            bone_index = 0
+            if child.parent_type == 'BONE':
+                parent_bone = child.parent_bone
+                if parent_bone != None and parent_bone != '':
+                    bone_index = child.parent.data.bones[parent_bone].bone_properties.tag
 
+            boneidx = bone_index
             m = modeltransforms[boneidx] if boneidx < len(
                 modeltransforms) else Matrix()
 


### PR DESCRIPTION
Last PR https://github.com/Skylumz/Sollumz/pull/323 removed the bone index UI component which was apparantly being used by YFT for importing/exporting.

It also introduced a new bone parenting method which causes YDD's drawable geometry to either get rotated by 180 degrees causing an inverted skeleton in viewport on import or throw an error on import when YDD contains multiple drawable components but only a single skeleton(cases with most NPC/SP peds).

Both the errors have been fixed and tested by some of the users which seem to work fine.