### PR TITLE
Fixed broken file path for non-embedded textures

### DIFF
--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -81,7 +81,7 @@ def shadergroup_to_materials(shadergroup, filepath):
                         if not n.texture_properties.embedded:
                             # Set external texture name for non-embedded textures
                             n.image.source = "FILE"
-                            n.image.filepath = "//" + n.image.name + ".dds"
+                            n.image.filepath = "//" + param.texture_name + ".dds"
 
                         if param.name == "BumpSampler" and hasattr(n.image, "colorspace_settings"):
                             n.image.colorspace_settings.name = "Non-Color"


### PR DESCRIPTION
The nodes image name already contains the file extention and causing `.dds` to appear twice. It also will be faulty because Blender is altering the image name in case of an image with that name beeing already present in Blender `causing .001`.

Just using the texture name will make "Find missing files" work again.