### PR TITLE
Added button to fix textures paths/extensions

### DIFF
--- a/sollumz_operators.py
+++ b/sollumz_operators.py
@@ -1,3 +1,4 @@
+import re
 import traceback
 import os
 import pathlib
@@ -693,7 +694,24 @@ class SOLLUMZ_OT_debug_hierarchy(SOLLUMZ_OT_base, bpy.types.Operator):
         self.message("Hierarchy successfuly set.")
         return True
 
+class SOLLUMZ_OT_debug_textures(SOLLUMZ_OT_base, bpy.types.Operator):
+    """Debug: Fix textures extensions. Press this button is you see '.dds.001' or any weird dds extension.\nYou will need to find missing textures after pressing this button"""
+    bl_idname = "sollumz.debug_textures"
+    bl_label = "Fix Textures"
+    bl_action = bl_label
+    bl_order = 100
 
+    def run(self, context):
+        regexDds = re.compile(r"(.dds.\d+).dds$", re.IGNORECASE)
+
+        for img in bpy.data.images:
+            img.filepath = regexDds.sub(".dds", img.filepath)
+        
+        for img in bpy.data.images:
+            img.reload()
+        
+        self.message('Textures succefully fixed, you may want to find missing textures now!')
+    
 def register():
     bpy.types.TOPBAR_MT_file_import.append(sollumz_menu_func_import)
     bpy.types.TOPBAR_MT_file_export.append(sollumz_menu_func_export)

--- a/sollumz_ui.py
+++ b/sollumz_ui.py
@@ -345,6 +345,9 @@ class SOLLUMZ_PT_DEBUG_PANEL(bpy.types.Panel):
         layout = self.layout
         layout.label(text="Sollumz Version: 1.3.1")
         row = layout.row()
+        row.operator("sollumz.debug_textures")
+        row.prop(context.scene, "debug_textures")
+        row = layout.row()
         row.operator("sollumz.debug_hierarchy")
         row.prop(context.scene, "debug_sollum_type")
 


### PR DESCRIPTION
Just added a "Fix textures" button cause when importing vanilla YDRs, you very often will have textures path looking like: `.dds.dds`, `.dds.001.dds`, `.dds.002.dds`, etc...

This button will look for all of these broken path and fix them.
You only have to do `File>External Data>Find missing textures` to make them working again.

Screenshot:
![image](https://user-images.githubusercontent.com/47056777/171434793-c55102d8-4874-4a1f-923c-195f15fa22be.png)

PS: sorry for double commit im not very used to git