### PR TITLE
Patch for broken YDD/YFT import/export 

### DIFF
--- a/ydd/yddimport.py
+++ b/ydd/yddimport.py
@@ -23,8 +23,12 @@ def drawable_dict_to_obj(drawable_dict, filepath, import_settings):
             break
 
     for drawable in drawable_dict:
+        # Pass is_ydd=True in drawable_to_obj function to opt out the drawable_model and bone parenting. 
+        # If is_ydd is not passed or set to False in case of YDD,
+        # drawable_model and drawable_mesh are rotated by 180° on Z-axis
+
         drawable_obj = drawable_to_obj(
-            drawable, filepath, drawable.name, bones_override=drawable_with_skel.skeleton.bones if drawable_with_skel else None, import_settings=import_settings)
+            drawable, filepath, drawable.name, bones_override=drawable_with_skel.skeleton.bones if drawable_with_skel else None, import_settings=import_settings, is_ydd=True)
         if (armature_with_skel_obj is None and drawable_with_skel is not None and len(drawable.skeleton.bones) > 0):
             armature_with_skel_obj = drawable_obj
 

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -396,10 +396,9 @@ def drawable_model_from_object(obj, bones=None, materials=None, export_settings=
 
     drawable_model.render_mask = obj.drawable_model_properties.render_mask
     drawable_model.flags = obj.drawable_model_properties.flags
-    # drawable_model.bone_index = obj.drawable_model_properties.bone_index
 
     drawable_model_parent = obj.parent
-    if drawable_model_parent.type == 'ARMATURE':
+    if drawable_model_parent.type == 'BONE':
         parent_bone = obj.parent_bone
         if parent_bone != None and parent_bone != '':
             drawable_model_bone_index = drawable_model_parent.data.bones[parent_bone].bone_properties.tag

--- a/yft/yftexport.py
+++ b/yft/yftexport.py
@@ -117,7 +117,13 @@ def fragment_from_object(exportop, fobj, exportpath, export_settings=None):
     for idx in range(len(dobj.data.bones)):
         m = Matrix()
         for model in dobj.children:
-            if model.drawable_model_properties.bone_index == idx:
+            bone_index = 0
+            if model.parent_type == 'BONE':
+                parent_bone = model.parent_bone
+                if parent_bone != None and parent_bone != '':
+                    bone_index = model.parent.data.bones[parent_bone].bone_properties.tag
+
+            if bone_index == idx:
                 m = model.matrix_basis
         fragment.bones_transforms.append(
             BoneTransformItem("Item", m))

--- a/yft/yftimport.py
+++ b/yft/yftimport.py
@@ -223,7 +223,13 @@ def fragment_to_obj(fragment, filepath, import_settings=None):
             modeltransforms.append(transforms[i].value)
 
         for child in dobj.children:
-            boneidx = child.drawable_model_properties.bone_index
+            bone_index = 0
+            if child.parent_type == 'BONE':
+                parent_bone = child.parent_bone
+                if parent_bone != None and parent_bone != '':
+                    bone_index = child.parent.data.bones[parent_bone].bone_properties.tag
+
+            boneidx = bone_index
 
             m = modeltransforms[boneidx] if boneidx < len(
                 modeltransforms) else Matrix()


### PR DESCRIPTION
Last PR https://github.com/Skylumz/Sollumz/pull/323 removed the bone index UI component which was apparantly being used by YFT for importing/exporting.

It also introduced a new bone parenting method which causes YDD's drawable geometry to either get rotated by 180 degrees causing an inverted skeleton in viewport on import or throw an error on import when YDD contains multiple drawable components but only a single skeleton(cases with most NPC/SP peds).

Both the errors have been fixed and tested by some of the users which seem to work fine.