### PR TITLE
new feature: apply recommended bone properties

### DIFF
--- a/cwxml/BoneProperties.xml
+++ b/cwxml/BoneProperties.xml
@@ -1,0 +1,10023 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bones>
+  <Item>
+    <Name>SKEL_ROOT</Name>
+    <Tag value="0" />
+    <Index value="0" />
+    <ParentIndex value="-1" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.0" y="0.007101" z="-0.018706" />
+    <Rotation x="0.0" y="0.0" z="1.0" w="0.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_Pelvis</Name>
+    <Tag value="11816" />
+    <Index value="1" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="45" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-1.6292068e-08" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.70710665" z="0.0" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Thigh</Name>
+    <Tag value="58271" />
+    <Index value="2" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="16" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.073508" y="-0.00022600219" z="-0.096118" />
+    <Rotation x="-0.0203208" y="0.038988568" z="-0.020012058" w="0.9988326" />
+    <Scale x="0.99999994" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Calf</Name>
+    <Tag value="63931" />
+    <Index value="3" />
+    <ParentIndex value="2" />
+    <SiblingIndex value="10" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.40651855" y="-4.589674e-08" z="-1.0277727e-06" />
+    <Rotation x="-1.7046948e-07" y="-2.80183e-06" z="-0.020961303" w="0.9997803" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Foot</Name>
+    <Tag value="14201" />
+    <Index value="4" />
+    <ParentIndex value="3" />
+    <SiblingIndex value="9" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.4129718" y="-1.5925616e-07" z="-5.3194817e-06" />
+    <Rotation x="-0.02181816" y="-0.032775477" z="0.61877424" w="0.78458154" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Toe0</Name>
+    <Tag value="2108" />
+    <Index value="5" />
+    <ParentIndex value="4" />
+    <SiblingIndex value="7" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.16152403" y="7.869676e-08" z="8.483767e-09" />
+    <Rotation x="0.984318" y="0.17640327" z="8.353487e-08" w="1.8155616e-07" />
+    <Scale x="1.0000005" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Flipper</Name>
+    <Tag value="58255" />
+    <Index value="6" />
+    <ParentIndex value="5" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.035480995" y="0.03023497" z="1.7653292e-09" />
+    <Rotation x="-4.319827e-08" y="4.109104e-08" z="-8.93844e-07" w="1.0" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>IK_L_Foot</Name>
+    <Tag value="65245" />
+    <Index value="7" />
+    <ParentIndex value="4" />
+    <SiblingIndex value="8" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.10168602" y="-0.06406995" z="1.2127202e-08" />
+    <Rotation x="-0.58039314" y="0.4039106" z="0.5641329" w="0.4263263" />
+    <Scale x="1.0000002" y="1.0000002" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>PH_L_Foot</Name>
+    <Tag value="57717" />
+    <Index value="8" />
+    <ParentIndex value="4" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.10168602" y="-0.06406995" z="1.2127202e-08" />
+    <Rotation x="-0.58039314" y="0.4039106" z="0.5641329" w="0.4263263" />
+    <Scale x="1.0000002" y="1.0000002" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_CalfBack</Name>
+    <Tag value="4115" />
+    <Index value="9" />
+    <ParentIndex value="3" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.06809332" y="-2.3748726e-08" z="-1.0598451e-06" />
+    <Rotation x="9.737952e-07" y="-4.255653e-06" z="0.02096152" w="0.9997803" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_L_Thigh</Name>
+    <Tag value="31696" />
+    <Index value="10" />
+    <ParentIndex value="2" />
+    <SiblingIndex value="11" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.39996353" y="-4.962203e-08" z="-1.0143849e-06" />
+    <Rotation x="3.684545e-08" y="2.0583393e-06" z="2.9540388e-07" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_ThighBack</Name>
+    <Tag value="24589" />
+    <Index value="11" />
+    <ParentIndex value="2" />
+    <SiblingIndex value="12" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.34500042" y="-4.170579e-08" z="-8.8085653e-07" />
+    <Rotation x="5.2241376e-07" y="-3.4647528e-06" z="-2.977904e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Knee</Name>
+    <Tag value="46078" />
+    <Index value="12" />
+    <ParentIndex value="2" />
+    <SiblingIndex value="13" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.40651855" y="-4.589674e-08" z="-1.0277727e-06" />
+    <Rotation x="-1.7046948e-07" y="-2.80183e-06" z="-0.020961303" w="0.9997803" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_BumRoot</Name>
+    <Tag value="64275" />
+    <Index value="13" />
+    <ParentIndex value="2" />
+    <SiblingIndex value="15" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-5.0931703e-09" y="3.6961865e-09" z="-2.590241e-09" />
+    <Rotation x="-0.025738448" y="0.0047714207" z="0.18217301" w="0.98291796" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Bum</Name>
+    <Tag value="56819" />
+    <Index value="14" />
+    <ParentIndex value="13" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="8.1490725e-09" y="-6.519258e-09" z="4.656613e-09" />
+    <Rotation x="-9.806828e-07" y="-3.725291e-07" z="4.4237827e-09" w="1.0" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_L_ThighRoll</Name>
+    <Tag value="23639" />
+    <Index value="15" />
+    <ParentIndex value="2" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-5.0931703e-09" y="3.6961865e-09" z="-2.590241e-09" />
+    <Rotation x="-1.1466909e-08" y="-3.0180672e-08" z="-1.7462304e-10" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Thigh</Name>
+    <Tag value="51826" />
+    <Index value="16" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="30" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.073508" y="-0.00022600219" z="0.096118" />
+    <Rotation x="0.02032081" y="-0.03898796" z="-0.020012045" w="0.9988326" />
+    <Scale x="1.0" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Calf</Name>
+    <Tag value="36864" />
+    <Index value="17" />
+    <ParentIndex value="16" />
+    <SiblingIndex value="24" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.40651855" y="3.306195e-08" z="4.02797e-08" />
+    <Rotation x="9.187187e-08" y="2.6448095e-06" z="-0.020961292" w="0.9997803" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Foot</Name>
+    <Tag value="52301" />
+    <Index value="18" />
+    <ParentIndex value="17" />
+    <SiblingIndex value="23" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.4129728" y="5.3923577e-07" z="7.371884e-06" />
+    <Rotation x="0.021818902" y="0.032776047" z="0.61877567" w="0.7845804" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Toe0</Name>
+    <Tag value="20781" />
+    <Index value="19" />
+    <ParentIndex value="18" />
+    <SiblingIndex value="21" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.161524" y="3.1199306e-08" z="1.11226655e-08" />
+    <Rotation x="0.98431796" y="0.17640336" z="8.873619e-08" w="1.3941286e-07" />
+    <Scale x="1.0000019" y="1.0000002" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Flipper</Name>
+    <Tag value="59791" />
+    <Index value="20" />
+    <ParentIndex value="19" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.04860593" y="0.030747034" z="0.00048302364" />
+    <Rotation x="0.0015288641" y="-0.039125826" z="5.89894e-05" w="0.9992331" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>IK_R_Foot</Name>
+    <Tag value="35502" />
+    <Index value="21" />
+    <ParentIndex value="18" />
+    <SiblingIndex value="22" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.10168501" y="-0.06406997" z="1.3839326e-08" />
+    <Rotation x="-0.56413215" y="0.4263283" z="0.5803915" w="0.40391192" />
+    <Scale x="0.99999976" y="0.99999976" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>PH_R_Foot</Name>
+    <Tag value="24806" />
+    <Index value="22" />
+    <ParentIndex value="18" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.10168501" y="-0.06406997" z="1.3839326e-08" />
+    <Rotation x="-0.56413215" y="0.4263283" z="0.5803915" w="0.40391192" />
+    <Scale x="0.99999976" y="0.99999976" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_CalfBack</Name>
+    <Tag value="45075" />
+    <Index value="23" />
+    <ParentIndex value="17" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.06400029" y="9.2666596e-08" z="9.884825e-07" />
+    <Rotation x="6.4843334e-08" y="8.90577e-09" z="2.2735912e-07" w="1.0" />
+    <Scale x="1.0000001" y="0.99999994" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_R_Thigh</Name>
+    <Tag value="38365" />
+    <Index value="24" />
+    <ParentIndex value="16" />
+    <SiblingIndex value="25" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.39917055" y="3.1664968e-08" z="1.0068179e-06" />
+    <Rotation x="-9.4587456e-08" y="-2.0822044e-06" z="-1.1641535e-10" w="1.0" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_ThighBack</Name>
+    <Tag value="20899" />
+    <Index value="25" />
+    <ParentIndex value="16" />
+    <SiblingIndex value="26" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.34500045" y="3.0267984e-08" z="8.7491935e-07" />
+    <Rotation x="-2.0139852e-08" y="3.8519797e-06" z="-2.9726655e-07" w="1.0" />
+    <Scale x="0.99999994" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Knee</Name>
+    <Tag value="16335" />
+    <Index value="26" />
+    <ParentIndex value="16" />
+    <SiblingIndex value="27" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.4065186" y="3.632158e-08" z="1.0289368e-06" />
+    <Rotation x="1.6627763e-07" y="2.5960207e-06" z="-0.020961002" w="0.9997803" />
+    <Scale x="0.99999994" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_BumRoot</Name>
+    <Tag value="1668" />
+    <Index value="27" />
+    <ParentIndex value="16" />
+    <SiblingIndex value="29" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="6.7811925e-09" y="6.9849193e-10" z="1.6880222e-09" />
+    <Rotation x="0.025738232" y="0.0047704307" z="0.18217319" w="0.98291796" />
+    <Scale x="0.99999994" y="0.99999976" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Bum</Name>
+    <Tag value="59033" />
+    <Index value="28" />
+    <ParentIndex value="27" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-6.9849193e-09" y="-3.259629e-09" z="3.2014214e-09" />
+    <Rotation x="1.5366822e-08" y="8.800998e-08" z="1.1874363e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_R_ThighRoll</Name>
+    <Tag value="6442" />
+    <Index value="29" />
+    <ParentIndex value="16" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="6.7811925e-09" y="6.9849193e-10" z="1.6880222e-09" />
+    <Rotation x="-5.343464e-07" y="9.638024e-07" z="-4.3597538e-08" w="1.0" />
+    <Scale x="1.0" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Bumstrap</Name>
+    <Tag value="36917" />
+    <Index value="30" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="31" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.030333" y="-0.158355" z="-0.118652" />
+    <Rotation x="-0.66446286" y="-0.24184497" z="0.6644631" w="0.24184479" />
+    <Scale x="0.99999994" y="0.9999997" z="0.9999995" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_LegStrap_1</Name>
+    <Tag value="16718" />
+    <Index value="31" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="35" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.15359601" y="-0.026610997" z="-0.260288" />
+    <Rotation x="-0.66308194" y="-7.90455e-07" z="0.74854684" w="7.90455e-07" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_LegStrap_2</Name>
+    <Tag value="16719" />
+    <Index value="32" />
+    <ParentIndex value="31" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.010745895" y="-0.0598143" z="-0.23743689" />
+    <Rotation x="-0.006303789" y="0.060103334" z="-0.10410548" w="0.99272853" />
+    <Scale x="1.0000001" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_LegStrap_3</Name>
+    <Tag value="16720" />
+    <Index value="33" />
+    <ParentIndex value="32" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.05173901" y="-0.09508698" z="0.236354" />
+    <Rotation x="0.1256218" y="-0.09569967" z="-0.27321577" w="0.9489014" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_LegStrap_4</Name>
+    <Tag value="16721" />
+    <Index value="34" />
+    <ParentIndex value="33" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.006662957" y="0.015003073" z="0.20509198" />
+    <Rotation x="0.030779691" y="0.0676706" z="0.023777664" w="0.9969493" />
+    <Scale x="1.0" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_LegStrap_1</Name>
+    <Tag value="22845" />
+    <Index value="35" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="40" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.148185" y="-0.024908002" z="0.256732" />
+    <Rotation x="-0.744184" y="-1.9960567e-06" z="0.66797465" w="1.7742726e-06" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_LegStrap_2</Name>
+    <Tag value="22846" />
+    <Index value="36" />
+    <ParentIndex value="35" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.009433302" y="-0.066690534" z="-0.23365372" />
+    <Rotation x="-7.0503376e-08" y="-0.0538879" z="1.4587821e-06" w="0.9985471" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_LegStrap_3</Name>
+    <Tag value="22847" />
+    <Index value="37" />
+    <ParentIndex value="36" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.059319954" y="-0.07109601" z="0.199522" />
+    <Rotation x="0.07652744" y="0.15723433" z="0.3616388" w="0.91577196" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_LegStrap_4</Name>
+    <Tag value="22848" />
+    <Index value="38" />
+    <ParentIndex value="37" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.03437397" y="0.0032540218" z="0.20435601" />
+    <Rotation x="-0.07652725" y="-0.1572342" z="-0.36163864" w="0.9157722" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_FrontClip</Name>
+    <Tag value="481" />
+    <Index value="39" />
+    <ParentIndex value="38" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.0037540058" y="-0.0009310021" z="0.0018670046" />
+    <Rotation x="-0.16561201" y="0.2958418" z="0.052160162" w="0.93932414" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Bumstrap</Name>
+    <Tag value="61493" />
+    <Index value="40" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="41" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.030333" y="-0.161916" z="0.118618" />
+    <Rotation x="0.6868496" y="-0.16804034" z="-0.68684983" w="0.16804028" />
+    <Scale x="0.99999994" y="0.99999976" z="0.9999989" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_L_BumRoll</Name>
+    <Tag value="39642" />
+    <Index value="41" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="42" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.013508001" y="-0.100226" z="-0.096117996" />
+    <Rotation x="0.0" y="0.0" z="-4.842878e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_R_BumRoll</Name>
+    <Tag value="42202" />
+    <Index value="42" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="43" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.013508001" y="-0.100226" z="0.09611801" />
+    <Rotation x="5.215407e-07" y="-2.4158453e-13" z="-4.842878e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Zipper</Name>
+    <Tag value="13823" />
+    <Index value="43" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="44" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.099347" y="0.122759" z="0.130838" />
+    <Rotation x="-0.49999994" y="0.49999994" z="0.49999988" w="0.50000024" />
+    <Scale x="0.9999999" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Zipper</Name>
+    <Tag value="13919" />
+    <Index value="44" />
+    <ParentIndex value="1" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.099346995" y="0.122759" z="-0.131" />
+    <Rotation x="-0.49999994" y="0.49999994" z="0.49999988" w="0.50000024" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_Spine_Root</Name>
+    <Tag value="57597" />
+    <Index value="45" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="315" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-1.6292068e-08" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="-0.70710665" z="0.0" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_Spine0</Name>
+    <Tag value="23553" />
+    <Index value="46" />
+    <ParentIndex value="45" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.018706" y="-0.01007" z="0.0" />
+    <Rotation x="-5.2215694e-07" y="-4.5294328e-07" z="-0.04761051" w="0.99886596" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_Spine1</Name>
+    <Tag value="24816" />
+    <Index value="47" />
+    <ParentIndex value="46" />
+    <SiblingIndex value="306" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.08485499" y="-6.682155e-14" z="-2.0455637e-11" />
+    <Rotation x="-4.9965074e-06" y="-2.5646585e-07" z="0.044387892" w="0.9990144" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_Spine2</Name>
+    <Tag value="24817" />
+    <Index value="48" />
+    <ParentIndex value="47" />
+    <SiblingIndex value="302" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.08592198" y="3.4911523e-09" z="-6.5725203e-12" />
+    <Rotation x="4.9988485e-06" y="-1.0548383e-07" z="-0.02384537" w="0.9997157" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_Spine3</Name>
+    <Tag value="24818" />
+    <Index value="49" />
+    <ParentIndex value="48" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.11289501" y="9.31297e-09" z="3.498002e-11" />
+    <Rotation x="-1.9967329e-06" y="-1.3246903e-07" z="0.033285968" w="0.999446" />
+    <Scale x="0.99999994" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Clavicle</Name>
+    <Tag value="64729" />
+    <Index value="50" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="84" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.218041" y="0.036433976" z="0.031919" />
+    <Rotation x="0.119502425" y="-0.77903354" z="-0.10088427" w="0.6071643" />
+    <Scale x="0.99999994" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_UpperArm</Name>
+    <Tag value="45509" />
+    <Index value="51" />
+    <ParentIndex value="50" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.18189466" y="1.0244548e-07" z="3.1017603e-06" />
+    <Rotation x="0.06215961" y="-0.3611857" z="0.13575521" w="0.9204627" />
+    <Scale x="0.9999998" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Forearm</Name>
+    <Tag value="61163" />
+    <Index value="52" />
+    <ParentIndex value="51" />
+    <SiblingIndex value="80" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.27417207" y="-1.3969839e-09" z="2.0098346e-06" />
+    <Rotation x="-1.5530055e-07" y="2.0266689e-06" z="0.039481603" w="0.9992203" />
+    <Scale x="0.99999994" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Hand</Name>
+    <Tag value="18905" />
+    <Index value="53" />
+    <ParentIndex value="52" />
+    <SiblingIndex value="76" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.25919527" y="-6.4843334e-08" z="-1.5269383e-06" />
+    <Rotation x="2.2117773e-10" y="-1.4095806e-07" z="-4.656613e-10" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger00</Name>
+    <Tag value="26610" />
+    <Index value="54" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="59" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.025857048" y="0.022764983" z="0.0006109472" />
+    <Rotation x="-0.049881127" y="-0.15601824" z="0.24832478" w="0.9547277" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger01</Name>
+    <Tag value="4089" />
+    <Index value="55" />
+    <ParentIndex value="54" />
+    <SiblingIndex value="58" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.056321997" y="1.9557774e-08" z="-2.31325e-09" />
+    <Rotation x="0.0052970364" y="0.011881302" z="-0.1440029" w="0.98949176" />
+    <Scale x="0.9999999" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger02</Name>
+    <Tag value="4090" />
+    <Index value="56" />
+    <ParentIndex value="55" />
+    <SiblingIndex value="57" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.035985027" y="-2.6077032e-08" z="-3.9494754e-09" />
+    <Rotation x="0.0016060176" y="0.010011965" z="-0.115533926" w="0.9932518" />
+    <Scale x="0.99999994" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Finger00</Name>
+    <Tag value="35939" />
+    <Index value="57" />
+    <ParentIndex value="55" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.015000992" y="-1.3038516e-08" z="1.0630158e-06" />
+    <Rotation x="7.753897e-09" y="-3.203728e-08" z="-9.778887e-09" w="1.0" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_FingerBulge00</Name>
+    <Tag value="24504" />
+    <Index value="58" />
+    <ParentIndex value="54" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.042619012" y="-0.024362994" z="0.014364969" />
+    <Rotation x="2.446852e-08" y="1.0173409e-09" z="1.5925616e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger10</Name>
+    <Tag value="26611" />
+    <Index value="59" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="63" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.10670707" y="0.02915597" z="-0.021098237" />
+    <Rotation x="-0.64476097" y="-0.059079554" z="-0.032992385" w="0.76138324" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger11</Name>
+    <Tag value="4169" />
+    <Index value="60" />
+    <ParentIndex value="59" />
+    <SiblingIndex value="62" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.047288988" y="-9.798678e-07" z="-1.0622898e-08" />
+    <Rotation x="-0.016798338" y="-0.031104825" z="-0.24323991" w="0.9693218" />
+    <Scale x="0.99999994" y="0.9999998" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger12</Name>
+    <Tag value="4170" />
+    <Index value="61" />
+    <ParentIndex value="60" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.024108985" y="9.890355e-07" z="-1.3737008e-08" />
+    <Rotation x="-0.0057926043" y="-0.010150993" z="-0.13526256" w="0.9907409" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Finger10</Name>
+    <Tag value="35923" />
+    <Index value="62" />
+    <ParentIndex value="59" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.021792993" y="9.371433e-09" z="-6.5920176e-09" />
+    <Rotation x="-5.1612733e-07" y="9.429641e-09" z="-7.590279e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger20</Name>
+    <Tag value="26612" />
+    <Index value="63" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="66" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.106342055" y="0.0051379725" z="-0.02273622" />
+    <Rotation x="-0.7020958" y="-0.100308135" z="-0.12540255" w="0.6937391" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger21</Name>
+    <Tag value="4185" />
+    <Index value="64" />
+    <ParentIndex value="63" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.051796973" y="-9.775596e-07" z="8.381903e-09" />
+    <Rotation x="-0.0070737265" y="-0.0152179925" z="-0.20448408" w="0.97872615" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger22</Name>
+    <Tag value="4186" />
+    <Index value="65" />
+    <ParentIndex value="64" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.03283901" y="1.0077617e-06" z="-1.3969839e-09" />
+    <Rotation x="-0.016172823" y="-0.028574077" z="-0.20346718" w="0.9785311" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger30</Name>
+    <Tag value="26613" />
+    <Index value="66" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="69" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.10014211" y="-0.017510023" z="-0.013329235" />
+    <Rotation x="-0.78387195" y="-0.02947491" z="-0.14438394" w="0.6031826" />
+    <Scale x="1.0" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger31</Name>
+    <Tag value="4137" />
+    <Index value="67" />
+    <ParentIndex value="66" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.044588976" y="8.381903e-09" z="-9.662472e-09" />
+    <Rotation x="0.001743757" y="-0.0013465658" z="-0.24992208" w="0.96826345" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger32</Name>
+    <Tag value="4138" />
+    <Index value="68" />
+    <ParentIndex value="67" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.030654015" y="9.313226e-10" z="-2.7939677e-09" />
+    <Rotation x="-0.02735448" y="-0.0050722957" z="-0.22550023" w="0.97384584" />
+    <Scale x="1.0000001" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger40</Name>
+    <Tag value="26614" />
+    <Index value="69" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="72" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.093703076" y="-0.033939023" z="0.0015987941" />
+    <Rotation x="-0.8335507" y="0.070921645" z="-0.11481199" w="0.5357068" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger41</Name>
+    <Tag value="4153" />
+    <Index value="70" />
+    <ParentIndex value="69" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.03822104" y="1.8626451e-08" z="-2.561137e-09" />
+    <Rotation x="0.0028127749" y="-0.02478234" z="-0.34978804" w="0.9364968" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_L_Finger42</Name>
+    <Tag value="4154" />
+    <Index value="71" />
+    <ParentIndex value="70" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.022898002" y="9.741634e-07" z="9.313226e-10" />
+    <Rotation x="-0.020559784" y="-0.008157903" z="-0.10414125" w="0.9943165" />
+    <Scale x="1.0" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>PH_L_Hand</Name>
+    <Tag value="60309" />
+    <Index value="72" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="73" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.054434035" y="-1.5832484e-08" z="-1.0235146e-07" />
+    <Rotation x="-1.1244008e-07" y="-8.965223e-06" z="-2.9988587e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>IK_L_Hand</Name>
+    <Tag value="36029" />
+    <Index value="73" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="74" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.054434035" y="-1.5832484e-08" z="-1.0235146e-07" />
+    <Rotation x="-1.1244008e-07" y="-8.965223e-06" z="-2.9988587e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_FingerTop00</Name>
+    <Tag value="41540" />
+    <Index value="74" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="75" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.079827055" y="0.04210197" z="-0.009243158" />
+    <Rotation x="-0.27495432" y="-0.1604099" z="0.105507836" w="0.9420919" />
+    <Scale x="0.9999999" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_HandSide</Name>
+    <Tag value="51082" />
+    <Index value="75" />
+    <ParentIndex value="53" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.051052023" y="-0.033568017" z="0.011898892" />
+    <Rotation x="-0.83355045" y="0.07092131" z="-0.11481177" w="0.53570694" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_L_ForeArmRoll</Name>
+    <Tag value="61007" />
+    <Index value="76" />
+    <ParentIndex value="52" />
+    <SiblingIndex value="77" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.12959811" y="-2.7474016e-08" z="-2.5353245e-07" />
+    <Rotation x="7.431916e-08" y="-9.82312e-08" z="-2.9848889e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>L_Cuff_ROOT</Name>
+    <Tag value="20970" />
+    <Index value="77" />
+    <ParentIndex value="52" />
+    <SiblingIndex value="79" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.2591942" y="-6.4319465e-08" z="-2.4922542e-06" />
+    <Rotation x="1.2203734e-06" y="3.497127e-07" z="0.7071063" w="0.70710737" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Cuff</Name>
+    <Tag value="53791" />
+    <Index value="78" />
+    <ParentIndex value="77" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.7462298e-10" y="-9.778887e-09" z="-1.3967489e-08" />
+    <Rotation x="-5.437046e-07" y="5.4748386e-07" z="2.5611373e-08" w="1.0" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Elbow</Name>
+    <Tag value="22711" />
+    <Index value="79" />
+    <ParentIndex value="52" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-4.656613e-10" y="7.450581e-09" z="7.0599953e-09" />
+    <Rotation x="5.20001e-07" y="-4.013009e-06" z="-2.477318e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_L_ArmRoll</Name>
+    <Tag value="5232" />
+    <Index value="80" />
+    <ParentIndex value="51" />
+    <SiblingIndex value="81" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="2.4912879e-08" y="-7.450581e-09" z="-1.9585045e-08" />
+    <Rotation x="-3.6900616e-08" y="-1.2004466e-07" z="2.0023435e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Bicep</Name>
+    <Tag value="64294" />
+    <Index value="81" />
+    <ParentIndex value="51" />
+    <SiblingIndex value="82" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.18082106" y="0.0100000035" z="-1.5637934e-08" />
+    <Rotation x="7.4419674e-08" y="-2.6600885e-06" z="-2.977904e-07" w="1.0" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_SkyDiveSleeve</Name>
+    <Tag value="2726" />
+    <Index value="82" />
+    <ParentIndex value="51" />
+    <SiblingIndex value="83" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.26952803" y="0.05847001" z="2.902924e-05" />
+    <Rotation x="0.00033863474" y="-0.008572059" z="0.039481044" w="0.9991835" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Sleeve</Name>
+    <Tag value="37692" />
+    <Index value="83" />
+    <ParentIndex value="51" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.25438005" y="0.059452012" z="0.007154974" />
+    <Rotation x="-1.3751652e-07" y="0.03740803" z="-3.0184341e-07" w="0.9993002" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Clavicle</Name>
+    <Tag value="10706" />
+    <Index value="84" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="118" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.21804099" y="0.036433972" z="-0.03191899" />
+    <Rotation x="-0.1195008" y="0.7790335" z="-0.10088034" w="0.60716516" />
+    <Scale x="1.0" y="1.0000001" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_UpperArm</Name>
+    <Tag value="40269" />
+    <Index value="85" />
+    <ParentIndex value="84" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.18189515" y="4.8428774e-08" z="-2.0118239e-06" />
+    <Rotation x="-0.06216014" y="0.36119157" z="0.1357549" w="0.92046046" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Forearm</Name>
+    <Tag value="28252" />
+    <Index value="86" />
+    <ParentIndex value="85" />
+    <SiblingIndex value="114" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.27417207" y="1.7229468e-08" z="-1.9682652e-06" />
+    <Rotation x="-3.140797e-08" y="-2.9959979e-06" z="0.039481625" w="0.9992203" />
+    <Scale x="1.0" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Hand</Name>
+    <Tag value="57005" />
+    <Index value="87" />
+    <ParentIndex value="86" />
+    <SiblingIndex value="110" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.25919515" y="5.0582457e-08" z="2.452387e-06" />
+    <Rotation x="-7.4296395e-08" y="1.2969835e-07" z="9.313226e-10" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger00</Name>
+    <Tag value="58866" />
+    <Index value="88" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="93" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.025858995" y="0.022764008" z="-0.0006119834" />
+    <Rotation x="0.049881686" y="0.15601769" z="0.24832383" w="0.954728" />
+    <Scale x="0.99999994" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger01</Name>
+    <Tag value="64016" />
+    <Index value="89" />
+    <ParentIndex value="88" />
+    <SiblingIndex value="92" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.056324" y="-9.313226e-10" z="1.0798449e-07" />
+    <Rotation x="-0.0052953498" y="-0.011881065" z="-0.14400397" w="0.98949164" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger02</Name>
+    <Tag value="64017" />
+    <Index value="90" />
+    <ParentIndex value="89" />
+    <SiblingIndex value="91" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.035984006" y="9.760261e-07" z="8.847215e-08" />
+    <Rotation x="-0.0016054483" y="-0.010014404" z="-0.11553397" w="0.99325174" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Finger00</Name>
+    <Tag value="11363" />
+    <Index value="91" />
+    <ParentIndex value="89" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.01500001" y="-1.4901161e-08" z="7.314326e-08" />
+    <Rotation x="4.0265604e-09" y="1.4400575e-07" z="-1.21071935e-08" w="1.0" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_FingerBulge00</Name>
+    <Tag value="27064" />
+    <Index value="92" />
+    <ParentIndex value="88" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.042618006" y="-0.024362992" z="-0.014362963" />
+    <Rotation x="4.1961812e-10" y="-3.4951452e-07" z="8.707866e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger10</Name>
+    <Tag value="58867" />
+    <Index value="93" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="97" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.10670705" y="0.029155023" z="0.021097234" />
+    <Rotation x="-0.7613833" y="0.032991227" z="0.05908009" w="0.6447609" />
+    <Scale x="0.99999994" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger11</Name>
+    <Tag value="64096" />
+    <Index value="94" />
+    <ParentIndex value="93" />
+    <SiblingIndex value="96" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.04729097" y="1.4901161e-08" z="-1.1350494e-08" />
+    <Rotation x="0.016798897" y="-0.031104723" z="0.24324138" w="0.96932137" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger12</Name>
+    <Tag value="64097" />
+    <Index value="95" />
+    <ParentIndex value="94" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.024107996" y="8.090865e-09" z="-1.1175871e-08" />
+    <Rotation x="0.0057920483" y="-0.010150675" z="0.13526323" w="0.9907408" />
+    <Scale x="0.99999994" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Finger10</Name>
+    <Tag value="11347" />
+    <Index value="96" />
+    <ParentIndex value="93" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.021793004" y="-3.236346e-08" z="-1.5978003e-08" />
+    <Rotation x="-3.0500814e-08" y="-4.6973582e-08" z="-1.0593794e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger20</Name>
+    <Tag value="58868" />
+    <Index value="97" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="100" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.10634307" y="0.0051380186" z="0.022735234" />
+    <Rotation x="-0.693739" y="0.12540227" z="0.10030913" w="0.7020959" />
+    <Scale x="0.99999994" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger21</Name>
+    <Tag value="64112" />
+    <Index value="98" />
+    <ParentIndex value="97" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.051797003" y="1.0129575e-06" z="-1.4202669e-08" />
+    <Rotation x="0.007074245" y="-0.01521777" z="0.2044828" w="0.9787263" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger22</Name>
+    <Tag value="64113" />
+    <Index value="99" />
+    <ParentIndex value="98" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.032838993" y="5.2024223e-08" z="-1.8626451e-09" />
+    <Rotation x="0.016172796" y="-0.028573802" z="0.20346723" w="0.97853106" />
+    <Scale x="0.9999998" y="1.0" z="0.9999998" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger30</Name>
+    <Tag value="58869" />
+    <Index value="100" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="103" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.10014306" y="-0.01750998" z="0.013328185" />
+    <Rotation x="-0.6031817" y="0.1443833" z="0.02947556" w="0.7838727" />
+    <Scale x="1.0" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger31</Name>
+    <Tag value="64064" />
+    <Index value="101" />
+    <ParentIndex value="100" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.04458901" y="-1.21071935e-08" z="-4.773028e-09" />
+    <Rotation x="-0.0017436524" y="-0.0013468753" z="0.24992244" w="0.96826345" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger32</Name>
+    <Tag value="64065" />
+    <Index value="102" />
+    <ParentIndex value="101" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.030654013" y="-2.0489097e-08" z="-6.170012e-09" />
+    <Rotation x="0.027353957" y="-0.0050731343" z="0.22549959" w="0.97384596" />
+    <Scale x="1.0" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger40</Name>
+    <Tag value="58870" />
+    <Index value="103" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="106" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.09370306" y="-0.033938985" z="-0.0015998563" />
+    <Rotation x="-0.5357047" y="0.11481298" z="-0.07092072" w="0.8335519" />
+    <Scale x="0.9999999" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger41</Name>
+    <Tag value="64080" />
+    <Index value="104" />
+    <ParentIndex value="103" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.03822102" y="-9.760261e-07" z="-1.5366822e-08" />
+    <Rotation x="-0.0028134652" y="-0.02478207" z="0.3497879" w="0.93649685" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_R_Finger42</Name>
+    <Tag value="64081" />
+    <Index value="105" />
+    <ParentIndex value="104" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.022898013" y="-1.1175871e-08" z="-3.7252903e-09" />
+    <Rotation x="0.02055927" y="-0.00815807" z="0.10414123" w="0.9943166" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>PH_R_Hand</Name>
+    <Tag value="28422" />
+    <Index value="106" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="107" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.05443502" y="1.6647391e-08" z="7.8821515e-08" />
+    <Rotation x="-1.8578324e-07" y="-9.261669e-06" z="2.9802322e-07" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>IK_R_Hand</Name>
+    <Tag value="6286" />
+    <Index value="107" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="108" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.05443502" y="1.6647391e-08" z="7.8821515e-08" />
+    <Rotation x="-1.8578324e-07" y="-9.261669e-06" z="2.9802322e-07" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_FingerTop00</Name>
+    <Tag value="61259" />
+    <Index value="108" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="109" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.079829015" y="0.042102024" z="0.00924215" />
+    <Rotation x="0.27495444" y="0.16040784" z="0.10550906" w="0.94209194" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_HandSide</Name>
+    <Tag value="26875" />
+    <Index value="109" />
+    <ParentIndex value="87" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.05105206" y="-0.03356899" z="-0.011897917" />
+    <Rotation x="-0.5357052" y="0.114812635" z="-0.07092097" w="0.8335516" />
+    <Scale x="0.99999994" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_R_ForeArmRoll</Name>
+    <Tag value="43810" />
+    <Index value="110" />
+    <ParentIndex value="86" />
+    <SiblingIndex value="111" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.12959811" y="2.3748726e-08" z="2.3192639e-07" />
+    <Rotation x="-3.7383785e-08" y="6.15088e-08" z="2.9802322e-07" w="1.0" />
+    <Scale x="1.0000001" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>R_Cuff_ROOT</Name>
+    <Tag value="23184" />
+    <Index value="111" />
+    <ParentIndex value="86" />
+    <SiblingIndex value="113" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.2591942" y="4.7148205e-08" z="2.5189765e-06" />
+    <Rotation x="-7.360955e-07" y="-7.203119e-07" z="0.70710707" w="0.7071065" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Cuff</Name>
+    <Tag value="24048" />
+    <Index value="112" />
+    <ParentIndex value="111" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-2.0954758e-09" y="1.3969839e-08" z="-2.2204006e-08" />
+    <Rotation x="1.5175843e-07" y="6.200358e-08" z="4.479662e-07" w="1.0" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Elbow</Name>
+    <Tag value="2992" />
+    <Index value="113" />
+    <ParentIndex value="86" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="1.8626451e-08" y="-1.8626451e-09" z="-1.4595884e-08" />
+    <Rotation x="3.8039366e-07" y="-2.919768e-06" z="8.1025064e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_R_ArmRoll</Name>
+    <Tag value="37119" />
+    <Index value="114" />
+    <ParentIndex value="85" />
+    <SiblingIndex value="115" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="2.0721927e-08" y="-1.2572855e-08" z="8.067943e-09" />
+    <Rotation x="-9.558257e-08" y="-8.9735614e-09" z="8.3004124e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Bicep</Name>
+    <Tag value="44575" />
+    <Index value="115" />
+    <ParentIndex value="85" />
+    <SiblingIndex value="116" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.18100004" y="5.355105e-09" z="-1.3170798e-08" />
+    <Rotation x="-5.4395093e-07" y="-2.119895e-06" z="-0.011070304" w="0.9999387" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_SkyDiveSleeve</Name>
+    <Tag value="4262" />
+    <Index value="116" />
+    <ParentIndex value="85" />
+    <SiblingIndex value="117" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.26954404" y="0.058472008" z="-2.0017787e-06" />
+    <Rotation x="-1.138165e-07" y="-2.7957078e-06" z="0.039482217" w="0.9992204" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Sleeve</Name>
+    <Tag value="37596" />
+    <Index value="117" />
+    <ParentIndex value="85" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.25437704" y="0.05945101" z="-0.0071560517" />
+    <Rotation x="2.5849203e-10" y="-0.038887095" z="-5.8251726e-10" w="0.9992436" />
+    <Scale x="1.0000001" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_Neck_1</Name>
+    <Tag value="39317" />
+    <Index value="118" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="282" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.24850005" y="-2.2354488e-08" z="-1.3287149e-11" />
+    <Rotation x="3.0425538e-06" y="-2.1783022e-07" z="0.10911469" w="0.99402916" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SKEL_Head</Name>
+    <Tag value="31086" />
+    <Index value="119" />
+    <ParentIndex value="118" />
+    <SiblingIndex value="281" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.11307591" y="-1.0165381e-06" z="-2.4427882e-10" />
+    <Rotation x="1.1963186e-05" y="-1.0083496e-06" z="-0.119666435" w="0.99281424" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>IK_Head</Name>
+    <Tag value="12844" />
+    <Index value="120" />
+    <ParentIndex value="119" />
+    <SiblingIndex value="121" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="5.3562005e-08" y="2.494471e-10" z="-2.1316282e-14" />
+    <Rotation x="3.999946e-06" y="2.1550566e-09" z="-4.658171e-10" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_facialRoot</Name>
+    <Tag value="65068" />
+    <Index value="121" />
+    <ParentIndex value="119" />
+    <SiblingIndex value="277" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.03724899" y="0.008495" z="1.9999577e-06" />
+    <Rotation x="-0.49779388" y="-0.5021964" z="-0.49779385" w="0.5021966" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_jaw</Name>
+    <Tag value="2849" />
+    <Index value="122" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="165" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-3.805667e-11" y="-0.00074794935" z="-0.048843" />
+    <Rotation x="-2.974254e-14" y="4.8297755e-10" z="8.9084476e-11" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_underChin</Name>
+    <Tag value="35477" />
+    <Index value="123" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="124" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-4.405365e-13" y="-0.08504092" z="0.11682199" />
+    <Rotation x="0.5591931" y="-1.2686444e-10" z="-8.680803e-11" w="0.8290374" />
+    <Scale x="1.0" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_underChin</Name>
+    <Tag value="9038" />
+    <Index value="124" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="125" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.032552995" y="-0.08005491" z="0.09853099" />
+    <Rotation x="0.39810085" y="0.37104672" z="0.05526948" w="0.83712924" />
+    <Scale x="0.99999994" y="0.99999994" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_chin</Name>
+    <Tag value="46456" />
+    <Index value="125" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="129" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="5.4178884e-13" y="-0.0858149" z="0.147472" />
+    <Rotation x="0.22495133" y="1.253842e-12" z="2.8383157e-12" w="0.97437" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_chinSkinBottom</Name>
+    <Tag value="39100" />
+    <Index value="126" />
+    <ParentIndex value="125" />
+    <SiblingIndex value="127" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.00030099996" y="-0.011813991" z="0.012570993" />
+    <Rotation x="0.3090167" y="4.7536486e-10" z="1.5308167e-10" w="0.9510567" />
+    <Scale x="1.0" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_chinSkinBottom</Name>
+    <Tag value="16015" />
+    <Index value="127" />
+    <ParentIndex value="125" />
+    <SiblingIndex value="128" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.015698997" y="-0.011165007" z="0.010252004" />
+    <Rotation x="0.29148197" y="0.23692602" z="-0.0013394878" w="0.92677" />
+    <Scale x="0.99999994" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_chinSkinBottom</Name>
+    <Tag value="40591" />
+    <Index value="128" />
+    <ParentIndex value="125" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.016300995" y="-0.011400007" z="0.011367981" />
+    <Rotation x="0.29148188" y="-0.23692615" z="0.0013395362" w="0.92677" />
+    <Scale x="1.0" y="0.9999998" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_tongueA</Name>
+    <Tag value="19068" />
+    <Index value="129" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="144" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.00015099999" y="-0.05970989" z="0.108555" />
+    <Rotation x="-0.1283996" y="-4.298816e-11" z="5.2094227e-12" w="0.9917225" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_tongueB</Name>
+    <Tag value="19069" />
+    <Index value="130" />
+    <ParentIndex value="129" />
+    <SiblingIndex value="142" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-9.826806e-12" y="0.0018800246" z="0.0117720105" />
+    <Rotation x="0.100126885" y="4.0172237e-11" z="3.6893817e-12" w="0.9949747" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_tongueC</Name>
+    <Tag value="19070" />
+    <Index value="131" />
+    <ParentIndex value="130" />
+    <SiblingIndex value="140" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-9.238832e-12" y="0.0009129026" z="0.011582997" />
+    <Rotation x="0.028456137" y="3.898001e-11" z="3.985986e-11" w="0.99959505" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_tongueD</Name>
+    <Tag value="19071" />
+    <Index value="132" />
+    <ParentIndex value="131" />
+    <SiblingIndex value="138" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-2.9309888e-12" y="-2.9353245e-08" z="0.0108610075" />
+    <Rotation x="1.3997213e-14" y="-4.0507777e-13" z="8.813263e-15" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_tongueE</Name>
+    <Tag value="19072" />
+    <Index value="133" />
+    <ParentIndex value="132" />
+    <SiblingIndex value="136" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-4.0589754e-12" y="-3.8230084e-08" z="0.009805998" />
+    <Rotation x="1.3993743e-14" y="-4.050779e-13" z="2.8592493e-13" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_tongueE</Name>
+    <Tag value="13810" />
+    <Index value="134" />
+    <ParentIndex value="133" />
+    <SiblingIndex value="135" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.007133999" y="2.2633133e-08" z="-3.1361935e-10" />
+    <Rotation x="1.8626307e-09" y="1.018229e-09" z="2.563054e-15" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_tongueE</Name>
+    <Tag value="12274" />
+    <Index value="135" />
+    <ParentIndex value="133" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.006954999" y="-4.9866426e-06" z="2.0007747e-09" />
+    <Rotation x="1.8627726e-09" y="1.018229e-09" z="2.5647887e-15" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_tongueD</Name>
+    <Tag value="13809" />
+    <Index value="136" />
+    <ParentIndex value="132" />
+    <SiblingIndex value="137" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.011347999" y="-2.7351232e-08" z="1.6444233e-09" />
+    <Rotation x="1.862773e-09" y="-3.6383838e-09" z="4.5666596e-16" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_tongueD</Name>
+    <Tag value="12273" />
+    <Index value="137" />
+    <ParentIndex value="132" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.011753998" y="-5.038217e-06" z="1.7837465e-10" />
+    <Rotation x="1.862773e-09" y="-3.6383838e-09" z="4.5666596e-16" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_tongueC</Name>
+    <Tag value="13808" />
+    <Index value="138" />
+    <ParentIndex value="131" />
+    <SiblingIndex value="139" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.015652997" y="-1.6759868e-08" z="-1.5538717e-09" />
+    <Rotation x="1.8624889e-09" y="-3.6383838e-09" z="4.531965e-16" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_tongueC</Name>
+    <Tag value="12272" />
+    <Index value="139" />
+    <ParentIndex value="131" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.016165998" y="-5.0291637e-06" z="6.644427e-10" />
+    <Rotation x="1.862773e-09" y="-3.6383838e-09" z="4.5666596e-16" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_tongueB</Name>
+    <Tag value="13807" />
+    <Index value="140" />
+    <ParentIndex value="130" />
+    <SiblingIndex value="141" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.016741998" y="0.0010510042" z="5.9992853e-05" />
+    <Rotation x="3.7239007e-09" y="5.2237796e-09" z="-1.9539925e-14" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_tongueB</Name>
+    <Tag value="12271" />
+    <Index value="141" />
+    <ParentIndex value="130" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.016741998" y="0.0010559614" z="5.9991373e-05" />
+    <Rotation x="1.8612556e-09" y="5.2237796e-09" z="-4.7961635e-14" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_tongueA</Name>
+    <Tag value="13806" />
+    <Index value="142" />
+    <ParentIndex value="129" />
+    <SiblingIndex value="143" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.017304" y="-1.0952661e-09" z="1.9591369e-09" />
+    <Rotation x="-1.1177471e-08" y="6.3936625e-09" z="1.8626471e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_tongueA</Name>
+    <Tag value="12270" />
+    <Index value="143" />
+    <ParentIndex value="129" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.017303996" y="-4.9740593e-06" z="-9.925998e-07" />
+    <Rotation x="-1.1177471e-08" y="6.3932077e-09" z="1.8626585e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_chinSkinTop</Name>
+    <Tag value="29222" />
+    <Index value="144" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="145" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.000100999976" y="-0.0754449" z="0.16209202" />
+    <Rotation x="-0.12186934" y="1.7365874e-11" z="7.099707e-11" w="0.99254614" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_chinSkinTop</Name>
+    <Tag value="16051" />
+    <Index value="145" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="146" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.015098998" y="-0.0751449" z="0.16119201" />
+    <Rotation x="-0.091416694" y="0.23637906" z="0.017803272" w="0.96718717" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_chinSkinMid</Name>
+    <Tag value="35226" />
+    <Index value="146" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="147" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-1.0000005e-06" y="-0.08674493" z="0.163292" />
+    <Rotation x="0.13052592" y="1.6980886e-12" z="-4.198137e-12" w="0.9914449" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_chinSkinMid</Name>
+    <Tag value="17447" />
+    <Index value="147" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="148" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.015698997" y="-0.086544886" z="0.162392" />
+    <Rotation x="0.13561526" y="0.29494712" z="0.06266153" w="0.94376284" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_chinSide</Name>
+    <Tag value="19038" />
+    <Index value="148" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="149" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.032398995" y="-0.079644926" z="0.152792" />
+    <Rotation x="0.107318856" y="0.31572452" z="0.18319213" w="0.9247926" />
+    <Scale x="0.99999994" y="0.99999994" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_chinSkinMid</Name>
+    <Tag value="62895" />
+    <Index value="149" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="150" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.015700998" y="-0.086844884" z="0.16139199" />
+    <Rotation x="0.13561566" y="-0.29494697" z="-0.06266117" w="0.94376284" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_chinSkinTop</Name>
+    <Tag value="61499" />
+    <Index value="150" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="151" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.015100996" y="-0.07624491" z="0.160692" />
+    <Rotation x="-0.091416694" y="-0.23637906" z="-0.017803255" w="0.96718717" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_chinSide</Name>
+    <Tag value="43614" />
+    <Index value="151" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="152" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.031301" y="-0.07914492" z="0.151792" />
+    <Rotation x="0.10731905" y="-0.31572405" z="-0.1831923" w="0.9247927" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_underChin</Name>
+    <Tag value="11252" />
+    <Index value="152" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="153" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.032551996" y="-0.080054924" z="0.09853101" />
+    <Rotation x="0.39810088" y="-0.37104672" z="-0.055269517" w="0.83712924" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipLowerSDK</Name>
+    <Tag value="47585" />
+    <Index value="153" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="157" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.016841995" y="-0.056437925" z="0.158909" />
+    <Rotation x="0.072306566" y="0.1877164" z="0.021603003" w="0.97932005" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipLowerAnalog</Name>
+    <Tag value="9290" />
+    <Index value="154" />
+    <ParentIndex value="153" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.8626451e-09" y="9.2666596e-08" z="1.816079e-08" />
+    <Rotation x="-1.4412217e-07" y="-3.49246e-08" z="-3.3760443e-08" w="1.0" />
+    <Scale x="0.9999999" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipLowerThicknessV</Name>
+    <Tag value="51017" />
+    <Index value="155" />
+    <ParentIndex value="154" />
+    <SiblingIndex value="156" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.00021399744" y="0.005821032" z="-0.00029699598" />
+    <Rotation x="-0.71354395" y="0.059383444" z="-0.01999437" w="0.69780296" />
+    <Scale x="0.9999999" y="0.9999999" z="0.9999998" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipLowerThicknessH</Name>
+    <Tag value="50811" />
+    <Index value="156" />
+    <ParentIndex value="154" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-4.5998022e-05" y="0.0037970478" z="0.0021130005" />
+    <Rotation x="-0.1358084" y="0.028824031" z="-0.051917076" w="0.98895395" />
+    <Scale x="0.9999998" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_lipLowerSDK</Name>
+    <Tag value="29317" />
+    <Index value="157" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="161" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="7.993606e-14" y="-0.057242893" z="0.165285" />
+    <Rotation x="0.05233618" y="8.539509e-13" z="-2.1845778e-12" w="0.9986295" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_lipLowerAnalog</Name>
+    <Tag value="55675" />
+    <Index value="158" />
+    <ParentIndex value="157" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-4.1033843e-13" y="-2.3266704e-08" z="1.504699e-08" />
+    <Rotation x="-6.333133e-08" y="-2.9430902e-12" z="1.0871304e-12" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_lipLowerThicknessV</Name>
+    <Tag value="50619" />
+    <Index value="159" />
+    <ParentIndex value="158" />
+    <SiblingIndex value="160" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-4.6362914e-13" y="0.006301024" z="-0.00029800073" />
+    <Rotation x="-0.71325064" y="1.6872509e-12" z="1.3664958e-12" w="0.70090914" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_lipLowerThicknessH</Name>
+    <Tag value="50669" />
+    <Index value="160" />
+    <ParentIndex value="158" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-2.433609e-13" y="0.004160965" z="0.0035390037" />
+    <Rotation x="-0.121869355" y="-1.7806366e-12" z="-2.3436082e-12" w="0.99254614" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipLowerSDK</Name>
+    <Tag value="41012" />
+    <Index value="161" />
+    <ParentIndex value="122" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-0.016842002" y="-0.056438886" z="0.15890901" />
+    <Rotation x="0.07230642" y="-0.18771636" z="-0.02160301" w="0.97932005" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipLowerAnalog</Name>
+    <Tag value="49881" />
+    <Index value="162" />
+    <ParentIndex value="161" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.0" y="1.8218998e-08" z="-1.44355e-08" />
+    <Rotation x="-3.492464e-10" y="2.8871003e-08" z="6.053598e-09" w="1.0" />
+    <Scale x="0.99999994" y="0.9999998" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipLowerThicknessV</Name>
+    <Tag value="50921" />
+    <Index value="163" />
+    <ParentIndex value="162" />
+    <SiblingIndex value="164" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.00021400116" y="0.005822021" z="-0.00029800087" />
+    <Rotation x="-0.7135439" y="-0.059383493" z="0.019994373" w="0.69780296" />
+    <Scale x="0.99999994" y="1.0000001" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipLowerThicknessH</Name>
+    <Tag value="50907" />
+    <Index value="164" />
+    <ParentIndex value="162" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="4.5998022e-05" y="0.0037980387" z="0.0021120007" />
+    <Rotation x="-0.13580836" y="-0.028824143" z="0.051917076" w="0.98895395" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_nose</Name>
+    <Tag value="8433" />
+    <Index value="165" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="174" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="1.178293e-10" y="0.0032360347" z="0.113935016" />
+    <Rotation x="-0.078459315" y="4.7408444e-10" z="1.2318263e-10" w="0.9969174" />
+    <Scale x="1.0" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_nostril</Name>
+    <Tag value="29474" />
+    <Index value="166" />
+    <ParentIndex value="165" />
+    <SiblingIndex value="168" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.022229994" y="-0.016242929" z="-0.006449018" />
+    <Rotation x="-0.06705011" y="0.6379385" z="0.021555426" w="0.76685995" />
+    <Scale x="1.0000001" y="1.0000002" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_nostrilThickness</Name>
+    <Tag value="49503" />
+    <Index value="167" />
+    <ParentIndex value="166" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.0067410134" y="-0.0040279636" z="-0.0032500029" />
+    <Rotation x="0.028140215" y="-0.9961805" z="-0.07236326" w="0.03995225" />
+    <Scale x="1.0" y="0.9999996" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_noseLower</Name>
+    <Tag value="57434" />
+    <Index value="168" />
+    <ParentIndex value="165" />
+    <SiblingIndex value="171" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="3.659295e-13" y="-0.026447963" z="-0.0033960117" />
+    <Rotation x="0.12186934" y="-1.4449565e-12" z="3.2080317e-12" w="0.99254614" />
+    <Scale x="1.0" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_noseLowerThickness</Name>
+    <Tag value="31189" />
+    <Index value="169" />
+    <ParentIndex value="168" />
+    <SiblingIndex value="170" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.004699999" y="0.0021729963" z="0.005215994" />
+    <Rotation x="-0.03592563" y="0.6839251" z="-0.12233824" w="0.7183239" />
+    <Scale x="1.0" y="1.0000001" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_noseLowerThickness</Name>
+    <Tag value="31093" />
+    <Index value="170" />
+    <ParentIndex value="168" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.0047" y="0.0021729954" z="0.0052159964" />
+    <Rotation x="-0.035925623" y="-0.6839253" z="0.1223383" w="0.7183237" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_noseTip</Name>
+    <Tag value="27232" />
+    <Index value="171" />
+    <ParentIndex value="165" />
+    <SiblingIndex value="172" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-3.5527137e-14" y="-0.016728913" z="0.006407" />
+    <Rotation x="0.19080876" y="5.084988e-13" z="2.168811e-12" w="0.9816272" />
+    <Scale x="1.0" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_nostril</Name>
+    <Tag value="31010" />
+    <Index value="172" />
+    <ParentIndex value="165" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-0.024580998" y="-0.018277897" z="-0.0053220186" />
+    <Rotation x="-0.06704999" y="-0.6379384" z="-0.021555528" w="0.76686007" />
+    <Scale x="1.0" y="0.9999999" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_nostrilThickness</Name>
+    <Tag value="14079" />
+    <Index value="173" />
+    <ParentIndex value="172" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.006738996" y="-0.004031961" z="-0.0032509975" />
+    <Rotation x="0.028140722" y="0.9961805" z="0.07236324" w="0.03995261" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_noseUpper</Name>
+    <Tag value="41039" />
+    <Index value="174" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="175" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.0010009998" y="0.016708057" z="0.109849006" />
+    <Rotation x="-0.29237163" y="8.7719726e-10" z="9.487005e-10" w="0.9563048" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_noseUpper</Name>
+    <Tag value="8120" />
+    <Index value="175" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="176" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.008498998" y="0.014507043" z="0.10394901" />
+    <Rotation x="-0.24219322" y="0.4057906" z="-0.1820958" w="0.86227465" />
+    <Scale x="0.99999994" y="1.0000001" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_noseBridge</Name>
+    <Tag value="39843" />
+    <Index value="176" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="177" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.0011009999" y="0.028708084" z="0.107449" />
+    <Rotation x="-7.450582e-08" y="3.874823e-10" z="-2.2577426e-15" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_nasolabialFurrow</Name>
+    <Tag value="23242" />
+    <Index value="177" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="178" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.035998996" y="-0.029592935" z="0.09954902" />
+    <Rotation x="0.02539152" y="0.07789611" z="-0.36399585" w="0.9277901" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_nasolabialBulge</Name>
+    <Tag value="52600" />
+    <Index value="178" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="179" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.036815997" y="-0.013621926" z="0.09229601" />
+    <Rotation x="-0.12608358" y="0.1763017" z="-0.093661055" w="0.9717244" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_cheekLower</Name>
+    <Tag value="26887" />
+    <Index value="179" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="182" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.054982994" y="-0.045869928" z="0.07004402" />
+    <Rotation x="0.0047067036" y="0.5005868" z="0.07778107" w="0.8621721" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_cheekLowerBulge1</Name>
+    <Tag value="58363" />
+    <Index value="180" />
+    <ParentIndex value="179" />
+    <SiblingIndex value="181" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.014178002" y="-0.0072141117" z="0.007422991" />
+    <Rotation x="0.06726229" y="-0.19365035" z="0.0051725702" w="0.9787485" />
+    <Scale x="1.0000001" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_cheekLowerBulge2</Name>
+    <Tag value="58364" />
+    <Index value="181" />
+    <ParentIndex value="179" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.00024300441" y="-0.008092102" z="0.0078009963" />
+    <Rotation x="0.08806679" y="-0.06436349" z="-0.00730453" w="0.99400616" />
+    <Scale x="0.99999994" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_cheekInner</Name>
+    <Tag value="59307" />
+    <Index value="182" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="183" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.021828998" y="-2.5932237e-05" z="0.095262006" />
+    <Rotation x="-0.051643416" y="0.13002522" z="-0.12938093" w="0.9816756" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_cheekOuter</Name>
+    <Tag value="33121" />
+    <Index value="183" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="184" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.05203799" y="-0.0107979" z="0.07132202" />
+    <Rotation x="-0.023426743" y="0.44604513" z="0.011680073" w="0.8946276" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyesackLower</Name>
+    <Tag value="30491" />
+    <Index value="184" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="185" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.035598997" y="0.0077070603" z="0.091349006" />
+    <Rotation x="0.083537854" y="0.14873122" z="0.0023137832" w="0.9853401" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyeball</Name>
+    <Tag value="5956" />
+    <Index value="185" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="186" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.033000994" y="0.021617062" z="0.08064201" />
+    <Rotation x="-2.6077028e-06" y="-4.8454274e-07" z="3.725416e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidLower</Name>
+    <Tag value="39308" />
+    <Index value="186" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="193" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.033000994" y="0.021271057" z="0.08064201" />
+    <Rotation x="0.1650459" y="-5.11539e-07" z="6.5482375e-08" w="0.986286" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidLowerOuterSDK</Name>
+    <Tag value="65100" />
+    <Index value="187" />
+    <ParentIndex value="186" />
+    <SiblingIndex value="190" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.0073589957" y="-0.0011319759" z="0.014366005" />
+    <Rotation x="0.004320636" y="0.1649912" z="0.025817955" w="0.9859476" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidLowerOuterAnalog</Name>
+    <Tag value="47530" />
+    <Index value="188" />
+    <ParentIndex value="187" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="1.8626451e-09" y="-4.1909516e-08" z="2.3283064e-08" />
+    <Rotation x="1.396984e-08" y="2.0489097e-08" z="1.1175872e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelashLowerOuter</Name>
+    <Tag value="55286" />
+    <Index value="189" />
+    <ParentIndex value="188" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-1.9993633e-05" y="0.00037292833" z="0.0016259998" />
+    <Rotation x="-0.038002178" y="0.088478304" z="-0.040921867" w="0.99451137" />
+    <Scale x="1.0" y="1.0000001" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidLowerInnerSDK</Name>
+    <Tag value="61777" />
+    <Index value="190" />
+    <ParentIndex value="186" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.0035290008" y="-0.00016199825" z="0.016121002" />
+    <Rotation x="0.0030416688" y="-0.08710245" z="-0.03476646" w="0.9955879" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidLowerInnerAnalog</Name>
+    <Tag value="33346" />
+    <Index value="191" />
+    <ParentIndex value="190" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-4.656613e-09" y="-7.916242e-09" z="-1.816079e-08" />
+    <Rotation x="5.0524257e-08" y="-4.4703484e-08" z="-4.6566132e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelashLowerInner</Name>
+    <Tag value="19663" />
+    <Index value="192" />
+    <ParentIndex value="191" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.00023300387" y="0.00014896714" z="0.0017649881" />
+    <Rotation x="-0.06760567" y="-0.004626803" z="0.010516279" w="0.997646" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidUpper</Name>
+    <Tag value="38849" />
+    <Index value="193" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="200" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.033000994" y="0.021963067" z="0.08064201" />
+    <Rotation x="-0.13917471" y="-4.859622e-07" z="-4.4559094e-08" w="0.99026793" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidUpperOuterSDK</Name>
+    <Tag value="44821" />
+    <Index value="194" />
+    <ParentIndex value="193" />
+    <SiblingIndex value="197" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.009108999" y="-0.001276853" z="0.014206014" />
+    <Rotation x="0.020418784" y="0.1289191" z="-0.15509598" w="0.97923857" />
+    <Scale x="0.9999999" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidUpperOuterAnalog</Name>
+    <Tag value="26618" />
+    <Index value="195" />
+    <ParentIndex value="194" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-5.5879354e-09" y="3.1664968e-08" z="1.8626451e-09" />
+    <Rotation x="7.636845e-08" y="3.5390258e-08" z="2.9802322e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelashUpperOuter</Name>
+    <Tag value="10167" />
+    <Index value="196" />
+    <ParentIndex value="195" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.0004720129" y="-0.0017620232" z="0.0026330221" />
+    <Rotation x="0.19177976" y="0.046285998" z="0.014565927" w="0.9802377" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidUpperInnerSDK</Name>
+    <Tag value="54081" />
+    <Index value="197" />
+    <ParentIndex value="193" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.0028250022" y="-0.0010869564" z="0.016324002" />
+    <Rotation x="-0.13898261" y="0.007283785" z="0.05182661" w="0.9889109" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelidUpperInnerAnalog</Name>
+    <Tag value="61586" />
+    <Index value="198" />
+    <ParentIndex value="197" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="1.0244548e-08" y="-5.844049e-08" z="-9.852499e-09" />
+    <Rotation x="-1.5256882e-07" y="3.4224286e-09" z="4.656613e-09" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyelashUpperInner</Name>
+    <Tag value="39711" />
+    <Index value="199" />
+    <ParentIndex value="198" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-5.6000426e-05" y="-0.0019500353" z="0.0016549601" />
+    <Rotation x="0.32373732" y="-0.07761584" z="-0.01718094" w="0.94280154" />
+    <Scale x="1.0" y="1.0000001" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyesackUpperOuterBulge</Name>
+    <Tag value="42329" />
+    <Index value="200" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="201" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.045002997" y="0.030477047" z="0.094405" />
+    <Rotation x="0.3882139" y="0.13949941" z="-0.25804928" w="0.87363636" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyesackUpperInnerBulge</Name>
+    <Tag value="12074" />
+    <Index value="201" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="202" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.029659998" y="0.032146093" z="0.09906901" />
+    <Rotation x="0.4313978" y="0.05012697" z="-0.059660427" w="0.89879024" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyesackUpperOuterFurrow</Name>
+    <Tag value="50583" />
+    <Index value="202" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="203" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.043498997" y="0.027807059" z="0.092649" />
+    <Rotation x="0.3771198" y="0.15236634" z="-0.3422201" w="0.84702456" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyesackUpperInnerFurrow</Name>
+    <Tag value="21159" />
+    <Index value="203" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="204" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.028698996" y="0.02910709" z="0.096149" />
+    <Rotation x="0.4538349" y="0.011883973" z="-0.023323782" w="0.89070123" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_forehead</Name>
+    <Tag value="37400" />
+    <Index value="204" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="205" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="9.6950004e-11" y="0.043839086" z="0.098974" />
+    <Rotation x="-0.061048534" y="4.7597726e-10" z="1.1469281e-10" w="0.9981349" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_foreheadInner</Name>
+    <Tag value="2115" />
+    <Index value="205" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="207" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.018119998" y="0.045344047" z="0.09684401" />
+    <Rotation x="-0.06971398" y="0.03470838" z="-0.0036479437" w="0.99695647" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_foreheadInnerBulge</Name>
+    <Tag value="30332" />
+    <Index value="206" />
+    <ParentIndex value="205" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.00041899644" y="-0.012636027" z="-0.005554978" />
+    <Rotation x="0.38372764" y="-0.078983195" z="0.1267522" w="0.9112896" />
+    <Scale x="0.9999999" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_foreheadOuter</Name>
+    <Tag value="36299" />
+    <Index value="207" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="208" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.04705499" y="0.045601077" z="0.084297016" />
+    <Rotation x="-0.14761513" y="0.37988162" z="-0.18970013" w="0.8932601" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_skull</Name>
+    <Tag value="16929" />
+    <Index value="208" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="214" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="1.3560708e-11" y="0.050601054" z="0.014111999" />
+    <Rotation x="-0.21126214" y="4.546562e-10" z="1.8819633e-10" w="0.97742945" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_foreheadUpper</Name>
+    <Tag value="63446" />
+    <Index value="209" />
+    <ParentIndex value="208" />
+    <SiblingIndex value="210" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.00010099998" y="-0.009775023" z="0.09300202" />
+    <Rotation x="0.020878492" y="-1.0465023e-11" z="6.218604e-14" w="0.999782" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_foreheadUpperInner</Name>
+    <Tag value="53011" />
+    <Index value="210" />
+    <ParentIndex value="208" />
+    <SiblingIndex value="211" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.023452997" y="-0.0067909756" z="0.08787706" />
+    <Rotation x="-0.013884966" y="0.19894913" z="-0.043798976" w="0.97893214" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_foreheadUpperOuter</Name>
+    <Tag value="20635" />
+    <Index value="211" />
+    <ParentIndex value="208" />
+    <SiblingIndex value="212" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.043998998" y="-0.0039459844" z="0.076759055" />
+    <Rotation x="-0.08811167" y="0.38466117" z="-0.08992653" w="0.9144317" />
+    <Scale x="1.0" y="0.99999994" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_foreheadUpperInner</Name>
+    <Tag value="52979" />
+    <Index value="212" />
+    <ParentIndex value="208" />
+    <SiblingIndex value="213" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.024471994" y="-0.0066669644" z="0.08881205" />
+    <Rotation x="-0.013884898" y="-0.19894908" z="0.04379896" w="0.97893214" />
+    <Scale x="1.0" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_foreheadUpperOuter</Name>
+    <Tag value="20603" />
+    <Index value="213" />
+    <ParentIndex value="208" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.045200992" y="-0.0038699715" z="0.07877003" />
+    <Rotation x="-0.088111944" y="-0.38466123" z="0.089926764" w="0.91443163" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_temple</Name>
+    <Tag value="44921" />
+    <Index value="214" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="215" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.07049799" y="0.034253154" z="0.054262996" />
+    <Rotation x="-2.5975161e-14" y="0.56640613" z="-1.9989415e-14" w="0.82412624" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_ear</Name>
+    <Tag value="6621" />
+    <Index value="215" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="217" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.077358" y="-0.005501917" z="0.0016170025" />
+    <Rotation x="-0.049375817" y="0.62738055" z="-0.06097434" w="0.77475035" />
+    <Scale x="0.9999999" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_earLower</Name>
+    <Tag value="24625" />
+    <Index value="216" />
+    <ParentIndex value="215" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.0047480026" y="-0.024305087" z="0.0038989896" />
+    <Rotation x="0.08207598" y="-0.16730145" z="0.0891548" w="0.97843" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_masseter</Name>
+    <Tag value="10256" />
+    <Index value="217" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="218" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.07319899" y="-0.034692846" z="0.048249" />
+    <Rotation x="0.0554379" y="0.6336578" z="0.06725143" w="0.7686883" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_jawRecess</Name>
+    <Tag value="40058" />
+    <Index value="218" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="219" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.07519899" y="-0.028292902" z="0.024449006" />
+    <Rotation x="0.009467053" y="0.6950809" z="0.0028716838" w="0.71886355" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_cheekOuterSkin</Name>
+    <Tag value="5285" />
+    <Index value="219" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="220" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.06759899" y="0.013807082" z="0.06654901" />
+    <Rotation x="-0.03922947" y="0.4984589" z="-0.06794755" w="0.86335576" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_cheekLower</Name>
+    <Tag value="62311" />
+    <Index value="220" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="223" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.054982994" y="-0.045872927" z="0.07004401" />
+    <Rotation x="0.0047068684" y="-0.50058645" z="-0.07778113" w="0.86217237" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_cheekLowerBulge1</Name>
+    <Tag value="22939" />
+    <Index value="221" />
+    <ParentIndex value="220" />
+    <SiblingIndex value="222" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.015671996" y="-0.006583052" z="0.006128002" />
+    <Rotation x="0.06726229" y="0.19365044" z="-0.0051725656" w="0.97874844" />
+    <Scale x="1.0000002" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_cheekLowerBulge2</Name>
+    <Tag value="22940" />
+    <Index value="222" />
+    <ParentIndex value="220" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.00050999597" y="-0.0069590397" z="0.007843006" />
+    <Rotation x="0.08806676" y="0.06436339" z="0.0073045683" w="0.99400616" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_masseter</Name>
+    <Tag value="2064" />
+    <Index value="223" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="224" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.073601" y="-0.03489195" z="0.048049003" />
+    <Rotation x="0.055437785" y="-0.6336579" z="-0.06725163" w="0.76868826" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_jawRecess</Name>
+    <Tag value="37844" />
+    <Index value="224" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="225" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.07680099" y="-0.027991984" z="0.023749003" />
+    <Rotation x="0.009467754" y="-0.6950804" z="-0.0028717213" w="0.71886396" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_ear</Name>
+    <Tag value="4407" />
+    <Index value="225" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="227" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.077357985" y="-0.0055029574" z="0.0016170032" />
+    <Rotation x="-0.04937608" y="-0.62738055" z="0.06097418" w="0.7747502" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_earLower</Name>
+    <Tag value="32817" />
+    <Index value="226" />
+    <ParentIndex value="225" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.0047489917" y="-0.024302028" z="0.0038989957" />
+    <Rotation x="0.08207586" y="0.16730136" z="-0.089154854" w="0.97843" />
+    <Scale x="0.99999994" y="0.9999998" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyesackLower</Name>
+    <Tag value="30587" />
+    <Index value="227" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="228" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.03790099" y="0.009007024" z="0.09234901" />
+    <Rotation x="0.083537795" y="-0.14873119" z="-0.002313735" w="0.9853401" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_nasolabialBulge</Name>
+    <Tag value="54814" />
+    <Index value="228" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="229" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.036435995" y="-0.0136439325" z="0.09233701" />
+    <Rotation x="-0.1260836" y="-0.17630169" z="0.09366102" w="0.9717244" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_cheekOuter</Name>
+    <Tag value="3378" />
+    <Index value="229" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="230" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.05203799" y="-0.010802926" z="0.07132201" />
+    <Rotation x="-0.023426777" y="-0.4460452" z="-0.011680138" w="0.8946276" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_cheekInner</Name>
+    <Tag value="29564" />
+    <Index value="230" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="231" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.021828998" y="-2.2959719e-05" z="0.09526201" />
+    <Rotation x="-0.05164303" y="-0.13002513" z="0.12938105" w="0.9816756" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_noseUpper</Name>
+    <Tag value="7382" />
+    <Index value="231" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="232" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.011600999" y="0.01480703" z="0.10424901" />
+    <Rotation x="-0.2421928" y="-0.40579075" z="0.18209612" w="0.86227465" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_foreheadInner</Name>
+    <Tag value="3651" />
+    <Index value="232" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="234" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.018119998" y="0.045345057" z="0.09684401" />
+    <Rotation x="-0.06971413" y="-0.03470839" z="0.0036479502" w="0.99695647" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_foreheadInnerBulge</Name>
+    <Tag value="30364" />
+    <Index value="233" />
+    <ParentIndex value="232" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.00041900156" y="-0.012634071" z="-0.0055550146" />
+    <Rotation x="0.38372788" y="0.0789832" z="-0.12675221" w="0.91128945" />
+    <Scale x="1.0000001" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_foreheadOuter</Name>
+    <Tag value="36811" />
+    <Index value="234" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="235" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.04705499" y="0.04560607" z="0.08429701" />
+    <Rotation x="-0.14761513" y="-0.37988156" z="0.18970014" w="0.8932601" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_cheekOuterSkin</Name>
+    <Tag value="45876" />
+    <Index value="235" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="236" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.076900996" y="0.0120070595" z="0.060048997" />
+    <Rotation x="-0.039229374" y="-0.49845892" z="0.06794749" w="0.86335564" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyesackUpperInnerFurrow</Name>
+    <Tag value="40878" />
+    <Index value="236" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="237" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.03170099" y="0.029907035" z="0.095049016" />
+    <Rotation x="0.45383465" y="-0.011883835" z="0.023323918" w="0.89070135" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyesackUpperOuterFurrow</Name>
+    <Tag value="5135" />
+    <Index value="237" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="238" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.04720099" y="0.027407035" z="0.092249" />
+    <Rotation x="0.37711978" y="-0.15236598" z="0.34222022" w="0.84702456" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyesackUpperInnerBulge</Name>
+    <Tag value="41817" />
+    <Index value="238" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="239" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.031929996" y="0.032711074" z="0.09810901" />
+    <Rotation x="0.43139774" y="-0.05012739" z="0.059660725" w="0.89879024" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyesackUpperOuterBulge</Name>
+    <Tag value="6905" />
+    <Index value="239" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="240" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.046723995" y="0.03002207" z="0.09425401" />
+    <Rotation x="0.3882136" y="-0.13949998" z="0.25804895" w="0.8736366" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_nasolabialFurrow</Name>
+    <Tag value="11434" />
+    <Index value="240" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="241" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.039501" y="-0.029391963" z="0.101549" />
+    <Rotation x="0.025391521" y="-0.077896126" z="0.36399585" w="0.92779016" />
+    <Scale x="1.0000001" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_temple</Name>
+    <Tag value="44825" />
+    <Index value="241" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="242" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.074536994" y="0.03425706" z="0.054262996" />
+    <Rotation x="-1.9508834e-14" y="-0.5664062" z="1.4497667e-14" w="0.82412624" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyeball</Name>
+    <Tag value="6468" />
+    <Index value="242" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="243" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.035921995" y="0.021598037" z="0.08063401" />
+    <Rotation x="-2.6077028e-06" y="-4.8454274e-07" z="3.725416e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidUpper</Name>
+    <Tag value="32276" />
+    <Index value="243" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="250" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.035921995" y="0.021943029" z="0.08063401" />
+    <Rotation x="-0.1391743" y="-4.8595575e-07" z="-4.4560174e-08" w="0.990268" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidUpperOuterSDK</Name>
+    <Tag value="45333" />
+    <Index value="244" />
+    <ParentIndex value="243" />
+    <SiblingIndex value="247" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.005999999" y="2.7033637e-05" z="0.014682991" />
+    <Rotation x="0.020418743" y="-0.12891905" z="0.15509593" w="0.9792386" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidUpperOuterAnalog</Name>
+    <Tag value="62042" />
+    <Index value="245" />
+    <ParentIndex value="244" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="2.4214387e-08" y="3.5390258e-08" z="1.3038516e-08" />
+    <Rotation x="1.1175871e-08" y="2.7939679e-08" z="8.381905e-09" w="1.0" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelashUpperOuter</Name>
+    <Tag value="3594" />
+    <Index value="246" />
+    <ParentIndex value="245" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.00046103448" y="-0.0017908821" z="0.0026269807" />
+    <Rotation x="0.19177984" y="-0.046285905" z="-0.014565757" w="0.9802377" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidUpperInnerSDK</Name>
+    <Tag value="54593" />
+    <Index value="247" />
+    <ParentIndex value="243" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.005281998" y="0.00027004603" z="0.015639" />
+    <Rotation x="-0.13898252" y="-0.007283757" z="-0.05182666" w="0.9889109" />
+    <Scale x="0.9999999" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidUpperInnerAnalog</Name>
+    <Tag value="31843" />
+    <Index value="248" />
+    <ParentIndex value="247" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="1.071021e-08" y="4.2375177e-08" z="3.040236e-08" />
+    <Rotation x="3.9976495e-08" y="1.0393251e-08" z="2.2817401e-08" w="1.0" />
+    <Scale x="1.0" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelashUpperInner</Name>
+    <Tag value="33138" />
+    <Index value="249" />
+    <ParentIndex value="248" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="8.899951e-05" y="-0.0022559958" z="0.0014640064" />
+    <Rotation x="0.32373732" y="0.07761586" z="0.017180951" w="0.94280154" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidLower</Name>
+    <Tag value="32735" />
+    <Index value="250" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="257" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.035921995" y="0.021251079" z="0.08063401" />
+    <Rotation x="0.16504577" y="-5.1153523e-07" z="6.548321e-08" w="0.9862859" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidLowerOuterSDK</Name>
+    <Tag value="445" />
+    <Index value="251" />
+    <ParentIndex value="250" />
+    <SiblingIndex value="254" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.0061280034" y="-0.00082394923" z="0.014719005" />
+    <Rotation x="0.0043206145" y="-0.16499124" z="-0.025818022" w="0.9859476" />
+    <Scale x="0.9999999" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidLowerOuterAnalog</Name>
+    <Tag value="17787" />
+    <Index value="252" />
+    <ParentIndex value="251" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.1175871e-08" y="3.8184226e-08" z="-2.4214387e-08" />
+    <Rotation x="-2.0489097e-08" y="2.9802322e-08" z="9.313226e-09" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelashLowerOuter</Name>
+    <Tag value="48713" />
+    <Index value="253" />
+    <ParentIndex value="252" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="1.9993633e-05" y="0.00037599006" z="0.0016249781" />
+    <Rotation x="-0.038002208" y="-0.088478304" z="0.040921904" w="0.99451137" />
+    <Scale x="0.9999998" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidLowerInnerSDK</Name>
+    <Tag value="62289" />
+    <Index value="254" />
+    <ParentIndex value="250" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.0053769993" y="-0.00019095551" z="0.015529003" />
+    <Rotation x="0.0030420632" y="0.08710299" z="0.03476688" w="0.9955878" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelidLowerInnerAnalog</Name>
+    <Tag value="3603" />
+    <Index value="255" />
+    <ParentIndex value="254" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="2.7939677e-09" y="-7.7998266e-08" z="4.656613e-10" />
+    <Rotation x="6.658957e-08" y="-2.2351745e-08" z="7.4505815e-09" w="1.0" />
+    <Scale x="0.99999994" y="0.9999999" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyelashLowerInner</Name>
+    <Tag value="13090" />
+    <Index value="256" />
+    <ParentIndex value="255" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.0002320027" y="0.00015300396" z="0.0017629974" />
+    <Rotation x="-0.067605734" y="0.004626793" z="-0.010515774" w="0.997646" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipUpperSDK</Name>
+    <Tag value="36656" />
+    <Index value="257" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="261" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.016786998" y="-0.042427912" z="0.11187901" />
+    <Rotation x="-0.0646725" y="0.18084124" z="-0.027909806" w="0.9809867" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipUpperAnalog</Name>
+    <Tag value="45519" />
+    <Index value="258" />
+    <ParentIndex value="257" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.0" y="-2.5029294e-08" z="7.916242e-09" />
+    <Rotation x="3.632158e-08" y="2.2817403e-08" z="1.6763806e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipUpperThicknessH</Name>
+    <Tag value="14286" />
+    <Index value="259" />
+    <ParentIndex value="258" />
+    <SiblingIndex value="260" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.00023500249" y="-0.0044890274" z="0.00216801" />
+    <Rotation x="0.13626897" y="0.030341791" z="-0.005125093" w="0.99019384" />
+    <Scale x="1.0" y="0.9999998" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipUpperThicknessV</Name>
+    <Tag value="14524" />
+    <Index value="260" />
+    <ParentIndex value="258" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.00037300028" y="-0.0061500403" z="-0.0004319935" />
+    <Rotation x="0.68369865" y="0.038892165" z="-0.034312155" w="0.72791916" />
+    <Scale x="0.99999994" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_lipUpperSDK</Name>
+    <Tag value="6004" />
+    <Index value="261" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="265" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="1.2807533e-10" y="-0.041369937" z="0.11639202" />
+    <Rotation x="-0.06975641" y="4.761564e-10" z="1.2013078e-10" w="0.9975641" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_lipUpperAnalog</Name>
+    <Tag value="57444" />
+    <Index value="262" />
+    <ParentIndex value="261" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-3.8902215e-13" y="1.3019117e-08" z="1.454038e-10" />
+    <Rotation x="1.48997685e-08" y="-8.1157303e-13" z="1.1715073e-12" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_lipUpperThicknessH</Name>
+    <Tag value="31123" />
+    <Index value="263" />
+    <ParentIndex value="262" />
+    <SiblingIndex value="264" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-1.3322676e-13" y="-0.0043059383" z="0.00333301" />
+    <Rotation x="0.16504782" y="3.8182413e-13" z="1.1229593e-12" w="0.98628557" />
+    <Scale x="1.0" y="0.99999994" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_lipUpperThicknessV</Name>
+    <Tag value="31105" />
+    <Index value="264" />
+    <ParentIndex value="262" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-4.03233e-13" y="-0.00598095" z="1.4014688e-05" />
+    <Rotation x="0.7372773" y="3.4999752e-09" z="3.821414e-09" w="0.6755902" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipCornerSDK</Name>
+    <Tag value="2844" />
+    <Index value="265" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="269" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.027351996" y="-0.05133993" z="0.10257102" />
+    <Rotation x="-2.2445665e-14" y="0.3007056" z="-6.097889e-15" w="0.953717" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipCornerAnalog</Name>
+    <Tag value="58728" />
+    <Index value="266" />
+    <ParentIndex value="265" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-2.5163729e-09" y="-8.162909e-09" z="8.2195584e-10" />
+    <Rotation x="-3.9191875e-08" y="-5.2154025e-08" z="-3.171557e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipCornerThicknessUpper</Name>
+    <Tag value="1980" />
+    <Index value="267" />
+    <ParentIndex value="266" />
+    <SiblingIndex value="268" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.007945002" y="0.0032109388" z="-0.0007189979" />
+    <Rotation x="0.6796162" y="-0.07245" z="0.0028374305" w="0.7299758" />
+    <Scale x="1.0" y="1.0000001" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_lipCornerThicknessLower</Name>
+    <Tag value="56642" />
+    <Index value="268" />
+    <ParentIndex value="266" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.0078390045" y="-0.0017730824" z="-0.00087099755" />
+    <Rotation x="-0.68068135" y="-0.007673004" z="-0.042926304" w="0.7312807" />
+    <Scale x="0.9999998" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipUpperSDK</Name>
+    <Tag value="30083" />
+    <Index value="269" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="273" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-0.016786998" y="-0.04242792" z="0.111879006" />
+    <Rotation x="-0.06467243" y="-0.1808413" z="0.027909797" w="0.9809867" />
+    <Scale x="0.99999994" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipUpperAnalog</Name>
+    <Tag value="20943" />
+    <Index value="270" />
+    <ParentIndex value="269" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="1.8626451e-09" y="-1.2374949e-07" z="-5.122274e-09" />
+    <Rotation x="-3.259629e-09" y="7.450581e-09" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipUpperThicknessH</Name>
+    <Tag value="14382" />
+    <Index value="271" />
+    <ParentIndex value="270" />
+    <SiblingIndex value="272" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.00023499504" y="-0.0044901087" z="0.002168004" />
+    <Rotation x="0.13626952" y="-0.03034177" z="0.0051250895" w="0.9901938" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipUpperThicknessV</Name>
+    <Tag value="14428" />
+    <Index value="272" />
+    <ParentIndex value="270" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.0003729947" y="-0.006152034" z="-0.0004319977" />
+    <Rotation x="0.68369865" y="-0.03889249" z="0.03431187" w="0.7279191" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipCornerSDK</Name>
+    <Tag value="2876" />
+    <Index value="273" />
+    <ParentIndex value="121" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-0.028596995" y="-0.052022953" z="0.103883006" />
+    <Rotation x="-1.685798e-14" y="-0.30070564" z="1.9977975e-14" w="0.953717" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipCornerAnalog</Name>
+    <Tag value="60942" />
+    <Index value="274" />
+    <ParentIndex value="273" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="1.1589805e-09" y="4.0672578e-08" z="7.744575e-09" />
+    <Rotation x="-4.3207308e-08" y="8.940701e-08" z="2.5980954e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipCornerThicknessUpper</Name>
+    <Tag value="21699" />
+    <Index value="275" />
+    <ParentIndex value="274" />
+    <SiblingIndex value="276" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.007945005" y="0.0032099762" z="-0.0007189936" />
+    <Rotation x="0.6796162" y="0.072450496" z="-0.0028376807" w="0.7299758" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_lipCornerThicknessLower</Name>
+    <Tag value="11194" />
+    <Index value="276" />
+    <ParentIndex value="274" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.007839008" y="-0.0017700513" z="-0.0008719951" />
+    <Rotation x="-0.6806812" y="0.007673057" z="0.042926174" w="0.73128074" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_MulletRoot</Name>
+    <Tag value="15987" />
+    <Index value="277" />
+    <ParentIndex value="119" />
+    <SiblingIndex value="279" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-0.35828096" y="-0.03214599" z="1.0003996e-06" />
+    <Rotation x="7.499936e-06" y="4.1569123e-08" z="0.010621253" w="0.9999436" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_MulletScaler</Name>
+    <Tag value="41410" />
+    <Index value="278" />
+    <ParentIndex value="277" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.33988503" y="-0.035836007" z="2.0000186e-06" />
+    <Rotation x="0.7114903" y="0.702696" z="-1.4025643e-05" w="1.563388e-05" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_Hair_Scale</Name>
+    <Tag value="50788" />
+    <Index value="279" />
+    <ParentIndex value="119" />
+    <SiblingIndex value="280" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.093063" y="1.6763764e-11" z="-1.0291501e-10" />
+    <Rotation x="-6.0000566e-06" y="7.70474e-09" z="-7.427288e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_Hair_Crown</Name>
+    <Tag value="5749" />
+    <Index value="280" />
+    <ParentIndex value="119" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.093063" y="1.6763764e-11" z="-1.0291501e-10" />
+    <Rotation x="-6.0000566e-06" y="7.70474e-09" z="-7.427288e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_Neck_1</Name>
+    <Tag value="14728" />
+    <Index value="281" />
+    <ParentIndex value="118" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.056536928" y="-1.0244098e-08" z="-1.2211032e-10" />
+    <Rotation x="4.498092e-06" y="-4.5485148e-08" z="-3.725544e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Suit_Pec</Name>
+    <Tag value="30468" />
+    <Index value="282" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="284" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.02713599" y="0.14024697" z="-0.08351599" />
+    <Rotation x="0.45733926" y="0.4516851" z="-0.5450321" w="0.5382949" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Suit_Front</Name>
+    <Tag value="9817" />
+    <Index value="283" />
+    <ParentIndex value="282" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.028259018" y="-0.28528988" z="-0.008667015" />
+    <Rotation x="5.58794e-08" y="4.7683716e-07" z="5.5879386e-08" w="1.0" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Suit_Pec</Name>
+    <Tag value="5892" />
+    <Index value="284" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="286" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.027136007" y="0.14024597" z="0.084001" />
+    <Rotation x="-0.46753156" y="-0.4617567" z="-0.53630966" w="0.52968574" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Suit_Front</Name>
+    <Tag value="15944" />
+    <Index value="285" />
+    <ParentIndex value="284" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.028082954" y="-0.28529996" z="0.008646033" />
+    <Rotation x="-2.7939647e-08" y="-4.9918947e-07" z="-5.5879394e-08" w="1.0" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_Torch</Name>
+    <Tag value="2262" />
+    <Index value="286" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="290" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.08159601" y="0.18390496" z="0.11580099" />
+    <Rotation x="0.22534399" y="-0.085390806" z="-0.13480063" w="0.96112293" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FX_Light</Name>
+    <Tag value="35161" />
+    <Index value="287" />
+    <ParentIndex value="286" />
+    <SiblingIndex value="288" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.06897293" y="0.053847983" z="-4.0978193e-08" />
+    <Rotation x="4.8430156e-08" y="-0.007529902" z="6.985118e-08" w="0.9999717" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FX_Light_Scale</Name>
+    <Tag value="20536" />
+    <Index value="288" />
+    <ParentIndex value="286" />
+    <SiblingIndex value="289" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.06897293" y="0.053847983" z="-4.0978193e-08" />
+    <Rotation x="4.8430156e-08" y="-0.007529902" z="6.985118e-08" w="0.9999717" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FX_Light_Switch</Name>
+    <Tag value="57742" />
+    <Index value="289" />
+    <ParentIndex value="286" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.06897293" y="0.053847983" z="-4.0978193e-08" />
+    <Rotation x="4.377216e-08" y="1.1175871e-07" z="6.61239e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>BagRoot</Name>
+    <Tag value="44297" />
+    <Index value="290" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="296" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.08416898" y="0.0046589896" z="1.0000012e-06" />
+    <Rotation x="-2.5035945e-06" y="-4.340619e-07" z="-0.009465049" w="0.9999553" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>BagPivotROOT</Name>
+    <Tag value="47158" />
+    <Index value="291" />
+    <ParentIndex value="290" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.14012003" y="-0.16648102" z="-0.030886002" />
+    <Rotation x="-0.014710264" y="0.09702926" z="0.14917025" w="0.98392946" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>BagPivot</Name>
+    <Tag value="19729" />
+    <Index value="292" />
+    <ParentIndex value="291" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="2.9802322e-08" y="1.8477351e-08" z="6.519258e-09" />
+    <Rotation x="-4.5368104e-08" y="4.37256e-07" z="-4.147036e-07" w="1.0" />
+    <Scale x="0.99999994" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>BagBody</Name>
+    <Tag value="43885" />
+    <Index value="293" />
+    <ParentIndex value="292" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.16076604" y="-0.008285029" z="-0.0005240028" />
+    <Rotation x="0.031599328" y="-2.7350885e-07" z="-1.612987e-08" w="0.99950063" />
+    <Scale x="1.0" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>BagBone_R</Name>
+    <Tag value="2359" />
+    <Index value="294" />
+    <ParentIndex value="293" />
+    <SiblingIndex value="295" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-2.4034534e-09" y="3.8944478e-08" z="-1.2619239e-09" />
+    <Rotation x="0.1731912" y="0.66683716" z="-0.010331806" w="0.724725" />
+    <Scale x="1.0000001" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>BagBone_L</Name>
+    <Tag value="2449" />
+    <Index value="295" />
+    <ParentIndex value="293" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-2.4034534e-09" y="3.8944478e-08" z="-1.2619239e-09" />
+    <Rotation x="0.75961363" y="-0.094777375" z="0.6280671" w="0.13977188" />
+    <Scale x="1.0000018" y="1.0000001" z="1.0000002" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Collar_01</Name>
+    <Tag value="48084" />
+    <Index value="296" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="297" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.24685797" y="0.106495954" z="-0.050547983" />
+    <Rotation x="-0.7071069" y="4.214669e-07" z="-0.70710665" w="4.2146712e-07" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Collar_03</Name>
+    <Tag value="48086" />
+    <Index value="297" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="298" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.31505194" y="-0.06761201" z="-0.05132299" />
+    <Rotation x="-0.70709014" y="-0.0048295083" z="-0.70709044" w="0.0048295096" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Collar_01</Name>
+    <Tag value="30887" />
+    <Index value="298" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="299" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.24685797" y="0.10649496" z="0.050551" />
+    <Rotation x="-0.7071069" y="4.2113766e-07" z="-0.70710665" w="4.2146704e-07" />
+    <Scale x="0.99999994" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Collar_03</Name>
+    <Tag value="30889" />
+    <Index value="299" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="300" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.31505093" y="-0.067612" z="0.051325995" />
+    <Rotation x="-0.7071069" y="4.214669e-07" z="-0.70710665" w="4.2146695e-07" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Collar_02</Name>
+    <Tag value="30888" />
+    <Index value="300" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="301" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.2914949" y="0.02247197" z="0.101881996" />
+    <Rotation x="-0.7071069" y="4.2146723e-07" z="-0.70710665" w="5.2683447e-07" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Collar_02</Name>
+    <Tag value="48085" />
+    <Index value="301" />
+    <ParentIndex value="49" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.29149598" y="0.022472966" z="-0.10187898" />
+    <Rotation x="-0.7071069" y="4.214671e-07" z="-0.70710665" w="5.268343e-07" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Suit_Side_Flapper</Name>
+    <Tag value="17043" />
+    <Index value="302" />
+    <ParentIndex value="47" />
+    <SiblingIndex value="304" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.04660999" y="0.006289001" z="-0.163919" />
+    <Rotation x="-0.6963554" y="-0.71320283" z="-0.05602354" w="0.057378747" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Suit_Side</Name>
+    <Tag value="24581" />
+    <Index value="303" />
+    <ParentIndex value="302" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.017828997" y="-0.10949193" z="0.007871982" />
+    <Rotation x="4.842384e-07" y="-3.315927e-08" z="-1.7959945e-08" w="1.0" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Suit_Side_Flapper</Name>
+    <Tag value="62491" />
+    <Index value="304" />
+    <ParentIndex value="47" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.046609975" y="0.006287001" z="0.16399997" />
+    <Rotation x="0.71243554" y="-0.6971364" z="0.05547541" w="0.0579565" />
+    <Scale x="1.0000001" y="1.0000002" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Suit_Side</Name>
+    <Tag value="22367" />
+    <Index value="305" />
+    <ParentIndex value="304" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.018006995" y="0.10950299" z="-0.0071809837" />
+    <Rotation x="0.0027920841" y="4.5843435e-06" z="-0.00087398157" w="0.9999957" />
+    <Scale x="0.9999999" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_Suit_Back_Flapper</Name>
+    <Tag value="55853" />
+    <Index value="306" />
+    <ParentIndex value="46" />
+    <SiblingIndex value="309" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.056246" y="-0.156041" z="8.873231e-10" />
+    <Rotation x="-0.67263895" y="-0.73997086" z="8.974164e-08" w="1.4407759e-07" />
+    <Scale x="0.99999994" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Suit_Back</Name>
+    <Tag value="22122" />
+    <Index value="307" />
+    <ParentIndex value="306" />
+    <SiblingIndex value="308" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.01544798" y="-0.084176" z="0.07659099" />
+    <Rotation x="1.043081e-06" y="-9.554856e-07" z="-5.0291527e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Suit_Back</Name>
+    <Tag value="18432" />
+    <Index value="308" />
+    <ParentIndex value="306" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.015447991" y="-0.084175974" z="-0.07700001" />
+    <Rotation x="-0.0071038613" y="-3.646698e-08" z="-4.6308262e-08" w="0.9999748" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_LifeSaver_Front</Name>
+    <Tag value="37920" />
+    <Index value="309" />
+    <ParentIndex value="46" />
+    <SiblingIndex value="310" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.011956997" y="0.217605" z="-1.2591679e-09" />
+    <Rotation x="-0.609053" y="-0.7931295" z="3.5090693e-07" w="5.98796e-08" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_LifeSaver_Back</Name>
+    <Tag value="8487" />
+    <Index value="310" />
+    <ParentIndex value="46" />
+    <SiblingIndex value="311" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.056246" y="-0.156041" z="8.873231e-10" />
+    <Rotation x="-0.6661557" y="-0.7458128" z="8.934243e-08" w="1.4521513e-07" />
+    <Scale x="0.99999994" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Pouches_ROOT</Name>
+    <Tag value="10594" />
+    <Index value="311" />
+    <ParentIndex value="46" />
+    <SiblingIndex value="313" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.05103499" y="0.013530504" z="-0.2568823" />
+    <Rotation x="-0.7063047" y="-0.033665825" z="-0.70630515" w="0.03366473" />
+    <Scale x="1.0000206" y="1.0000002" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Pouches</Name>
+    <Tag value="16705" />
+    <Index value="312" />
+    <ParentIndex value="311" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="2.4873813e-08" y="8.398364e-09" z="-2.8615512e-09" />
+    <Rotation x="4.7311255e-07" y="4.925587e-07" z="-3.5093603e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Pouches_ROOT</Name>
+    <Tag value="10754" />
+    <Index value="313" />
+    <ParentIndex value="46" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.051034" y="0.013529527" z="0.24064094" />
+    <Rotation x="-0.7063047" y="-0.03366559" z="-0.7063051" w="0.033664916" />
+    <Scale x="1.0000204" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Pouches</Name>
+    <Tag value="19265" />
+    <Index value="314" />
+    <ParentIndex value="313" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-4.419114e-10" y="1.2999024e-10" z="-1.3921593e-09" />
+    <Rotation x="4.991897e-07" y="4.8666413e-07" z="-4.999408e-07" w="1.0" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>IK_Root</Name>
+    <Tag value="56604" />
+    <Index value="315" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="316" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-1.6292068e-08" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_BlushSlider</Name>
+    <Tag value="41166" />
+    <Index value="316" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="317" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-1.6292068e-08" y="0.0071009994" z="-0.981294" />
+    <Rotation x="0.0" y="0.0" z="1.0" w="0.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Skirt</Name>
+    <Tag value="50201" />
+    <Index value="317" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="318" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.1888596" y="0.0033108555" z="-0.094954625" />
+    <Rotation x="-0.028519588" y="0.7338503" z="0.00021826474" w="0.67871225" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Skirt</Name>
+    <Tag value="30482" />
+    <Index value="318" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="319" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.18885861" y="0.0033109188" z="-0.0949547" />
+    <Rotation x="0.00021828558" y="0.6787103" z="-0.02851969" w="0.73385215" />
+    <Scale x="0.9999999" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_M_BackSkirtRoll</Name>
+    <Tag value="3515" />
+    <Index value="319" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="322" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-8.9125205e-09" y="-0.080226004" z="-0.023508" />
+    <Rotation x="0.0" y="0.70710665" z="0.0" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_BackSkirtRoll</Name>
+    <Tag value="16562" />
+    <Index value="320" />
+    <ParentIndex value="319" />
+    <SiblingIndex value="321" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-3.7070436e-10" y="7.450581e-09" z="-0.096118" />
+    <Rotation x="-0.0203208" y="0.038988695" z="-0.020012017" w="0.9988326" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_BackSkirtRoll</Name>
+    <Tag value="49473" />
+    <Index value="321" />
+    <ParentIndex value="319" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="3.707008e-10" y="7.450581e-09" z="0.096118" />
+    <Rotation x="0.020321336" y="-0.038988072" z="-0.020012006" w="0.9988326" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_M_FrontSkirtRoll</Name>
+    <Tag value="52667" />
+    <Index value="322" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="325" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-8.9125205e-09" y="0.079774" z="-0.023508" />
+    <Rotation x="0.0" y="0.70710665" z="0.0" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_FrontSkirtRoll</Name>
+    <Tag value="39785" />
+    <Index value="323" />
+    <ParentIndex value="322" />
+    <SiblingIndex value="324" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-3.7070436e-10" y="7.450581e-09" z="-0.096118" />
+    <Rotation x="-0.0203208" y="0.038988695" z="-0.020012017" w="0.9988326" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_FrontSkirtRoll</Name>
+    <Tag value="34545" />
+    <Index value="324" />
+    <ParentIndex value="322" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="3.707008e-10" y="7.450581e-09" z="0.096118" />
+    <Rotation x="0.020321336" y="-0.038988072" z="-0.020012006" w="0.9988326" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_CockNBalls_ROOT</Name>
+    <Tag value="50813" />
+    <Index value="325" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="327" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-4.296345e-05" y="0.067884" z="-0.168329" />
+    <Rotation x="-1.6855466e-07" y="0.70710695" z="0.7071066" w="3.0626623e-07" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_CockNBalls</Name>
+    <Tag value="40244" />
+    <Index value="326" />
+    <ParentIndex value="325" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-1.6502355e-12" y="-4.4307473e-09" z="-4.2999378e-05" />
+    <Rotation x="-1.0635346e-17" y="3.1702967e-11" z="1.2753228e-14" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_Watch</Name>
+    <Tag value="10040" />
+    <Index value="327" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="328" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.5166244" y="-0.034375172" z="0.03961394" />
+    <Rotation x="0.024081003" y="0.87838256" z="0.013162964" w="0.47716972" />
+    <Scale x="0.9999999" y="0.99999964" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_CopRadio</Name>
+    <Tag value="33349" />
+    <Index value="328" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="329" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.2078726" y="0.007065732" z="0.11092398" />
+    <Rotation x="6.571816e-05" y="-0.7071069" z="-0.70710665" w="5.476e-05" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_FlipFlop</Name>
+    <Tag value="23869" />
+    <Index value="329" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="330" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.16453682" y="0.101873904" z="-0.93896896" />
+    <Rotation x="-0.48007926" y="-0.5191536" z="0.5000414" w="0.49996218" />
+    <Scale x="0.9999999" y="0.9999999" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_L_Leg_Fireman_F</Name>
+    <Tag value="6783" />
+    <Index value="330" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="331" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.15504523" y="0.038921855" z="-0.85149336" />
+    <Rotation x="0.5000009" y="0.5000028" z="0.49999738" w="0.49999893" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_L_Leg_Fireman_B</Name>
+    <Tag value="6779" />
+    <Index value="331" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="332" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.155046" y="-0.101607904" z="-0.8514934" />
+    <Rotation x="0.50000095" y="0.50000274" z="0.49999744" w="0.49999887" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_PantHem_ROOT</Name>
+    <Tag value="25003" />
+    <Index value="332" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="334" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-0.15852462" y="-0.051551815" z="-0.8888251" />
+    <Rotation x="0.48895207" y="0.54774815" z="0.46849447" w="0.49133578" />
+    <Scale x="1.0" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_PantHem</Name>
+    <Tag value="15639" />
+    <Index value="333" />
+    <ParentIndex value="332" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.0" y="6.472692e-08" z="-4.8894435e-09" />
+    <Rotation x="-6.409051e-08" y="0.012182792" z="0.0009137546" w="0.9999254" />
+    <Scale x="1.0" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_ShirtFront_TARGET</Name>
+    <Tag value="35724" />
+    <Index value="334" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="335" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.1305133" y="0.1089988" z="-0.3256104" />
+    <Rotation x="0.6694204" y="0.10285361" z="-0.7271958" w="0.11173059" />
+    <Scale x="0.99999976" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_FlipFlop</Name>
+    <Tag value="64460" />
+    <Index value="335" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="336" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.16453746" y="0.10187484" z="-0.93896747" />
+    <Rotation x="-0.50004053" y="-0.4999627" z="0.4800784" w="0.51915455" />
+    <Scale x="1.0" y="1.0000002" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_R_Leg_Fireman_F</Name>
+    <Tag value="4223" />
+    <Index value="336" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="337" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.15504493" y="0.038922597" z="-0.85149246" />
+    <Rotation x="0.49999806" y="0.4999987" z="0.5000019" w="0.5000014" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_R_Leg_Fireman_B</Name>
+    <Tag value="4219" />
+    <Index value="337" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="338" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.1550457" y="-0.101607144" z="-0.8514925" />
+    <Rotation x="0.49999812" y="0.49999863" z="0.5000019" w="0.5000014" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_PantHem_ROOT</Name>
+    <Tag value="24843" />
+    <Index value="338" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="340" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.1585253" y="-0.05155104" z="-0.88882416" />
+    <Rotation x="0.4699124" y="0.48972243" z="0.48733804" w="0.5494143" />
+    <Scale x="0.9999999" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_PantHem</Name>
+    <Tag value="13079" />
+    <Index value="339" />
+    <ParentIndex value="338" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-3.259629e-09" y="4.004687e-08" z="-3.7252903e-09" />
+    <Rotation x="1.6043182e-07" y="-0.01218272" z="0.0009142728" w="0.9999254" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_ShirtFront_TARGET</Name>
+    <Tag value="3422" />
+    <Index value="340" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="341" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.13023907" y="0.10899947" z="-0.3256095" />
+    <Rotation x="0.1028532" y="0.6694212" z="-0.11173036" w="0.7271952" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_R_Belt_Police</Name>
+    <Tag value="38229" />
+    <Index value="341" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="342" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.19068196" y="-0.016596" z="0.03860006" />
+    <Rotation x="2.9802317e-07" y="8.8817835e-14" z="-1.0" w="8.8817835e-14" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_L_Belt_Police</Name>
+    <Tag value="57948" />
+    <Index value="342" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="343" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.15956403" y="-0.08257501" z="0.038599953" />
+    <Rotation x="2.9802317e-07" y="8.8817835e-14" z="-1.0" w="8.8817835e-14" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_ShirtCompressor</Name>
+    <Tag value="35428" />
+    <Index value="343" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="344" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.11954197" y="0.149909" z="0.05367004" />
+    <Rotation x="0.0115223825" y="-0.014394696" z="0.9627026" w="0.269933" />
+    <Scale x="0.9999998" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_ShirtCompressor</Name>
+    <Tag value="31738" />
+    <Index value="344" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="345" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.12673403" y="0.125251" z="0.05366996" />
+    <Rotation x="-0.027647723" y="-0.0066186343" z="-0.97212774" w="0.23272176" />
+    <Scale x="1.0000018" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_SecPass</Name>
+    <Tag value="25435" />
+    <Index value="345" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="346" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.08349099" y="0.138531" z="-0.028305972" />
+    <Rotation x="-0.09616416" y="-0.01752389" z="0.979088" w="0.17841545" />
+    <Scale x="1.0000011" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Thumb</Name>
+    <Tag value="8323" />
+    <Index value="346" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="347" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.5053993" y="-0.033078115" z="0.006159899" />
+    <Rotation x="0.024154568" y="0.87837976" z="0.013123284" w="0.47717252" />
+    <Scale x="1.0" y="0.99999964" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_HandWebbing</Name>
+    <Tag value="15828" />
+    <Index value="347" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="348" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.51785576" y="-0.01994251" z="-0.022061693" />
+    <Rotation x="-0.3138245" y="0.82075983" z="-0.1704837" w="0.4458731" />
+    <Scale x="0.99999994" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Wrist</Name>
+    <Tag value="49600" />
+    <Index value="348" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="349" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.48931393" y="-0.03470465" z="0.030949807" />
+    <Rotation x="0.024154568" y="0.8783798" z="0.013123295" w="0.47717234" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_L_Cuff_TILTER</Name>
+    <Tag value="46636" />
+    <Index value="349" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="350" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.48963952" y="-0.0346719" z="0.030451678" />
+    <Rotation x="0.024154745" y="0.8783781" z="0.013122816" w="0.47717556" />
+    <Scale x="0.99999994" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_L_ArmRoll_Vest</Name>
+    <Tag value="9247" />
+    <Index value="350" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="351" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.19960576" y="-0.042337712" z="0.47750652" />
+    <Rotation x="-0.010543648" y="0.8786455" z="-0.0057271183" w="0.47732422" />
+    <Scale x="0.99999994" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Shoulder</Name>
+    <Tag value="29957" />
+    <Index value="351" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="354" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-0.031918816" y="0.014337812" z="0.5193961" />
+    <Rotation x="-0.15658748" y="0.9800883" z="-0.019262077" w="0.12056657" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Scap_ROOT</Name>
+    <Tag value="934" />
+    <Index value="352" />
+    <ParentIndex value="351" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.18189518" y="-3.7252903e-08" z="3.741185e-09" />
+    <Rotation x="0.9758677" y="0.18103895" z="-0.12100973" w="0.01624393" />
+    <Scale x="1.0000019" y="1.0000002" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Scap</Name>
+    <Tag value="10362" />
+    <Index value="353" />
+    <ParentIndex value="352" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.01639398" y="0.07200001" z="-0.04299999" />
+    <Rotation x="-3.4979772e-07" y="1.1060157e-06" z="-0.15932088" w="0.98722696" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_ArmPit_In_ROOT</Name>
+    <Tag value="58850" />
+    <Index value="354" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="356" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-0.16095248" y="-0.034242693" z="0.42463085" />
+    <Rotation x="0.86230385" y="-0.18610911" z="0.46983013" w="0.03248305" />
+    <Scale x="1.000002" y="1.0000004" z="1.0000002" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_ArmPit_In</Name>
+    <Tag value="10508" />
+    <Index value="355" />
+    <ParentIndex value="354" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-3.5390258e-08" y="2.2351742e-08" z="4.749745e-08" />
+    <Rotation x="-2.6077034e-08" y="-2.2351742e-08" z="3.3527613e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_ArmPit_Out_ROOT</Name>
+    <Tag value="35718" />
+    <Index value="356" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="358" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-0.16095248" y="-0.034242693" z="0.42463085" />
+    <Rotation x="-0.9799556" y="0.18249118" z="-0.06320872" w="0.04887388" />
+    <Scale x="1.000002" y="1.0000004" z="1.0000002" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_ArmPit_Out</Name>
+    <Tag value="17376" />
+    <Index value="357" />
+    <ParentIndex value="356" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="1.0244548e-08" y="1.4901161e-08" z="3.7252903e-09" />
+    <Rotation x="1.2107195e-08" y="1.3504179e-08" z="6.007031e-08" w="1.0" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Wrist</Name>
+    <Tag value="29881" />
+    <Index value="358" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="359" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.48932508" y="-0.034706343" z="0.030955842" />
+    <Rotation x="0.013122114" y="0.47716507" z="0.024154719" w="0.8783837" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_R_Cuff_TILTER</Name>
+    <Tag value="26917" />
+    <Index value="359" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="360" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.48965067" y="-0.034673598" z="0.030457728" />
+    <Rotation x="0.013120271" y="0.4771687" z="0.024154501" w="0.8783817" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Thumb</Name>
+    <Tag value="53771" />
+    <Index value="360" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="361" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.50541043" y="-0.033079755" z="0.006163532" />
+    <Rotation x="0.013122067" y="0.47717318" z="0.024154602" w="0.8783793" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_HandWebbing</Name>
+    <Tag value="35547" />
+    <Index value="361" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="362" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.5261057" y="-0.019944217" z="-0.016712962" />
+    <Rotation x="-0.1704803" y="0.44586548" z="-0.31382674" w="0.82076395" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_R_ArmRoll_Vest</Name>
+    <Tag value="9151" />
+    <Index value="362" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="363" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.19960687" y="-0.042338353" z="0.47750604" />
+    <Rotation x="-0.0057277395" y="0.477314" z="-0.010544527" w="0.878651" />
+    <Scale x="1.0" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Shoulder</Name>
+    <Tag value="54533" />
+    <Index value="363" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="366" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.03191918" y="0.014337558" z="0.5193961" />
+    <Rotation x="-0.019262338" y="0.12056566" z="-0.15658657" w="0.98008853" />
+    <Scale x="1.0" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Scap_ROOT</Name>
+    <Tag value="3148" />
+    <Index value="364" />
+    <ParentIndex value="363" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.18189536" y="1.17346644e-07" z="1.015206e-07" />
+    <Rotation x="0.121002994" y="0.016242122" z="-0.9758687" w="0.18103808" />
+    <Scale x="1.0000002" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Scap</Name>
+    <Tag value="45786" />
+    <Index value="365" />
+    <ParentIndex value="364" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.015999999" y="0.07200001" z="-0.043000013" />
+    <Rotation x="-2.7207489e-07" y="9.844462e-07" z="0.15931918" w="0.98722714" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_ArmPit_In_ROOT</Name>
+    <Tag value="17890" />
+    <Index value="366" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="368" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.16095163" y="-0.034242798" z="0.4246309" />
+    <Rotation x="-0.032483086" y="0.46983078" z="0.1861083" w="0.8623037" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_ArmPit_In</Name>
+    <Tag value="8294" />
+    <Index value="367" />
+    <ParentIndex value="366" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="3.7252903e-09" y="7.450581e-09" z="2.3283064e-08" />
+    <Rotation x="1.8626451e-09" y="2.0861629e-07" z="-2.6077037e-08" w="1.0" />
+    <Scale x="0.9999999" y="0.9999998" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_ArmPit_Out_ROOT</Name>
+    <Tag value="33504" />
+    <Index value="368" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="370" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.16095163" y="-0.034242798" z="0.4246309" />
+    <Rotation x="0.04887356" y="0.063208245" z="0.18249038" w="0.9799558" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_ArmPit_Out</Name>
+    <Tag value="47119" />
+    <Index value="369" />
+    <ParentIndex value="368" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="1.21071935e-08" y="-3.7252903e-09" z="-5.122274e-09" />
+    <Rotation x="-4.656613e-09" y="3.403984e-07" z="-6.589107e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_Hair_Squisher</Name>
+    <Tag value="41750" />
+    <Index value="370" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="371" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="1.4138837e-07" y="0.0033650286" z="0.75343627" />
+    <Rotation x="0.0031187523" y="-0.70709944" z="-0.0031080842" w="0.70710045" />
+    <Scale x="0.99999994" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_FireManCollar</Name>
+    <Tag value="50493" />
+    <Index value="371" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="372" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="1.0817489e-08" y="0.0041845404" z="0.6603769" />
+    <Rotation x="0.0031279419" y="-0.7070999" z="-0.0030988934" w="0.7071" />
+    <Scale x="0.99999994" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Trap_R_Rot_Fix</Name>
+    <Tag value="15719" />
+    <Index value="372" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="375" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.038999956" y="-0.010714781" z="0.5983064" />
+    <Rotation x="0.00633966" y="0.31332824" z="-0.084265575" w="0.9458777" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Trap_R_Support</Name>
+    <Tag value="2123" />
+    <Index value="373" />
+    <ParentIndex value="372" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="4.307367e-08" y="8.381903e-09" z="-2.73576e-08" />
+    <Rotation x="0.0" y="-8.323464e-06" z="-1.0086225e-06" w="1.0" />
+    <Scale x="0.9999999" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_Trap</Name>
+    <Tag value="47006" />
+    <Index value="374" />
+    <ParentIndex value="373" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-1.0011718e-08" y="-4.656613e-10" z="-2.0838343e-08" />
+    <Rotation x="-2.7939682e-09" y="-9.904616e-07" z="-1.1175872e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Trap_L_Rot_Fix</Name>
+    <Tag value="46951" />
+    <Index value="375" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="378" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-0.038999904" y="-0.010714974" z="0.5983065" />
+    <Rotation x="-0.092189595" y="0.9454137" z="0.030333394" w="0.31108505" />
+    <Scale x="1.0" y="1.0000005" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Trap_L_Support</Name>
+    <Tag value="34093" />
+    <Index value="376" />
+    <ParentIndex value="375" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="1.6298145e-08" y="2.5819531e-08" z="7.21775e-09" />
+    <Rotation x="0.02536947" y="3.0797105e-06" z="6.647398e-07" w="0.99967813" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_Trap</Name>
+    <Tag value="8906" />
+    <Index value="377" />
+    <ParentIndex value="376" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="1.8626451e-09" y="6.519258e-09" z="-3.259629e-09" />
+    <Rotation x="-3.7252899e-09" y="-1.2596138e-07" z="-1.7695129e-08" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_CollarStraps_ROOT</Name>
+    <Tag value="63769" />
+    <Index value="378" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="380" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="5.2143776e-07" y="0.09891515" z="0.5377247" />
+    <Rotation x="-0.004398685" y="-0.70709306" z="0.0043958463" w="0.7070932" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SM_CollarStraps</Name>
+    <Tag value="60773" />
+    <Index value="379" />
+    <ParentIndex value="378" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-3.4924073e-09" y="1.2109287e-08" z="7.1054274e-15" />
+    <Rotation x="0.0075219315" y="-8.422163e-06" z="4.4367088e-08" w="0.9999718" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_ScubaTank</Name>
+    <Tag value="37547" />
+    <Index value="380" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="381" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-3.58066e-07" y="-0.12059252" z="0.49022385" />
+    <Rotation x="0.50000024" y="0.49999946" z="0.5000005" w="0.49999988" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_FireTank</Name>
+    <Tag value="21755" />
+    <Index value="381" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="382" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-3.58066e-07" y="-0.12059252" z="0.49022385" />
+    <Rotation x="0.50000024" y="0.49999946" z="0.5000005" w="0.49999988" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Hanress_Hook</Name>
+    <Tag value="42114" />
+    <Index value="382" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="383" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.00013165174" y="-0.19345567" z="0.5268479" />
+    <Rotation x="7.315406e-08" y="-0.006579307" z="0.99997836" w="2.00991e-06" />
+    <Scale x="1.0" y="0.99999976" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>RB_Neck</Name>
+    <Tag value="39896" />
+    <Index value="383" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="384" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="3.682395e-08" y="-0.021714676" z="0.55030686" />
+    <Rotation x="-0.08152431" y="-0.70239145" z="0.0815258" w="0.7023914" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_CollarBack</Name>
+    <Tag value="6035" />
+    <Index value="384" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="385" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-2.0802153e-07" y="-0.082319856" z="0.59794825" />
+    <Rotation x="-0.06985285" y="-0.7036481" z="0.06985361" w="0.703648" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_R_Pouch</Name>
+    <Tag value="54352" />
+    <Index value="385" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="386" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.10485827" y="0.14014786" z="0.20416932" />
+    <Rotation x="9.70644e-07" y="1.6807346e-07" z="-0.25881988" w="0.96592563" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_L_Pouch</Name>
+    <Tag value="8904" />
+    <Index value="386" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="387" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.12979747" y="0.12860988" z="0.20416927" />
+    <Rotation x="6.674226e-07" y="-2.566798e-07" z="0.2164391" w="0.9762961" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_BackStraps_SpecOPs</Name>
+    <Tag value="22084" />
+    <Index value="387" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="388" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.015991999" y="-0.22264563" z="0.18326448" />
+    <Rotation x="1.6938843e-08" y="-0.006970783" z="0.9999758" w="5.010519e-06" />
+    <Scale x="1.0" y="1.0000005" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Harness_R_1</Name>
+    <Tag value="41714" />
+    <Index value="388" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="391" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.27345544" y="0.038862083" z="-0.38389623" />
+    <Rotation x="4.6228017e-08" y="-0.0" z="-1.0" w="2.755404e-14" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Harness_R_2</Name>
+    <Tag value="41715" />
+    <Index value="389" />
+    <ParentIndex value="388" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.128527" y="-0.09802424" z="0.43031892" />
+    <Rotation x="2.9802328e-07" y="-8.212249e-21" z="-1.177676e-28" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Harness_R_3</Name>
+    <Tag value="41716" />
+    <Index value="390" />
+    <ParentIndex value="389" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-2.562582e-09" y="1.6192736e-09" z="-1.2339845e-09" />
+    <Rotation x="-0.068253085" y="0.2232446" z="-0.2842931" w="0.9298823" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Harness_L_1</Name>
+    <Tag value="10851" />
+    <Index value="391" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="394" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.27300474" y="0.038861107" z="-0.38389713" />
+    <Rotation x="4.6228017e-08" y="-0.0" z="-1.0" w="2.755404e-14" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Harness_L_2</Name>
+    <Tag value="10852" />
+    <Index value="392" />
+    <ParentIndex value="391" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.128" y="-0.09802426" z="0.43031892" />
+    <Rotation x="2.9802325e-07" y="-8.212249e-21" z="-1.177676e-28" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Harness_L_3</Name>
+    <Tag value="10853" />
+    <Index value="393" />
+    <ParentIndex value="392" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.00320099" y="0.01598901" z="0.0044959984" />
+    <Rotation x="0.052036908" y="-0.17280966" z="0.32644576" w="0.9278266" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_L_ShirtFront</Name>
+    <Tag value="46872" />
+    <Index value="394" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="395" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.09900202" y="0.11891726" z="0.07302365" />
+    <Rotation x="-0.022347793" y="0.73440886" z="0.005918304" w="0.6783135" />
+    <Scale x="0.9999999" y="0.9999997" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>MH_R_ShirtFront</Name>
+    <Tag value="52999" />
+    <Index value="395" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="396" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.09872803" y="0.118917644" z="0.073023625" />
+    <Rotation x="0.00021896866" y="0.67871135" z="-0.02852072" w="0.73385113" />
+    <Scale x="1.0" y="1.0000004" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Brow_Out_000</Name>
+    <Tag value="58331" />
+    <Index value="396" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="397" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.010967693" y="0.017017484" z="0.7383076" />
+    <Rotation x="-0.07119454" y="-0.12872559" z="0.8655805" w="0.47867686" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lid_Upper_000</Name>
+    <Tag value="45750" />
+    <Index value="397" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="398" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.028007288" y="0.08493268" z="0.7261851" />
+    <Rotation x="-1.4433779e-06" y="1.2753356e-06" z="0.74938256" w="0.66213727" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Eye_000</Name>
+    <Tag value="25260" />
+    <Index value="398" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="399" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.02801025" y="0.08474517" z="0.7259014" />
+    <Rotation x="-8.724803e-07" y="2.3616703e-06" z="0.7493826" w="0.6621372" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_CheekBone_000</Name>
+    <Tag value="21550" />
+    <Index value="399" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="400" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.0052505047" y="0.097836554" z="0.71186745" />
+    <Rotation x="0.16391157" y="-0.1205381" z="-0.97603226" w="0.07723098" />
+    <Scale x="0.9999995" y="0.99999976" z="0.99999744" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Corner_000</Name>
+    <Tag value="29868" />
+    <Index value="400" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="401" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.020313185" y="0.07895745" z="0.65924394" />
+    <Rotation x="0.004994553" y="0.028114187" z="0.85237455" w="0.5221516" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lid_Upper_000</Name>
+    <Tag value="43536" />
+    <Index value="401" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="402" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.029968346" y="0.08662312" z="0.72965187" />
+    <Rotation x="-6.364996e-05" y="8.552374e-05" z="0.66221076" w="0.74931765" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Eye_000</Name>
+    <Tag value="27474" />
+    <Index value="402" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="403" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.029973384" y="0.08643459" z="0.7293702" />
+    <Rotation x="-5.872537e-05" y="7.18525e-05" z="0.66220057" w="0.7493267" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_CheekBone_000</Name>
+    <Tag value="19336" />
+    <Index value="403" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="404" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0051964954" y="0.09783751" z="0.7118686" />
+    <Rotation x="-0.120525494" y="0.16394268" z="-0.07718352" w="0.9760323" />
+    <Scale x="0.9999999" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Brow_Out_000</Name>
+    <Tag value="1356" />
+    <Index value="404" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="405" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.010923307" y="0.017019603" z="0.7383079" />
+    <Rotation x="0.12852752" y="0.071324706" z="0.47877604" w="0.8655443" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Corner_000</Name>
+    <Tag value="11174" />
+    <Index value="405" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="406" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.020285815" y="0.078962035" z="0.6592505" />
+    <Rotation x="-0.028220322" y="-0.0050316704" z="0.52220345" w="0.8523391" />
+    <Scale x="1.0" y="1.0000001" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Brow_Centre_000</Name>
+    <Tag value="37193" />
+    <Index value="406" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="407" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.7611726e-05" y="0.012434494" z="0.7233058" />
+    <Rotation x="0.07749833" y="-0.07758237" z="0.70286906" w="0.70281583" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLipRoot_000</Name>
+    <Tag value="20178" />
+    <Index value="407" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="411" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-1.4027548e-05" y="0.050063606" z="0.67815447" />
+    <Rotation x="-0.044913415" y="0.044823043" z="0.7057083" w="0.70565534" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLip_000</Name>
+    <Tag value="61839" />
+    <Index value="408" />
+    <ParentIndex value="407" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.065556005" y="-3.7271093e-09" z="0.0026099791" />
+    <Rotation x="-1.7024888e-05" y="0.1683612" z="0.00018038515" w="0.9857254" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Top_000</Name>
+    <Tag value="20279" />
+    <Index value="409" />
+    <ParentIndex value="408" />
+    <SiblingIndex value="410" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.0005310293" y="0.0068000075" z="-0.012573007" />
+    <Rotation x="-0.29112718" y="-0.023821337" z="0.8527044" w="0.43309665" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Top_000</Name>
+    <Tag value="17719" />
+    <Index value="410" />
+    <ParentIndex value="408" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.00053102535" y="-0.0068019894" z="-0.012571065" />
+    <Rotation x="0.29117313" y="-0.023840489" z="-0.8526488" w="0.43317422" />
+    <Scale x="1.0000002" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Jaw_000</Name>
+    <Tag value="46240" />
+    <Index value="411" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="417" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-1.14089535e-05" y="0.02091952" z="0.66872543" />
+    <Rotation x="-0.22816686" y="0.22807246" z="0.6693149" w="0.6692835" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLipRoot_000</Name>
+    <Tag value="17188" />
+    <Index value="412" />
+    <ParentIndex value="411" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.038162988" y="-7.454219e-09" z="0.010449041" />
+    <Rotation x="-3.0868276e-05" y="-0.21595144" z="0.00011056558" w="0.97640413" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLip_000</Name>
+    <Tag value="20623" />
+    <Index value="413" />
+    <ParentIndex value="412" />
+    <SiblingIndex value="416" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.053985998" y="-7.275958e-12" z="0.0045080376" />
+    <Rotation x="1.06789635e-08" y="-0.24434556" z="8.8089996e-07" w="0.96968824" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Bot_000</Name>
+    <Tag value="47419" />
+    <Index value="414" />
+    <ParentIndex value="413" />
+    <SiblingIndex value="415" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.0055779885" y="0.005002994" z="0.0045250542" />
+    <Rotation x="0.24193354" y="0.00035432892" z="0.86964726" w="0.43032768" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Bot_000</Name>
+    <Tag value="49979" />
+    <Index value="415" />
+    <ParentIndex value="413" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.0055779726" y="-0.005005001" z="0.004525054" />
+    <Rotation x="-0.24182336" y="0.0002985736" z="-0.86959404" w="0.43049693" />
+    <Scale x="0.99999976" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Tongue_000</Name>
+    <Tag value="47495" />
+    <Index value="416" />
+    <ParentIndex value="412" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.012284001" y="3.7198333e-09" z="0.010703057" />
+    <Rotation x="-1.8366844e-05" y="-0.110525474" z="0.00015942237" w="0.9938733" />
+    <Scale x="1.0" y="0.99999994" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_eyesackUpperOuter</Name>
+    <Tag value="37761" />
+    <Index value="417" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="418" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.039057687" y="0.096141085" z="0.639295" />
+    <Rotation x="-0.27989483" y="0.88729125" z="0.35589656" w="0.08781091" />
+    <Scale x="0.99999994" y="0.9999997" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_eyesackUpperOuter</Name>
+    <Tag value="37857" />
+    <Index value="418" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="419" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.040487327" y="0.095003575" z="0.63866425" />
+    <Rotation x="-0.27988386" y="-0.8872961" z="-0.3558913" w="0.08781859" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_L_foreheadMid</Name>
+    <Tag value="16987" />
+    <Index value="419" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="420" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.038021665" y="0.09594454" z="0.6536992" />
+    <Rotation x="0.02743517" y="-0.6448712" z="-0.76349384" w="0.021580655" />
+    <Scale x="1.0" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FACIAL_R_foreheadMid</Name>
+    <Tag value="10414" />
+    <Index value="420" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="421" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.034964316" y="0.09750921" z="0.65295726" />
+    <Rotation x="0.027427848" y="0.64487153" z="0.7634941" w="0.021569898" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_L_Breast</Name>
+    <Tag value="64654" />
+    <Index value="421" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="422" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.0945031" y="0.16186303" z="0.29926547" />
+    <Rotation x="-2.3398117e-07" y="3.9747155e-12" z="1.0" w="2.1477412e-11" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>SPR_R_Breast</Name>
+    <Tag value="34911" />
+    <Index value="422" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="423" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.09450189" y="0.1618638" z="0.29926547" />
+    <Rotation x="-2.3398117e-07" y="3.9747155e-12" z="1.0" w="2.1477412e-11" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Brow_Out_002</Name>
+    <Tag value="58331" />
+    <Index value="423" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="424" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.020945195" y="-0.0039286497" z="0.7136535" />
+    <Rotation x="-0.0011700412" y="-0.16689718" z="0.8684558" w="0.46682832" />
+    <Scale x="0.9999999" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lid_Upper_002</Name>
+    <Tag value="45750" />
+    <Index value="424" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="425" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.032728158" y="0.092341095" z="0.7152684" />
+    <Rotation x="-0.025938079" y="0.0363361" z="0.73877287" w="0.67247427" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Eye_002</Name>
+    <Tag value="25260" />
+    <Index value="425" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="426" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.032650147" y="0.09158171" z="0.7156487" />
+    <Rotation x="-0.025938401" y="0.036335565" z="0.7387732" w="0.6724739" />
+    <Scale x="0.9999999" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_CheekBone_002</Name>
+    <Tag value="21550" />
+    <Index value="426" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="427" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.013772395" y="0.10803939" z="0.70386416" />
+    <Rotation x="0.16666088" y="-0.11964224" z="-0.9754297" w="0.08029168" />
+    <Scale x="0.99999964" y="0.9999998" z="0.9999984" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Corner_002</Name>
+    <Tag value="29868" />
+    <Index value="427" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="428" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.011627677" y="0.051192403" z="0.6409321" />
+    <Rotation x="-0.016316043" y="0.069529" z="0.81617755" w="0.57337046" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lid_Upper_002</Name>
+    <Tag value="43536" />
+    <Index value="428" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="429" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.034180846" y="0.09224309" z="0.7157154" />
+    <Rotation x="-0.02828318" y="0.035699993" z="0.67201346" w="0.739137" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Eye_002</Name>
+    <Tag value="27474" />
+    <Index value="429" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="430" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.034101855" y="0.0914807" z="0.7160967" />
+    <Rotation x="-0.025248323" y="0.03236924" z="0.6722181" w="0.7392142" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_CheekBone_002</Name>
+    <Tag value="19336" />
+    <Index value="430" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="431" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.013771605" y="0.108039774" z="0.7038641" />
+    <Rotation x="-0.11969519" y="0.166013" z="-0.08021098" w="0.97554046" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Brow_Out_002</Name>
+    <Tag value="1356" />
+    <Index value="431" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="432" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.020946804" y="-0.0039282325" z="0.71365255" />
+    <Rotation x="0.16705436" y="0.00087515236" z="0.4667671" w="0.86845875" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Corner_002</Name>
+    <Tag value="11174" />
+    <Index value="432" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="433" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.011184343" y="0.04967411" z="0.63997364" />
+    <Rotation x="-0.07012509" y="0.017163573" z="0.57329804" w="0.8161602" />
+    <Scale x="0.9999999" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Brow_Centre_002</Name>
+    <Tag value="37193" />
+    <Index value="433" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="434" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-6.393469e-07" y="-0.014818843" z="0.7221109" />
+    <Rotation x="0.035283946" y="-0.035285436" z="0.70622784" w="0.7062239" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLipRoot_002</Name>
+    <Tag value="20178" />
+    <Index value="434" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="438" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.6871556e-06" y="0.052904468" z="0.6518526" />
+    <Rotation x="0.0029958743" y="-0.0029941644" z="0.70710325" w="0.7070976" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLip_002</Name>
+    <Tag value="61839" />
+    <Index value="435" />
+    <ParentIndex value="434" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.06302699" y="-7.450808e-09" z="0.0004269872" />
+    <Rotation x="-1.3154204e-06" y="0.7380054" z="-1.2178156e-06" w="0.6747948" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Top_002</Name>
+    <Tag value="20279" />
+    <Index value="436" />
+    <ParentIndex value="435" />
+    <SiblingIndex value="437" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.014702022" y="0.009321" z="6.599165e-05" />
+    <Rotation x="-0.68156713" y="-0.2981511" z="0.5661929" w="0.35496166" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Top_002</Name>
+    <Tag value="17719" />
+    <Index value="437" />
+    <ParentIndex value="435" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.014701986" y="-0.009323001" z="6.5984226e-05" />
+    <Rotation x="0.68049175" y="-0.2988216" z="-0.5674894" w="0.35439035" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Jaw_002</Name>
+    <Tag value="46240" />
+    <Index value="438" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="444" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.1768777e-06" y="0.017314553" z="0.6583864" />
+    <Rotation x="-0.2552697" y="0.2552671" z="0.65942466" w="0.6594204" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLipRoot_002</Name>
+    <Tag value="17188" />
+    <Index value="439" />
+    <ParentIndex value="438" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.05125499" y="-3.725404e-09" z="-0.0018239692" />
+    <Rotation x="1.7370262e-08" y="-0.36100417" z="-6.724131e-09" w="0.9325642" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLip_002</Name>
+    <Tag value="20623" />
+    <Index value="440" />
+    <ParentIndex value="439" />
+    <SiblingIndex value="443" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.046667" y="3.7253187e-09" z="-0.012208013" />
+    <Rotation x="-1.5980712e-08" y="-0.51371384" z="9.568711e-09" w="0.8579616" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Bot_002</Name>
+    <Tag value="47419" />
+    <Index value="441" />
+    <ParentIndex value="440" />
+    <SiblingIndex value="442" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.018878032" y="0.008469999" z="-0.0012100216" />
+    <Rotation x="0.5450536" y="0.19590865" z="0.6603457" w="0.47799587" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Bot_002</Name>
+    <Tag value="49979" />
+    <Index value="442" />
+    <ParentIndex value="440" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.01887801" y="-0.008472003" z="-0.0012090032" />
+    <Rotation x="-0.5446782" y="0.19617642" z="-0.66065896" w="0.47788095" />
+    <Scale x="1.0" y="0.99999994" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Tongue_002</Name>
+    <Tag value="47495" />
+    <Index value="443" />
+    <ParentIndex value="439" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0015130065" y="2.842171e-14" z="0.0035610055" />
+    <Rotation x="-1.3969839e-08" y="-1.9896587e-12" z="1.2805689e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Brow_Out_006</Name>
+    <Tag value="58331" />
+    <Index value="444" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="445" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.014174961" y="0.014186025" z="0.7285216" />
+    <Rotation x="-0.032123018" y="-0.14974375" z="0.88176453" w="0.44613478" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lid_Upper_006</Name>
+    <Tag value="45750" />
+    <Index value="445" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="446" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.0339941" y="0.08883958" z="0.72041875" />
+    <Rotation x="1.4974241e-05" y="-1.323026e-05" z="0.708562" w="0.70564854" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Eye_006</Name>
+    <Tag value="25260" />
+    <Index value="446" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="447" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.033994082" y="0.08783314" z="0.7214869" />
+    <Rotation x="-1.1166739e-05" y="1.3644491e-05" z="0.7085606" w="0.70565" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_CheekBone_006</Name>
+    <Tag value="21550" />
+    <Index value="447" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="448" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.010767369" y="0.10692603" z="0.7112856" />
+    <Rotation x="0.16610564" y="-0.11089416" z="-0.97568375" w="0.09029297" />
+    <Scale x="1.000001" y="1.0000002" z="1.0000029" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Corner_006</Name>
+    <Tag value="29868" />
+    <Index value="448" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="449" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.008226808" y="0.061220597" z="0.6487947" />
+    <Rotation x="0.043062504" y="0.06964221" z="0.8140947" w="0.57493067" />
+    <Scale x="0.9999999" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lid_Upper_006</Name>
+    <Tag value="43536" />
+    <Index value="449" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="450" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.035398897" y="0.08883323" z="0.72011554" />
+    <Rotation x="-6.291935e-05" y="6.402468e-05" z="0.70564365" w="0.7085669" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Eye_006</Name>
+    <Tag value="27474" />
+    <Index value="450" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="451" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.035397917" y="0.08782678" z="0.7211837" />
+    <Rotation x="-7.7843986e-05" y="7.985494e-05" z="0.7056477" w="0.7085629" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_CheekBone_006</Name>
+    <Tag value="19336" />
+    <Index value="451" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="452" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.010768631" y="0.10692634" z="0.7112856" />
+    <Rotation x="-0.11085695" y="0.16649275" z="-0.090340644" w="0.97561747" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Brow_Out_006</Name>
+    <Tag value="1356" />
+    <Index value="452" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="453" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.014175039" y="0.014185622" z="0.72852165" />
+    <Rotation x="0.15056846" y="0.030487519" z="0.4458491" w="0.88182664" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Corner_006</Name>
+    <Tag value="11174" />
+    <Index value="453" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="454" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.012697168" y="0.06300497" z="0.64936143" />
+    <Rotation x="-0.06946404" y="-0.0433179" z="0.5749477" w="0.8140844" />
+    <Scale x="1.0" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Brow_Centre_006</Name>
+    <Tag value="37193" />
+    <Index value="454" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="455" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0025741393" y="0.00096421316" z="0.72285897" />
+    <Rotation x="0.05697165" y="-0.056975234" z="0.70480657" w="0.70480907" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLipRoot_006</Name>
+    <Tag value="20178" />
+    <Index value="455" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="459" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.0026641772" y="0.063712135" z="0.66432023" />
+    <Rotation x="0.0029952072" y="-0.002993521" z="0.7071005" w="0.7071004" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLip_006</Name>
+    <Tag value="61839" />
+    <Index value="456" />
+    <ParentIndex value="455" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.058394983" y="-7.000209e-05" z="0.0033279725" />
+    <Rotation x="-2.7022734e-05" y="0.7067405" z="2.6661994e-05" w="0.7074729" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Top_006</Name>
+    <Tag value="20279" />
+    <Index value="457" />
+    <ParentIndex value="456" />
+    <SiblingIndex value="458" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.014575963" y="0.011190999" z="-0.0037189962" />
+    <Rotation x="-0.6662559" y="-0.27488086" z="0.58413583" w="0.37326798" />
+    <Scale x="1.0" y="1.0000001" z="1.0000002" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Top_006</Name>
+    <Tag value="17719" />
+    <Index value="458" />
+    <ParentIndex value="456" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.014703976" y="-0.0067670015" z="-0.002220999" />
+    <Rotation x="0.66677684" y="-0.27454555" z="-0.58353996" w="0.37351638" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Jaw_006</Name>
+    <Tag value="46240" />
+    <Index value="459" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="465" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.002332666" y="0.03090633" z="0.6842531" />
+    <Rotation x="-0.2529046" y="0.25290343" z="0.6603333" w="0.66033256" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLipRoot_006</Name>
+    <Tag value="17188" />
+    <Index value="460" />
+    <ParentIndex value="459" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.056994" y="-5.101033e-05" z="-0.009407983" />
+    <Rotation x="-9.1856236e-07" y="-0.35766068" z="8.3050503e-07" w="0.9338516" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLip_006</Name>
+    <Tag value="20623" />
+    <Index value="461" />
+    <ParentIndex value="460" />
+    <SiblingIndex value="464" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.045982003" y="0.00016099568" z="-0.0070889993" />
+    <Rotation x="2.3755081e-07" y="-0.5468672" z="4.2328097e-07" w="0.83721936" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Bot_006</Name>
+    <Tag value="47419" />
+    <Index value="462" />
+    <ParentIndex value="461" />
+    <SiblingIndex value="463" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.014437953" y="0.010038003" z="0.0005199799" />
+    <Rotation x="0.5347896" y="0.21670859" z="0.70684946" w="0.40914708" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Bot_006</Name>
+    <Tag value="49979" />
+    <Index value="463" />
+    <ParentIndex value="461" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.015537994" y="-0.007406995" z="-0.0018419975" />
+    <Rotation x="-0.5318879" y="0.21838358" z="-0.7090376" w="0.40825194" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Tongue_006</Name>
+    <Tag value="47495" />
+    <Index value="464" />
+    <ParentIndex value="460" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0073680026" y="-0.0005009957" z="0.0083920285" />
+    <Rotation x="-8.855739e-08" y="0.040317092" z="1.5017367e-06" w="0.99918693" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Brow_Out_001</Name>
+    <Tag value="58331" />
+    <Index value="465" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="466" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.0022291713" y="0.024643647" z="0.7402832" />
+    <Rotation x="-0.008370646" y="-0.16301943" z="0.86839175" w="0.468242" />
+    <Scale x="1.0000001" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lid_Upper_001</Name>
+    <Tag value="45750" />
+    <Index value="466" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="467" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.03204396" y="0.0790401" z="0.7206625" />
+    <Rotation x="5.6740737e-05" y="-5.5774875e-05" z="0.7078789" w="0.7063339" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Eye_001</Name>
+    <Tag value="25260" />
+    <Index value="467" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="468" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.032040942" y="0.07766233" z="0.72142637" />
+    <Rotation x="-3.014964e-06" y="5.5344485e-06" z="0.70787776" w="0.706335" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_CheekBone_001</Name>
+    <Tag value="21550" />
+    <Index value="468" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="469" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.01243617" y="0.0927273" z="0.7109656" />
+    <Rotation x="0.11488939" y="-0.0042952457" z="-0.99293745" w="0.02927931" />
+    <Scale x="1.000003" y="0.99999994" z="1.0000002" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Corner_001</Name>
+    <Tag value="29868" />
+    <Index value="469" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="470" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.016187785" y="0.059602417" z="0.6491385" />
+    <Rotation x="0.040450722" y="0.029946808" z="0.8026455" w="0.5943293" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lid_Upper_001</Name>
+    <Tag value="43536" />
+    <Index value="470" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="471" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.03136004" y="0.07865243" z="0.72117996" />
+    <Rotation x="0.0005498403" y="-0.0005518091" z="0.70638365" w="0.7078288" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Eye_001</Name>
+    <Tag value="27474" />
+    <Index value="471" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="472" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.031357065" y="0.077276625" z="0.7219469" />
+    <Rotation x="-0.0011823607" y="0.0011830921" z="0.70638293" w="0.707828" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_CheekBone_001</Name>
+    <Tag value="19336" />
+    <Index value="472" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="473" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.01242283" y="0.09272965" z="0.7109656" />
+    <Rotation x="-0.0042643384" y="0.116214685" z="-0.029215135" w="0.9927852" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Brow_Out_001</Name>
+    <Tag value="1356" />
+    <Index value="473" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="474" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0022238286" y="0.024643708" z="0.74028313" />
+    <Rotation x="0.16317628" y="0.00808433" z="0.46825087" w="0.8683602" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Corner_001</Name>
+    <Tag value="11174" />
+    <Index value="474" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="475" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.015587243" y="0.057649426" z="0.64906627" />
+    <Rotation x="-0.028267892" y="-0.04271679" z="0.59446615" w="0.80248755" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Brow_Centre_001</Name>
+    <Tag value="37193" />
+    <Index value="475" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="476" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-9.777174e-07" y="0.011210363" z="0.743553" />
+    <Rotation x="0.015965559" y="-0.015964903" z="0.70694107" w="0.706912" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLipRoot_001</Name>
+    <Tag value="20178" />
+    <Index value="476" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="480" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-2.6912023e-06" y="0.054540507" z="0.6661656" />
+    <Rotation x="0.0029951062" y="-0.0029933003" z="0.7071146" w="0.7070863" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLip_001</Name>
+    <Tag value="61839" />
+    <Index value="477" />
+    <ParentIndex value="476" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.048511" y="3.410605e-13" z="-0.004610076" />
+    <Rotation x="-1.3679377e-06" y="0.43729332" z="-1.2865124e-06" w="0.89931893" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Top_001</Name>
+    <Tag value="20279" />
+    <Index value="478" />
+    <ParentIndex value="477" />
+    <SiblingIndex value="479" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.005040007" y="0.008721996" z="-0.0005890099" />
+    <Rotation x="-0.5163345" y="-0.10841703" z="0.70223147" w="0.4780329" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Top_001</Name>
+    <Tag value="17719" />
+    <Index value="479" />
+    <ParentIndex value="477" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0030169496" y="-0.009547003" z="0.0004960236" />
+    <Rotation x="0.5157693" y="-0.10880288" z="-0.7026285" w="0.47797197" />
+    <Scale x="1.0" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Jaw_001</Name>
+    <Tag value="46240" />
+    <Index value="480" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="486" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.1047596e-06" y="0.01287052" z="0.6655276" />
+    <Rotation x="-0.19316748" y="0.19315985" z="0.68022496" w="0.6801982" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLipRoot_001</Name>
+    <Tag value="17188" />
+    <Index value="481" />
+    <ParentIndex value="480" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.05322099" y="-7.450728e-09" z="-0.00021804305" />
+    <Rotation x="-2.8953828e-13" y="-0.27317545" z="-9.359929e-13" w="0.96196425" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLip_001</Name>
+    <Tag value="20623" />
+    <Index value="482" />
+    <ParentIndex value="481" />
+    <SiblingIndex value="485" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.041651" y="-2.8510527e-13" z="0.008171951" />
+    <Rotation x="-1.1290964e-08" y="-0.30310377" z="-3.5500655e-08" w="0.9529576" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Bot_001</Name>
+    <Tag value="47419" />
+    <Index value="483" />
+    <ParentIndex value="482" />
+    <SiblingIndex value="484" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0050440053" y="-2.0001084e-05" z="-0.0034620126" />
+    <Rotation x="0.30306575" y="0.1263165" z="0.78101027" w="0.5312421" />
+    <Scale x="1.0" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Bot_001</Name>
+    <Tag value="49979" />
+    <Index value="484" />
+    <ParentIndex value="482" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0050440067" y="2.5000423e-05" z="-0.0034620136" />
+    <Rotation x="-0.30003077" y="0.12837966" z="-0.7821644" w="0.53077215" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Tongue_001</Name>
+    <Tag value="47495" />
+    <Index value="485" />
+    <ParentIndex value="481" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.002978" y="-3.463896e-14" z="0.009164974" />
+    <Rotation x="-6.418477e-17" y="7.3483494e-13" z="9.102576e-15" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Brow_Out_003</Name>
+    <Tag value="58331" />
+    <Index value="486" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="487" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.004363282" y="0.031878807" z="0.7335906" />
+    <Rotation x="0.0022643653" y="-0.16873816" z="0.868435" w="0.4662006" />
+    <Scale x="0.9999999" y="0.9999999" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lid_Upper_003</Name>
+    <Tag value="45750" />
+    <Index value="487" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="488" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.034263194" y="0.095414646" z="0.7204406" />
+    <Rotation x="5.8288924e-06" y="5.134824e-06" z="0.71240807" w="0.7017655" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Eye_003</Name>
+    <Tag value="25260" />
+    <Index value="488" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="489" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.034209173" y="0.09393074" z="0.7209896" />
+    <Rotation x="5.7890547e-06" y="5.1740662e-06" z="0.71240765" w="0.70176584" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_CheekBone_003</Name>
+    <Tag value="21550" />
+    <Index value="489" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="490" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.014370414" y="0.11009522" z="0.7104775" />
+    <Rotation x="0.11488747" y="-0.0042933836" z="-0.9929374" w="0.029290717" />
+    <Scale x="1.0000027" y="1.0" z="1.0000002" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Corner_003</Name>
+    <Tag value="29868" />
+    <Index value="490" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="491" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.016726999" y="0.07429012" z="0.64480466" />
+    <Rotation x="0.04108494" y="0.029069547" z="0.8152844" w="0.57686955" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lid_Upper_003</Name>
+    <Tag value="43536" />
+    <Index value="491" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="492" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.034572806" y="0.095403664" z="0.7207754" />
+    <Rotation x="-0.00021181979" y="0.00021252871" z="0.7016911" w="0.7124813" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Eye_003</Name>
+    <Tag value="27474" />
+    <Index value="492" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="493" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.034517832" y="0.09392075" z="0.7213254" />
+    <Rotation x="-0.00021108113" y="0.00021347802" z="0.7016903" w="0.712482" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_CheekBone_003</Name>
+    <Tag value="19336" />
+    <Index value="493" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="494" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.014421585" y="0.11009261" z="0.7104784" />
+    <Rotation x="-0.004287749" y="0.11473624" z="-0.029387997" w="0.99295205" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Brow_Out_003</Name>
+    <Tag value="1356" />
+    <Index value="494" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="495" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.004399718" y="0.03187793" z="0.7335906" />
+    <Rotation x="0.16876654" y="-0.0023102744" z="0.4661037" w="0.86848134" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Corner_003</Name>
+    <Tag value="11174" />
+    <Index value="495" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="496" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.01628502" y="0.07290596" z="0.64475644" />
+    <Rotation x="-0.029013336" y="-0.04114242" z="0.57679236" w="0.8153381" />
+    <Scale x="0.99999994" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Brow_Centre_003</Name>
+    <Tag value="37193" />
+    <Index value="496" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="497" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-1.272303e-07" y="0.020542" z="0.7300056" />
+    <Rotation x="0.037539344" y="-0.03753826" z="0.70611984" w="0.70609945" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLipRoot_003</Name>
+    <Tag value="20178" />
+    <Index value="497" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="501" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.7777368e-06" y="0.060685277" z="0.6662167" />
+    <Rotation x="0.0029957036" y="-0.002992227" z="0.70711285" w="0.7070881" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLip_003</Name>
+    <Tag value="61839" />
+    <Index value="498" />
+    <ParentIndex value="497" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.05528601" y="-2.2737368e-13" z="-0.008293992" />
+    <Rotation x="-6.731827e-07" y="0.43729493" z="-1.3629256e-06" w="0.89931816" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Top_003</Name>
+    <Tag value="20279" />
+    <Index value="499" />
+    <ParentIndex value="498" />
+    <SiblingIndex value="500" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0043719993" y="0.011491999" z="-0.0010249938" />
+    <Rotation x="-0.51632863" y="-0.10841345" z="0.7022523" w="0.4780093" />
+    <Scale x="0.9999998" y="1.0" z="0.9999998" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Top_003</Name>
+    <Tag value="17719" />
+    <Index value="500" />
+    <ParentIndex value="498" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0043699746" y="-0.011551004" z="-0.0010280148" />
+    <Rotation x="0.5164183" y="-0.108324476" z="-0.70225257" w="0.4779323" />
+    <Scale x="1.0" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Jaw_003</Name>
+    <Tag value="46240" />
+    <Index value="501" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="507" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.2594156e-06" y="0.023118656" z="0.6578325" />
+    <Rotation x="-0.19316846" y="0.1931596" z="0.6802225" w="0.6802005" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLipRoot_003</Name>
+    <Tag value="17188" />
+    <Index value="502" />
+    <ParentIndex value="501" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.042255025" y="-7.450922e-09" z="0.0050099995" />
+    <Rotation x="-3.1200311e-06" y="-0.2731751" z="1.1070917e-05" w="0.9619643" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLip_003</Name>
+    <Tag value="20623" />
+    <Index value="503" />
+    <ParentIndex value="502" />
+    <SiblingIndex value="506" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.053480003" y="-3.7248356e-09" z="0.001972996" />
+    <Rotation x="-2.166286e-08" y="-0.36653307" z="8.534453e-09" w="0.930405" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Bot_003</Name>
+    <Tag value="47419" />
+    <Index value="504" />
+    <ParentIndex value="503" />
+    <SiblingIndex value="505" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0010619886" y="0.005749997" z="-0.0016070056" />
+    <Rotation x="0.3682647" y="0.15253976" z="0.7524769" w="0.52430093" />
+    <Scale x="1.0000001" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Bot_003</Name>
+    <Tag value="49979" />
+    <Index value="505" />
+    <ParentIndex value="503" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0010600018" y="-0.0058080032" z="-0.0016069869" />
+    <Rotation x="-0.36804998" y="0.15270425" z="-0.7526471" w="0.5241592" />
+    <Scale x="1.0000001" y="1.0000001" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Tongue_003</Name>
+    <Tag value="47495" />
+    <Index value="506" />
+    <ParentIndex value="502" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.006707999" y="2.2737368e-13" z="0.0077760345" />
+    <Rotation x="1.168645e-06" y="8.678363e-06" z="1.9008306e-05" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Brow_Out_004</Name>
+    <Tag value="58331" />
+    <Index value="507" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="508" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.004363282" y="0.031878807" z="0.7335906" />
+    <Rotation x="0.002262602" y="-0.16873908" z="0.8684284" w="0.46621245" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lid_Upper_004</Name>
+    <Tag value="45750" />
+    <Index value="508" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="509" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.034319207" y="0.096268676" z="0.72044015" />
+    <Rotation x="7.19529e-06" y="6.298821e-06" z="0.71239746" w="0.7017762" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Eye_004</Name>
+    <Tag value="25260" />
+    <Index value="509" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="510" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.034239173" y="0.09393183" z="0.7209796" />
+    <Rotation x="6.905831e-06" y="6.583965e-06" z="0.71239775" w="0.7017759" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_CheekBone_004</Name>
+    <Tag value="21550" />
+    <Index value="510" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="511" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.013509435" y="0.111493535" z="0.7106768" />
+    <Rotation x="0.11488708" y="-0.0042962506" z="-0.99293774" w="0.029276397" />
+    <Scale x="1.0000027" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Corner_004</Name>
+    <Tag value="29868" />
+    <Index value="511" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="512" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.01502993" y="0.06945646" z="0.64463407" />
+    <Rotation x="0.041087642" y="0.02906948" z="0.8152739" w="0.57688415" />
+    <Scale x="1.0000001" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lid_Upper_004</Name>
+    <Tag value="43536" />
+    <Index value="512" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="513" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.034461793" y="0.09627228" z="0.7208221" />
+    <Rotation x="-0.00091388944" y="0.0009267616" z="0.701818" w="0.71235514" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Eye_004</Name>
+    <Tag value="27474" />
+    <Index value="513" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="514" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.034379825" y="0.093934424" z="0.72136253" />
+    <Rotation x="-0.0009138508" y="0.00092672126" z="0.7018183" w="0.71235484" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_CheekBone_004</Name>
+    <Tag value="19336" />
+    <Index value="514" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="515" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.013421585" y="0.1101847" z="0.71069527" />
+    <Rotation x="-0.0073077125" y="0.11606449" z="-0.05522037" w="0.99167854" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Brow_Out_004</Name>
+    <Tag value="1356" />
+    <Index value="515" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="516" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.004361718" y="0.031878933" z="0.7335906" />
+    <Rotation x="0.16946474" y="-0.0035999715" z="0.46600926" w="0.8683917" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Corner_004</Name>
+    <Tag value="11174" />
+    <Index value="516" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="517" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.01502307" y="0.06945789" z="0.64463407" />
+    <Rotation x="-0.02725256" y="-0.04365707" z="0.57702065" w="0.81510645" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Brow_Centre_004</Name>
+    <Tag value="37193" />
+    <Index value="517" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="518" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-1.1001317e-06" y="0.018599749" z="0.7297985" />
+    <Rotation x="0.037539404" y="-0.037542343" z="0.7061137" w="0.7061055" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLipRoot_004</Name>
+    <Tag value="20178" />
+    <Index value="518" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="522" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-8.3947333e-07" y="0.065069124" z="0.66625327" />
+    <Rotation x="0.0029927131" y="-0.0029901217" z="0.70710784" w="0.70709306" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLip_004</Name>
+    <Tag value="61839" />
+    <Index value="519" />
+    <ParentIndex value="518" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.052619994" y="2.2737368e-13" z="-0.0061199763" />
+    <Rotation x="-2.0301077e-06" y="0.4372952" z="-1.277109e-06" w="0.89931804" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Top_004</Name>
+    <Tag value="20279" />
+    <Index value="520" />
+    <ParentIndex value="519" />
+    <SiblingIndex value="521" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.005697968" y="0.009679001" z="-0.0010529858" />
+    <Rotation x="-0.4751962" y="-0.13565788" z="0.73070836" w="0.47101057" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Top_004</Name>
+    <Tag value="17719" />
+    <Index value="521" />
+    <ParentIndex value="519" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0056979707" y="-0.009670999" z="-0.001051967" />
+    <Rotation x="0.47572643" y="-0.13530426" z="-0.73032844" w="0.47116613" />
+    <Scale x="0.9999999" y="0.99999994" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Jaw_004</Name>
+    <Tag value="46240" />
+    <Index value="522" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="528" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.2594156e-06" y="0.023118656" z="0.6578325" />
+    <Rotation x="-0.19316691" y="0.19316286" z="0.6802184" w="0.6802041" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLipRoot_004</Name>
+    <Tag value="17188" />
+    <Index value="523" />
+    <ParentIndex value="522" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.045756023" y="-2.0006219e-13" z="0.005273998" />
+    <Rotation x="-2.5638267e-06" y="-0.27317208" z="1.1222757e-05" w="0.9619652" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLip_004</Name>
+    <Tag value="20623" />
+    <Index value="524" />
+    <ParentIndex value="523" />
+    <SiblingIndex value="527" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.049641997" y="2.2737368e-13" z="0.004984981" />
+    <Rotation x="-5.950277e-07" y="-0.30310363" z="1.11073916e-07" w="0.95295763" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Bot_004</Name>
+    <Tag value="47419" />
+    <Index value="525" />
+    <ParentIndex value="524" />
+    <SiblingIndex value="526" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0018030223" y="0.0049040024" z="-0.00045601782" />
+    <Rotation x="0.26912668" y="0.14910412" z="0.79336286" w="0.5252753" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Bot_004</Name>
+    <Tag value="49979" />
+    <Index value="526" />
+    <ParentIndex value="524" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.001802046" y="-0.004896999" z="-0.00045799746" />
+    <Rotation x="-0.27484092" y="0.13903311" z="-0.811256" w="0.49698687" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Tongue_004</Name>
+    <Tag value="47495" />
+    <Index value="527" />
+    <ParentIndex value="523" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0003259984" y="-3.725404e-09" z="0.009393972" />
+    <Rotation x="-9.427101e-09" y="5.9963604e-06" z="1.8995197e-05" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Brow_Out_005</Name>
+    <Tag value="58331" />
+    <Index value="528" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="529" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.019832835" y="0.023576977" z="0.73414147" />
+    <Rotation x="-0.037254896" y="-0.14307266" z="0.8999703" w="0.41011706" />
+    <Scale x="1.0000001" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lid_Upper_005</Name>
+    <Tag value="45750" />
+    <Index value="529" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="530" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.03306114" y="0.09187224" z="0.7227435" />
+    <Rotation x="-6.72347e-07" y="-5.1968645e-06" z="0.71201044" w="0.70216894" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Eye_005</Name>
+    <Tag value="25260" />
+    <Index value="530" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="531" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.03303111" y="0.08978145" z="0.7232791" />
+    <Rotation x="-9.166256e-07" y="-4.9559644e-06" z="0.71201044" w="0.7021689" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_CheekBone_005</Name>
+    <Tag value="21550" />
+    <Index value="531" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="532" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.012718385" y="0.1082791" z="0.7136656" />
+    <Rotation x="0.17519215" y="-0.09962899" z="-0.97884583" w="0.035252616" />
+    <Scale x="1.0" y="1.0000001" z="1.0000038" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Corner_005</Name>
+    <Tag value="29868" />
+    <Index value="532" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="533" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.018912949" y="0.0708361" z="0.64637834" />
+    <Rotation x="0.04108023" y="0.029064799" z="0.81530446" w="0.5768417" />
+    <Scale x="1.0" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lid_Upper_005</Name>
+    <Tag value="43536" />
+    <Index value="533" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="534" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.03329486" y="0.09187034" z="0.72306544" />
+    <Rotation x="-0.0016233417" y="0.0016452686" z="0.7021621" w="0.7120135" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Eye_005</Name>
+    <Tag value="27474" />
+    <Index value="534" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="535" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.03326589" y="0.08977956" z="0.723599" />
+    <Rotation x="-0.0016233417" y="0.0016452686" z="0.7021621" w="0.7120135" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_CheekBone_005</Name>
+    <Tag value="19336" />
+    <Index value="535" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="536" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.012719615" y="0.108279474" z="0.7136646" />
+    <Rotation x="-0.09962858" y="0.17515637" z="-0.03525388" w="0.9788523" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Brow_Out_005</Name>
+    <Tag value="1356" />
+    <Index value="536" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="537" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="-0.019834166" y="0.023576418" z="0.7341415" />
+    <Rotation x="0.14284837" y="0.037743576" z="0.41018862" w="0.8999528" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Corner_005</Name>
+    <Tag value="11174" />
+    <Index value="537" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="538" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.017379051" y="0.070835605" z="0.6463783" />
+    <Rotation x="-0.028969966" y="-0.041216463" z="0.57684195" w="0.81530076" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Brow_Centre_005</Name>
+    <Tag value="37193" />
+    <Index value="538" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="539" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="6.4596435e-08" y="0.0072927214" z="0.7338401" />
+    <Rotation x="0.013209094" y="-0.013209108" z="0.70698303" w="0.7069838" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLipRoot_005</Name>
+    <Tag value="20178" />
+    <Index value="539" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="543" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-7.4373736e-07" y="0.05842864" z="0.66786885" />
+    <Rotation x="0.0029958428" y="-0.0029933117" z="0.70710075" w="0.7071002" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_UpperLip_005</Name>
+    <Tag value="61839" />
+    <Index value="540" />
+    <ParentIndex value="539" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.063543" y="-3.725461e-09" z="-0.0013219402" />
+    <Rotation x="-6.3580605e-06" y="0.7539873" z="4.8382963e-06" w="0.65688896" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Top_005</Name>
+    <Tag value="20279" />
+    <Index value="541" />
+    <ParentIndex value="540" />
+    <SiblingIndex value="542" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.011457019" y="0.015718002" z="-0.0016589932" />
+    <Rotation x="-0.73380476" y="-0.30916083" z="0.44279754" w="0.41216564" />
+    <Scale x="1.0" y="1.0" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Top_005</Name>
+    <Tag value="17719" />
+    <Index value="542" />
+    <ParentIndex value="540" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.011455974" y="-0.016176" z="-0.0016590114" />
+    <Rotation x="0.73407" y="-0.30889723" z="-0.44235533" w="0.41236573" />
+    <Scale x="0.99999994" y="0.9999998" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Jaw_005</Name>
+    <Tag value="46240" />
+    <Index value="543" />
+    <ParentIndex value="0" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="-1.239949e-06" y="0.023781683" z="0.6795222" />
+    <Rotation x="-0.24950664" y="0.24950509" z="0.6616241" w="0.6616247" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLipRoot_005</Name>
+    <Tag value="17188" />
+    <Index value="544" />
+    <ParentIndex value="543" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.057922" y="1.3367085e-13" z="-0.006287001" />
+    <Rotation x="-1.6097835e-06" y="-0.35285488" z="4.230124e-06" w="0.93567806" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_LowerLip_005</Name>
+    <Tag value="20623" />
+    <Index value="545" />
+    <ParentIndex value="544" />
+    <SiblingIndex value="548" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ, Unk0</Flags>
+    <Translation x="0.05007899" y="-7.450637e-09" z="-0.0061619948" />
+    <Rotation x="8.974317e-06" y="-0.5537457" z="4.8586303e-06" w="0.8326858" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_L_Lip_Bot_005</Name>
+    <Tag value="47419" />
+    <Index value="546" />
+    <ParentIndex value="545" />
+    <SiblingIndex value="547" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.013715982" y="0.01449" z="0.00072699966" />
+    <Rotation x="0.53973943" y="0.2405843" z="0.64274913" w="0.48751834" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_R_Lip_Bot_005</Name>
+    <Tag value="49979" />
+    <Index value="547" />
+    <ParentIndex value="545" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0137159955" y="-0.014947002" z="0.00072700856" />
+    <Rotation x="-0.53968436" y="0.24063155" z="-0.642793" w="0.48749813" />
+    <Scale x="1.0" y="0.99999994" z="0.9999998" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>FB_Tongue_005</Name>
+    <Tag value="47495" />
+    <Index value="548" />
+    <ParentIndex value="544" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.011160997" y="-3.725461e-09" z="0.007967013" />
+    <Rotation x="4.5285768e-07" y="0.019206425" z="8.429408e-06" w="0.9998155" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Root</Name>
+    <Tag value="0" />
+    <Index value="549" />
+    <ParentIndex value="-1" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>AAPClip</Name>
+    <Tag value="0" />
+    <Index value="550" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="551" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_GripR</Name>
+    <Tag value="18308" />
+    <Index value="551" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="566" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.115186" y="-0.023006003" z="-0.086754" />
+    <Rotation x="0.6578194" y="0.00028754104" z="0.093093015" w="0.7474004" />
+    <Scale x="0.99999994" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Main_Bone</Name>
+    <Tag value="3360" />
+    <Index value="552" />
+    <ParentIndex value="551" />
+    <SiblingIndex value="565" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.12698801" y="0.072022006" z="0.00320901" />
+    <Rotation x="-0.65781957" y="-0.00028752367" z="-0.093092896" w="0.7474003" />
+    <Scale x="1.0" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Cock1</Name>
+    <Tag value="39439" />
+    <Index value="553" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="555" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.085381" y="-3.6001205e-05" z="0.039165996" />
+    <Rotation x="-0.9999999" y="1.9984017e-15" z="0.00048251546" w="1.2665986e-06" />
+    <Scale x="1.0" y="0.99999976" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Breach</Name>
+    <Tag value="24367" />
+    <Index value="554" />
+    <ParentIndex value="553" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.080982" y="-3.6019825e-05" z="0.014045057" />
+    <Rotation x="0.9999999" y="-1.4901158e-07" z="-0.0004825155" w="1.8440182e-06" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_VFX_Eject</Name>
+    <Tag value="28405" />
+    <Index value="555" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="556" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.028993998" y="-0.006626997" z="0.023547001" />
+    <Rotation x="4.712737e-07" y="-2.9263782e-07" z="-0.70710665" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Muzzle</Name>
+    <Tag value="17833" />
+    <Index value="556" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="557" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.400527" y="-3.6001205e-05" z="0.01751602" />
+    <Rotation x="-1.0" y="5.9604633e-07" z="-0.00018198887" w="1.2293456e-06" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPFlshLasr</Name>
+    <Tag value="4396" />
+    <Index value="557" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="558" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.27496" y="-0.021457996" z="0.015687015" />
+    <Rotation x="1.8626443e-08" y="-4.1909525e-09" z="-1.838817e-15" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPSupp</Name>
+    <Tag value="4230" />
+    <Index value="558" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="559" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.22960599" y="-3.6001205e-05" z="0.013727012" />
+    <Rotation x="-1.0514158e-14" y="-4.1909525e-09" z="-1.4901163e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPScop</Name>
+    <Tag value="64805" />
+    <Index value="559" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="560" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.058273997" y="-3.7252947e-09" z="0.050524004" />
+    <Rotation x="-8.460241e-15" y="-4.19098e-09" z="-2.9492501e-16" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPGrip</Name>
+    <Tag value="19397" />
+    <Index value="560" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="561" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.165883" y="-3.599375e-05" z="-0.011580992" />
+    <Rotation x="-1.7619586e-14" y="-4.1909525e-09" z="-1.4901164e-07" w="1.0" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>NM_Butt_Marker</Name>
+    <Tag value="26613" />
+    <Index value="561" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="562" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.339877" y="3.725285e-09" z="0.019273983" />
+    <Rotation x="-1.5565667e-14" y="-4.1909516e-09" z="-2.9491464e-16" w="1.0" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Sight_front</Name>
+    <Tag value="1830" />
+    <Index value="562" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="563" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.27072" y="-1.11758744e-08" z="0.057152014" />
+    <Rotation x="-1.5565667e-14" y="-4.1909516e-09" z="-2.9491464e-16" w="1.0" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Sight_rear</Name>
+    <Tag value="31549" />
+    <Index value="563" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="564" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.044209" y="-7.450584e-09" z="0.061043996" />
+    <Rotation x="-8.460241e-15" y="-4.19098e-09" z="-2.9492501e-16" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPClip</Name>
+    <Tag value="1477" />
+    <Index value="564" />
+    <ParentIndex value="552" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.036883" y="-0.00043099374" z="-0.005107998" />
+    <Rotation x="-1.556567e-14" y="-4.19098e-09" z="-2.949248e-16" w="1.0" />
+    <Scale x="1.0" y="0.9999999" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Trigger</Name>
+    <Tag value="23712" />
+    <Index value="565" />
+    <ParentIndex value="551" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.09992101" y="0.044866003" z="-0.0038689917" />
+    <Rotation x="-0.6578196" y="-0.00028756604" z="-0.09309295" w="0.7474002" />
+    <Scale x="0.9999999" y="1.0" z="0.9999999" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_GripL</Name>
+    <Tag value="18302" />
+    <Index value="566" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="567" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.165886" y="0.0" z="-0.016113" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPScop_2</Name>
+    <Tag value="3634" />
+    <Index value="567" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="568" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.058274318" y="-5.9604645e-08" z="0.086188" />
+    <Rotation x="-2.2351742e-07" y="-8.7078654e-08" z="7.450582e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Ammo2</Name>
+    <Tag value="35438" />
+    <Index value="568" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="569" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.021239" y="-3.6001205e-05" z="-2.9e-05" />
+    <Rotation x="0.999998" y="-2.2204505e-16" z="0.002008512" w="6.5170633e-07" />
+    <Scale x="1.0" y="0.9999997" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Trigger_Pr</Name>
+    <Tag value="56099" />
+    <Index value="569" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="571" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.026373118" y="-0.00012276694" z="-0.002314611" />
+    <Rotation x="-0.69522715" y="-1.9683412e-06" z="0.7187902" w="2.4151027e-06" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Hammer</Name>
+    <Tag value="24730" />
+    <Index value="570" />
+    <ParentIndex value="569" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.04973286" y="-0.00012299791" z="-0.04453382" />
+    <Rotation x="-0.69522727" y="2.9525113e-06" z="0.71879005" w="3.0561089e-06" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Ammo</Name>
+    <Tag value="18561" />
+    <Index value="571" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="572" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.09341913" y="2.0228326e-05" z="0.03127338" />
+    <Rotation x="4.5449755e-15" y="6.100163e-08" z="-7.4505806e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Drum</Name>
+    <Tag value="29951" />
+    <Index value="572" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="574" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.048356563" y="-7.785857e-07" z="0.0059488267" />
+    <Rotation x="-2.9802322e-07" y="-8.428468e-08" z="7.4505834e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Shell</Name>
+    <Tag value="47897" />
+    <Index value="573" />
+    <ParentIndex value="572" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.03656" y="3.725307e-09" z="1.2070758e-10" />
+    <Rotation x="2.842171e-14" y="-3.3881318e-21" z="-3.3881318e-21" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAP_Clip</Name>
+    <Tag value="51308" />
+    <Index value="574" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="575" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.048356563" y="-7.785857e-07" z="0.0059488267" />
+    <Rotation x="-2.9802322e-07" y="-8.428468e-08" z="7.4505834e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Safety</Name>
+    <Tag value="53712" />
+    <Index value="575" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="576" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.03578413" y="-3.6071986e-05" z="0.0010327413" />
+    <Rotation x="0.37297705" y="2.2231166e-07" z="-0.9278406" w="2.8917881e-07" />
+    <Scale x="0.99999994" y="1.0" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Projectile</Name>
+    <Tag value="60568" />
+    <Index value="576" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="577" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.15920086" y="-0.0006670356" z="0.032255773" />
+    <Rotation x="0.7071068" y="0.7071068" z="-3.6948651e-07" w="5.33851e-08" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Sights</Name>
+    <Tag value="62546" />
+    <Index value="577" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="578" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.20148616" y="-3.6057085e-05" z="0.07212972" />
+    <Rotation x="-0.7084593" y="5.4895727e-06" z="-0.70575166" w="5.0672984e-06" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Handle</Name>
+    <Tag value="22525" />
+    <Index value="578" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="579" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.14186086" y="-3.6016107e-05" z="0.06927677" />
+    <Rotation x="0.69718593" y="2.701109e-06" z="0.71689045" w="3.1166646e-06" />
+    <Scale x="0.99999994" y="0.9999999" z="0.99999994" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Breach</Name>
+    <Tag value="3861" />
+    <Index value="579" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="580" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.15920609" y="-3.9860606e-07" z="0.07863373" />
+    <Rotation x="-2.9802322e-07" y="-8.428468e-08" z="2.5118793e-14" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Feed</Name>
+    <Tag value="36598" />
+    <Index value="580" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="581" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.1142191" y="0.010759555" z="0.0040267175" />
+    <Rotation x="-2.6077035e-07" y="-8.4284686e-08" z="7.4505834e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Barrels</Name>
+    <Tag value="49287" />
+    <Index value="581" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="584" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.07033025" y="1.5646219e-07" z="0.012702014" />
+    <Rotation x="-0.7071068" y="-9.0549975e-08" z="-1.4817142e-08" w="0.7071067" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Barrels_G1</Name>
+    <Tag value="40870" />
+    <Index value="582" />
+    <ParentIndex value="581" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.553053" y="6.9037537e-10" z="2.0120619e-09" />
+    <Rotation x="-2.0120705e-08" y="-7.4505834e-08" z="2.4548535e-15" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Barrels_G2</Name>
+    <Tag value="40871" />
+    <Index value="583" />
+    <ParentIndex value="582" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="1.8928148e-09" y="-2.4095598e-10" z="-7.327472e-15" />
+    <Rotation x="1.664642e-14" y="-3.2754667e-15" z="7.450581e-08" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>Gun_Cock2</Name>
+    <Tag value="39440" />
+    <Index value="584" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="585" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.05814319" y="-3.5859644e-05" z="0.03982056" />
+    <Rotation x="-0.9999998" y="5.9604633e-07" z="0.00058098236" w="1.6391276e-06" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>W_PI_APPistol_Mag1</Name>
+    <Tag value="0" />
+    <Index value="585" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="586" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPSupp_2</Name>
+    <Tag value="6180" />
+    <Index value="586" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="587" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.10786928" y="-0.00026457384" z="0.036447167" />
+    <Rotation x="-1.8626451e-07" y="2.0954662e-09" z="-1.4901161e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gun_crane</Name>
+    <Tag value="18771" />
+    <Index value="587" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="589" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.07162121" y="0.004608456" z="-0.0003857348" />
+    <Rotation x="6.7041645e-07" y="-0.99999744" z="6.0603455e-08" w="0.0022710108" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gun_cylinder</Name>
+    <Tag value="3562" />
+    <Index value="588" />
+    <ParentIndex value="587" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.06605701" y="-0.0045559965" z="-0.025935998" />
+    <Rotation x="-1.9984014e-15" y="0.0" z="-2.8407832e-14" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPCover</Name>
+    <Tag value="27459" />
+    <Index value="589" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="590" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.29580224" y="-0.017849889" z="0.043663252" />
+    <Rotation x="-2.6077038e-07" y="-1.438893e-07" z="3.7522065e-14" w="1.0" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>WAPGrip_2</Name>
+    <Tag value="44079" />
+    <Index value="590" />
+    <ParentIndex value="549" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.20284425" y="0.00040506944" z="0.0095152175" />
+    <Rotation x="-7.636845e-07" y="-1.438894e-07" z="1.4901173e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>chassis</Name>
+    <Tag value="0" />
+    <Index value="591" />
+    <ParentIndex value="-1" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>bonnet</Name>
+    <Tag value="42990" />
+    <Index value="592" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="593" />
+    <Flags>RotX, RotY, RotZ, LimitRotation</Flags>
+    <Translation x="0.0" y="0.908907" z="0.237789" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>bumper_f</Name>
+    <Tag value="22841" />
+    <Index value="593" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="594" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.68811" y="2.009038" z="-0.249379" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>door_dside_f</Name>
+    <Tag value="60963" />
+    <Index value="594" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="598" />
+    <Flags>RotX, RotY, RotZ, Unk0, LimitRotation</Flags>
+    <Translation x="-0.931056" y="0.834526" z="0.058414" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>window_lf</Name>
+    <Tag value="26734" />
+    <Index value="595" />
+    <ParentIndex value="594" />
+    <SiblingIndex value="596" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.21617001" y="-0.729174" z="0.296309" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>handle_dside_f</Name>
+    <Tag value="49152" />
+    <Index value="596" />
+    <ParentIndex value="594" />
+    <SiblingIndex value="597" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.041966975" y="-1.020997" z="0.051500004" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>doorlight_lf</Name>
+    <Tag value="11965" />
+    <Index value="597" />
+    <ParentIndex value="594" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.101383984" y="-0.512125" z="-0.31534" />
+    <Rotation x="-8.940698e-07" y="-4.9999954e-07" z="-5.960459e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>door_pside_f</Name>
+    <Tag value="35346" />
+    <Index value="598" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="602" />
+    <Flags>RotX, RotY, RotZ, Unk0, LimitRotation</Flags>
+    <Translation x="0.931056" y="0.834526" z="0.058414" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>window_rf</Name>
+    <Tag value="28174" />
+    <Index value="599" />
+    <ParentIndex value="598" />
+    <SiblingIndex value="600" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.21617103" y="-0.729174" z="0.296309" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>handle_pside_f</Name>
+    <Tag value="23407" />
+    <Index value="600" />
+    <ParentIndex value="598" />
+    <SiblingIndex value="601" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.041377008" y="-1.0210781" z="0.051500004" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>doorlight_rf</Name>
+    <Tag value="11549" />
+    <Index value="601" />
+    <ParentIndex value="598" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.101383984" y="-0.512125" z="-0.31534" />
+    <Rotation x="-8.940698e-07" y="-4.9999954e-07" z="-5.960459e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wing_lf</Name>
+    <Tag value="4218" />
+    <Index value="602" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="603" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.695344" y="1.424053" z="-0.108989" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wing_rf</Name>
+    <Tag value="4186" />
+    <Index value="603" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="604" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.695344" y="1.424053" z="-0.108989" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>window_lr</Name>
+    <Tag value="26746" />
+    <Index value="604" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="605" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.242148" y="-0.659198" z="0.408264" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>window_rr</Name>
+    <Tag value="28186" />
+    <Index value="605" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="606" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.242148" y="-0.659198" z="0.408264" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>windscreen</Name>
+    <Tag value="39561" />
+    <Index value="606" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="607" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.812724" z="0.353622" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>brakelight_m</Name>
+    <Tag value="20609" />
+    <Index value="607" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="608" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-1.981777" z="0.227733" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>bodyshell</Name>
+    <Tag value="60113" />
+    <Index value="608" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="609" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_lr</Name>
+    <Tag value="35938" />
+    <Index value="609" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="610" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.752513" y="-1.392337" z="-0.230326" />
+    <Rotation x="4.4703526e-07" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_lf</Name>
+    <Tag value="35926" />
+    <Index value="610" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="611" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.800976" y="1.392512" z="-0.245242" />
+    <Rotation x="4.4703526e-07" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>suspension_lr</Name>
+    <Tag value="5589" />
+    <Index value="611" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="612" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.264679" y="-1.381213" z="-0.188217" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>suspension_lf</Name>
+    <Tag value="5577" />
+    <Index value="612" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="613" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.327127" y="1.361764" z="-0.255051" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_rf</Name>
+    <Tag value="36022" />
+    <Index value="613" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="614" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.800976" y="1.392512" z="-0.245242" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>suspension_rf</Name>
+    <Tag value="6505" />
+    <Index value="614" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="615" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.327127" y="1.361764" z="-0.255051" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_rr</Name>
+    <Tag value="36034" />
+    <Index value="615" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="616" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.752513" y="-1.392337" z="-0.230326" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>suspension_rr</Name>
+    <Tag value="6517" />
+    <Index value="616" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="617" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.264679" y="-1.381213" z="-0.188217" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>taillight_l</Name>
+    <Tag value="18400" />
+    <Index value="617" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="618" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.563472" y="-2.012676" z="0.123255" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>indicator_lf</Name>
+    <Tag value="41664" />
+    <Index value="618" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="619" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.710881" y="1.996823" z="-0.007242" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>headlight_l</Name>
+    <Tag value="10804" />
+    <Index value="619" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="620" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.547511" y="2.002458" z="-0.032041" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>taillight_r</Name>
+    <Tag value="18438" />
+    <Index value="620" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="621" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.563472" y="-2.012676" z="0.123255" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>headlight_r</Name>
+    <Tag value="10842" />
+    <Index value="621" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="622" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.547511" y="2.002458" z="-0.032041" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>indicator_rf</Name>
+    <Tag value="40032" />
+    <Index value="622" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="623" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.710881" y="1.996823" z="-0.007242" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>engine</Name>
+    <Tag value="30510" />
+    <Index value="623" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="624" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-1.113749" z="0.312486" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>exhaust_2</Name>
+    <Tag value="50446" />
+    <Index value="624" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="625" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.139996" y="-2.086256" z="-0.23247" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>overheat_2</Name>
+    <Tag value="65271" />
+    <Index value="625" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="626" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.167925" y="-1.109777" z="0.309944" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>overheat</Name>
+    <Tag value="15850" />
+    <Index value="626" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="627" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.157507" y="-1.134706" z="0.313388" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>exhaust</Name>
+    <Tag value="4944" />
+    <Index value="627" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="628" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.152972" y="-2.085992" z="-0.232469" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>interiorlight</Name>
+    <Tag value="37995" />
+    <Index value="628" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="629" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.247651" z="0.423891" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_pside_f</Name>
+    <Tag value="59562" />
+    <Index value="629" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="630" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.413043" y="0.107033" z="-0.226291" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_dside_f</Name>
+    <Tag value="20012" />
+    <Index value="630" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="631" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.413043" y="0.107033" z="-0.226291" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_rr</Name>
+    <Tag value="26398" />
+    <Index value="631" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="632" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.752513" y="-1.392337" z="-0.230326" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_rf</Name>
+    <Tag value="26418" />
+    <Index value="632" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="633" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.800976" y="1.392512" z="-0.245242" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_lr</Name>
+    <Tag value="27902" />
+    <Index value="633" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="634" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.752513" y="-1.392337" z="-0.230326" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_lf</Name>
+    <Tag value="27922" />
+    <Index value="634" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="639" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0</Flags>
+    <Translation x="-0.800976" y="1.392512" z="-0.245242" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmesh_lf</Name>
+    <Tag value="20247" />
+    <Index value="635" />
+    <ParentIndex value="634" />
+    <SiblingIndex value="636" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmesh_lf_l1</Name>
+    <Tag value="11707" />
+    <Index value="636" />
+    <ParentIndex value="634" />
+    <SiblingIndex value="637" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.013279e-06" y="-6.3164062" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmesh_lf_l2</Name>
+    <Tag value="11708" />
+    <Index value="637" />
+    <ParentIndex value="634" />
+    <SiblingIndex value="638" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="2.026558e-06" y="-11.993805" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmesh_lf_ng</Name>
+    <Tag value="12049" />
+    <Index value="638" />
+    <ParentIndex value="634" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.013279e-06" y="5.613678" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>chassis_lowlod</Name>
+    <Tag value="37313" />
+    <Index value="639" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="640" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_1</Name>
+    <Tag value="8874" />
+    <Index value="640" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="641" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>slipstream_r</Name>
+    <Tag value="33134" />
+    <Index value="641" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="642" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.895345" y="-1.572285" z="0.253511" />
+    <Rotation x="0.0" y="0.0" z="-5.96047e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>slipstream_l</Name>
+    <Tag value="33128" />
+    <Index value="642" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="643" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.898563" y="-1.572157" z="0.252479" />
+    <Rotation x="0.0" y="0.0" z="-5.96047e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>dashglow</Name>
+    <Tag value="11869" />
+    <Index value="643" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="644" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.405938" y="0.626537" z="0.240638" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>platelight</Name>
+    <Tag value="5558" />
+    <Index value="644" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="645" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-2.061844" z="0.03534" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>neon_l</Name>
+    <Tag value="49485" />
+    <Index value="645" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="646" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.695434" y="-0.068249" z="-0.477859" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>neon_r</Name>
+    <Tag value="49491" />
+    <Index value="646" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="647" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.692917" y="-0.068249" z="-0.477859" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>neon_f</Name>
+    <Tag value="49479" />
+    <Index value="647" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="648" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="2.018558" z="-0.432113" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>neon_b</Name>
+    <Tag value="49475" />
+    <Index value="648" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="649" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-1.704751" z="-0.437995" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>steeringwheel</Name>
+    <Tag value="20285" />
+    <Index value="649" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="650" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.414957" y="0.358426" z="0.144534" />
+    <Rotation x="-0.160062" y="0.0" z="0.0" w="0.987107" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_12</Name>
+    <Tag value="10844" />
+    <Index value="650" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="651" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_ten</Name>
+    <Tag value="41970" />
+    <Index value="651" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="652" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>dials</Name>
+    <Tag value="16572" />
+    <Index value="652" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="653" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>chassis_dummy</Name>
+    <Tag value="39433" />
+    <Index value="653" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="654" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>petroltank</Name>
+    <Tag value="23306" />
+    <Index value="654" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="655" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.200095" z="0.359298" />
+    <Rotation x="-1.4901159e-06" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>swingarm</Name>
+    <Tag value="61088" />
+    <Index value="655" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="662" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.0" y="-0.134308" z="-0.206583" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_9</Name>
+    <Tag value="8882" />
+    <Index value="656" />
+    <ParentIndex value="655" />
+    <SiblingIndex value="657" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>bikedisc_r</Name>
+    <Tag value="60105" />
+    <Index value="657" />
+    <ParentIndex value="655" />
+    <SiblingIndex value="658" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.000469" y="-0.525022" z="-0.014832005" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmeshbk_r</Name>
+    <Tag value="19882" />
+    <Index value="658" />
+    <ParentIndex value="655" />
+    <SiblingIndex value="659" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.000469" y="-0.525022" z="-0.014832005" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmeshbk_r_l1</Name>
+    <Tag value="32916" />
+    <Index value="659" />
+    <ParentIndex value="655" />
+    <SiblingIndex value="660" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.000469" y="-3.5648632" z="-0.014833286" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmeshbk_r_l2</Name>
+    <Tag value="32917" />
+    <Index value="660" />
+    <ParentIndex value="655" />
+    <SiblingIndex value="661" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.000469" y="-6.669705" z="-0.01483351" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmeshbk_r_ng</Name>
+    <Tag value="33130" />
+    <Index value="661" />
+    <ParentIndex value="655" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.000469" y="2.4052758" z="-0.0148316175" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>handlebars</Name>
+    <Tag value="49213" />
+    <Index value="662" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="666" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="2e-05" y="0.566308" z="0.152685" />
+    <Rotation x="0.21373282" y="0.0" z="0.0" w="0.9768922" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hbgrip_r</Name>
+    <Tag value="46530" />
+    <Index value="663" />
+    <ParentIndex value="662" />
+    <SiblingIndex value="664" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.27898" y="-0.01974602" z="0.25134403" />
+    <Rotation x="-0.21373427" y="0.0" z="0.0" w="0.9768919" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hbgrip_l</Name>
+    <Tag value="46652" />
+    <Index value="664" />
+    <ParentIndex value="662" />
+    <SiblingIndex value="665" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.278819" y="-0.02025199" z="0.2515761" />
+    <Rotation x="-0.21373427" y="0.0" z="0.0" w="0.9768919" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_4</Name>
+    <Tag value="8877" />
+    <Index value="665" />
+    <ParentIndex value="662" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="1.4901161e-08" z="7.450581e-09" />
+    <Rotation x="-1.4901161e-08" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>forks_u</Name>
+    <Tag value="25308" />
+    <Index value="666" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="673" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="2e-05" y="0.566307" z="0.152685" />
+    <Rotation x="0.21373282" y="0.0" z="0.0" w="0.9768922" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>forks_l</Name>
+    <Tag value="25427" />
+    <Index value="667" />
+    <ParentIndex value="666" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.0" y="1.4901161e-08" z="7.450581e-09" />
+    <Rotation x="-1.4901161e-08" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>bikedisc_f</Name>
+    <Tag value="60125" />
+    <Index value="668" />
+    <ParentIndex value="667" />
+    <SiblingIndex value="669" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.9999998e-05" y="-0.000746049" z="-0.4127103" />
+    <Rotation x="-0.21373275" y="0.0" z="0.0" w="0.9768922" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmeshbk_f</Name>
+    <Tag value="19998" />
+    <Index value="669" />
+    <ParentIndex value="667" />
+    <SiblingIndex value="670" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.9999998e-05" y="-0.000746049" z="-0.4127103" />
+    <Rotation x="-0.21373275" y="0.0" z="0.0" w="0.9768922" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmeshbk_f_l1</Name>
+    <Tag value="51883" />
+    <Index value="670" />
+    <ParentIndex value="667" />
+    <SiblingIndex value="671" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.9999998e-05" y="-2.762857" z="0.85669106" />
+    <Rotation x="-0.21373366" y="0.0" z="0.0" w="0.976892" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmeshbk_f_l2</Name>
+    <Tag value="51884" />
+    <Index value="671" />
+    <ParentIndex value="667" />
+    <SiblingIndex value="672" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.9999998e-05" y="-5.5840297" z="2.1532352" />
+    <Rotation x="-0.21373472" y="0.0" z="0.0" w="0.97689176" />
+    <Scale x="1.0" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmeshbk_f_ng</Name>
+    <Tag value="52097" />
+    <Index value="672" />
+    <ParentIndex value="667" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.9999998e-05" y="2.6618292" z="-1.6363662" />
+    <Rotation x="-0.2137327" y="0.0" z="0.0" w="0.97689223" />
+    <Scale x="1.0" y="1.0000001" z="1.0000001" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_a</Name>
+    <Tag value="58614" />
+    <Index value="673" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="674" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.032761" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_f</Name>
+    <Tag value="23191" />
+    <Index value="674" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="675" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-0.286317" z="0.348424" />
+    <Rotation x="-1.4901159e-06" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_b</Name>
+    <Tag value="58615" />
+    <Index value="675" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="676" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.032761" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_r</Name>
+    <Tag value="23203" />
+    <Index value="676" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="677" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.002189" y="-0.720131" z="0.48369" />
+    <Rotation x="-2.086162e-06" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>transmission_m</Name>
+    <Tag value="17073" />
+    <Index value="677" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="678" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="-2.079293" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>transmission_r</Name>
+    <Tag value="17046" />
+    <Index value="678" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="679" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="-2.079293" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>suspension_lm</Name>
+    <Tag value="5584" />
+    <Index value="679" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="680" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.418019" y="-3.645118" z="-1.905867" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>suspension_rm</Name>
+    <Tag value="6512" />
+    <Index value="680" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="681" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.405641" y="-3.645117" z="-1.905867" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>bumper_r</Name>
+    <Tag value="22821" />
+    <Index value="681" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="688" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.500297" y="-6.227783" z="-1.426912" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>indicator_rr</Name>
+    <Tag value="40012" />
+    <Index value="682" />
+    <ParentIndex value="681" />
+    <SiblingIndex value="683" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.592778" y="-0.099824905" z="0.040385008" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>brakelight_r</Name>
+    <Tag value="20678" />
+    <Index value="683" />
+    <ParentIndex value="681" />
+    <SiblingIndex value="684" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.40809697" y="-0.099823" z="0.040385008" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>indicator_lr</Name>
+    <Tag value="41644" />
+    <Index value="684" />
+    <ParentIndex value="681" />
+    <SiblingIndex value="685" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.5966411" y="-0.099823" z="0.040385008" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>brakelight_l</Name>
+    <Tag value="20608" />
+    <Index value="685" />
+    <ParentIndex value="681" />
+    <SiblingIndex value="686" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.411961" y="-0.099824905" z="0.040385008" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>reversinglight_l</Name>
+    <Tag value="34500" />
+    <Index value="686" />
+    <ParentIndex value="681" />
+    <SiblingIndex value="687" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.771487" y="-0.099823" z="0.040385008" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>reversinglight_r</Name>
+    <Tag value="34570" />
+    <Index value="687" />
+    <ParentIndex value="681" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.232377" y="-0.099823" z="0.040385008" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>legs</Name>
+    <Tag value="4712" />
+    <Index value="688" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="689" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="1.459146" z="-2.253404" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_lm1</Name>
+    <Tag value="29921" />
+    <Index value="689" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="690" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.261587" y="-3.637633" z="-2.079294" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_rm1</Name>
+    <Tag value="5857" />
+    <Index value="690" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="691" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.261587" y="-3.637633" z="-2.079294" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmesh_lr</Name>
+    <Tag value="20227" />
+    <Index value="691" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="692" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.261587" y="-5.002678" z="-2.079294" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmesh_lr_l1</Name>
+    <Tag value="27353" />
+    <Index value="692" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="693" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.261587" y="-20.959673" z="-2.079294" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmesh_lr_l2</Name>
+    <Tag value="27354" />
+    <Index value="693" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="694" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.261587" y="-36.84649" z="-2.079294" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheelmesh_lr_ng</Name>
+    <Tag value="27695" />
+    <Index value="694" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="695" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.261587" y="12.445551" z="-2.079294" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>attach_male</Name>
+    <Tag value="42470" />
+    <Index value="695" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="696" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="4.506315" z="-1.152416" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>petroltank_l</Name>
+    <Tag value="50131" />
+    <Index value="696" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="697" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.890002" y="-1.136988" z="0.146866" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>petroltank_r</Name>
+    <Tag value="50009" />
+    <Index value="697" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="698" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.708685" y="-1.136988" z="0.146866" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>windscreen_r</Name>
+    <Tag value="56413" />
+    <Index value="698" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="699" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="1.619356" z="1.804879" />
+    <Rotation x="0.0" y="0.0" z="1.0" w="0.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>transmission_f</Name>
+    <Tag value="17066" />
+    <Index value="699" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="700" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>boot</Name>
+    <Tag value="31608" />
+    <Index value="700" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="701" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, LimitRotation</Flags>
+    <Translation x="0.0" y="-4.711486" z="0.910657" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_dside_r</Name>
+    <Tag value="20120" />
+    <Index value="701" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="702" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.927612" y="-0.075845" z="1.343992" />
+    <Rotation x="0.0" y="0.0" z="-0.70710665" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_pside_r</Name>
+    <Tag value="59446" />
+    <Index value="702" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="703" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.927612" y="-0.250135" z="1.343992" />
+    <Rotation x="0.0" y="0.0" z="0.7071066" w="0.70710707" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_pside_r3</Name>
+    <Tag value="33329" />
+    <Index value="703" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="704" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.927612" y="-4.052222" z="1.343992" />
+    <Rotation x="0.0" y="0.0" z="0.7071068" w="0.7071068" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_dside_r3</Name>
+    <Tag value="35185" />
+    <Index value="704" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="705" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.927612" y="-3.9920332" z="1.343992" />
+    <Rotation x="0.0" y="0.0" z="-0.7071068" w="0.7071068" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_dside_r1</Name>
+    <Tag value="35183" />
+    <Index value="705" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="706" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.927612" y="-1.113011" z="1.343992" />
+    <Rotation x="0.0" y="0.0" z="-0.7071068" w="0.7071068" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_pside_r1</Name>
+    <Tag value="33327" />
+    <Index value="706" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="707" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.927612" y="-1.436152" z="1.343992" />
+    <Rotation x="0.0" y="0.0" z="0.7071068" w="0.7071068" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_dside_r2</Name>
+    <Tag value="35184" />
+    <Index value="707" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="708" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.927612" y="-2.98231" z="1.343992" />
+    <Rotation x="0.0" y="0.0" z="-0.7071068" w="0.7071068" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_pside_r2</Name>
+    <Tag value="33328" />
+    <Index value="708" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="709" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.927612" y="-2.767684" z="1.343992" />
+    <Rotation x="0.0" y="0.0" z="0.7071068" w="0.7071068" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>petrolcap</Name>
+    <Tag value="2450" />
+    <Index value="709" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="710" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.208856" y="-0.518289" z="0.797392" />
+    <Rotation x="0.0" y="-0.4226179" z="0.0" w="0.90630794" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>door_dside_r</Name>
+    <Tag value="61071" />
+    <Index value="710" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="711" />
+    <Flags>RotX, RotY, RotZ, LimitRotation</Flags>
+    <Translation x="0.0" y="-4.030447" z="-0.866792" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren4</Name>
+    <Tag value="25002" />
+    <Index value="711" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="712" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="6.63316" z="-0.937714" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren1</Name>
+    <Tag value="24999" />
+    <Index value="712" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="713" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.347239" y="5.048112" z="2.060381" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren2</Name>
+    <Tag value="25000" />
+    <Index value="713" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="714" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.349393" y="5.048138" z="2.060966" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren3</Name>
+    <Tag value="25001" />
+    <Index value="714" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="715" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-7.246228" z="3.351181" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>rotor_main</Name>
+    <Tag value="61947" />
+    <Index value="715" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="718" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.0" y="4.38279" z="2.990525" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>rotor_main_slow</Name>
+    <Tag value="8987" />
+    <Index value="716" />
+    <ParentIndex value="715" />
+    <SiblingIndex value="717" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>rotor_main_fast</Name>
+    <Tag value="56039" />
+    <Index value="717" />
+    <ParentIndex value="715" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.12518692" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>rotor_rear</Name>
+    <Tag value="42489" />
+    <Index value="718" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="721" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.0" y="-5.374059" z="3.570461" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>rotor_rear_slow</Name>
+    <Tag value="41033" />
+    <Index value="719" />
+    <ParentIndex value="718" />
+    <SiblingIndex value="720" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>rotor_rear_fast</Name>
+    <Tag value="58261" />
+    <Index value="720" />
+    <ParentIndex value="718" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, ScaleX, ScaleY, ScaleZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_j</Name>
+    <Tag value="58623" />
+    <Index value="721" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="722" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.130108" y="-3.434657" z="0.602553" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_i</Name>
+    <Tag value="58622" />
+    <Index value="722" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="723" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.130107" y="-2.165748" z="0.602553" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_h</Name>
+    <Tag value="58621" />
+    <Index value="723" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="724" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.130108" y="-0.890005" z="0.602553" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_g</Name>
+    <Tag value="58620" />
+    <Index value="724" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="725" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.130108" y="0.387364" z="0.602553" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_f</Name>
+    <Tag value="58619" />
+    <Index value="725" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="726" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.130107" y="3.012917" z="0.602553" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_e</Name>
+    <Tag value="58618" />
+    <Index value="726" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="727" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.130108" y="-3.434657" z="0.602553" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_d</Name>
+    <Tag value="58617" />
+    <Index value="727" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="728" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.130107" y="-2.165748" z="0.602553" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_c</Name>
+    <Tag value="58616" />
+    <Index value="728" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="729" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.130107" y="-0.890005" z="0.602553" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>tow_mount_a</Name>
+    <Tag value="30133" />
+    <Index value="729" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="730" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.183472" y="1.573436" z="-0.864631" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>tow_mount_b</Name>
+    <Tag value="30134" />
+    <Index value="730" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="731" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.183472" y="1.573436" z="-0.864631" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>vehicle_blocker</Name>
+    <Tag value="30126" />
+    <Index value="731" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="732" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>elevator_l</Name>
+    <Tag value="2105" />
+    <Index value="732" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="733" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.072624" y="-7.029217" z="0.112184" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>elevator_r</Name>
+    <Tag value="2175" />
+    <Index value="733" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="734" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.072625" y="-7.029217" z="0.112183" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>nozzles_f</Name>
+    <Tag value="6510" />
+    <Index value="734" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="735" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, LimitRotation</Flags>
+    <Translation x="0.0" y="0.060631" z="-0.318009" />
+    <Rotation x="0.0" y="5e-07" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>nozzles_r</Name>
+    <Tag value="6394" />
+    <Index value="735" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="738" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, Unk0, LimitRotation</Flags>
+    <Translation x="1e-06" y="-1.911024" z="-0.312315" />
+    <Rotation x="0.0" y="5e-07" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>exhaust_3</Name>
+    <Tag value="50447" />
+    <Index value="736" />
+    <ParentIndex value="735" />
+    <SiblingIndex value="737" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.551148" y="-0.002496004" z="-0.293934" />
+    <Rotation x="0.7071068" y="3.5355342e-07" z="3.5355342e-07" w="0.7071068" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>exhaust_4</Name>
+    <Tag value="50448" />
+    <Index value="737" />
+    <ParentIndex value="735" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.551148" y="-0.002496004" z="-0.293934" />
+    <Rotation x="0.7071068" y="3.5355342e-07" z="3.5355342e-07" w="0.7071068" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_door_rmr</Name>
+    <Tag value="1459" />
+    <Index value="738" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="739" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="0.315594" y="-1.912271" z="-0.848611" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_door_rml</Name>
+    <Tag value="1421" />
+    <Index value="739" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="740" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-0.315596" y="-1.912271" z="-0.84861" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_door_fl</Name>
+    <Tag value="59324" />
+    <Index value="740" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="741" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, LimitRotation</Flags>
+    <Translation x="-0.206776" y="1.828781" z="-0.855798" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_door_fr</Name>
+    <Tag value="59298" />
+    <Index value="741" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="742" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, LimitRotation</Flags>
+    <Translation x="0.206774" y="1.828781" z="-0.855798" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_f</Name>
+    <Tag value="16998" />
+    <Index value="742" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="743" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, LimitRotation</Flags>
+    <Translation x="0.0" y="2.388563" z="-0.443729" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>afterburner</Name>
+    <Tag value="63802" />
+    <Index value="743" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="744" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-8.112055" z="0.121855" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>weapon_1a</Name>
+    <Tag value="42814" />
+    <Index value="744" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="745" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.346982" y="1.438778" z="-0.926186" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>weapon_1b</Name>
+    <Tag value="42815" />
+    <Index value="745" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="746" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.348485" y="1.438778" z="-0.926186" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_rm</Name>
+    <Tag value="20820" />
+    <Index value="746" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="747" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, LimitRotation</Flags>
+    <Translation x="0.0" y="-1.488018" z="-0.440753" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wing_l</Name>
+    <Tag value="33042" />
+    <Index value="747" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="752" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>aileron_l</Name>
+    <Tag value="31604" />
+    <Index value="748" />
+    <ParentIndex value="747" />
+    <SiblingIndex value="749" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-4.346069" y="-3.851911" z="-0.191733" />
+    <Rotation x="-0.011376012" y="-0.08641019" z="0.13003044" w="0.987672" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_rl</Name>
+    <Tag value="20819" />
+    <Index value="749" />
+    <ParentIndex value="747" />
+    <SiblingIndex value="750" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, LimitRotation</Flags>
+    <Translation x="-3.129482" y="-3.16942" z="-0.02103" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>weapon_2a</Name>
+    <Tag value="42862" />
+    <Index value="750" />
+    <ParentIndex value="747" />
+    <SiblingIndex value="751" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-5.13886" y="-0.557701" z="-0.857433" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wingtip_1</Name>
+    <Tag value="51517" />
+    <Index value="751" />
+    <ParentIndex value="747" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-5.585284" y="-4.59959" z="-0.420582" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wing_r</Name>
+    <Tag value="33048" />
+    <Index value="752" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="758" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>aileron_r</Name>
+    <Tag value="31546" />
+    <Index value="753" />
+    <ParentIndex value="752" />
+    <SiblingIndex value="754" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="4.346069" y="-3.851911" z="-0.191736" />
+    <Rotation x="-0.011376012" y="0.08641019" z="-0.13003044" w="0.987672" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_rr</Name>
+    <Tag value="20825" />
+    <Index value="754" />
+    <ParentIndex value="752" />
+    <SiblingIndex value="755" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ, LimitRotation</Flags>
+    <Translation x="3.129482" y="-3.16942" z="-0.021032" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>weapon_2b</Name>
+    <Tag value="42863" />
+    <Index value="755" />
+    <ParentIndex value="752" />
+    <SiblingIndex value="756" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="5.141255" y="-0.557701" z="-0.857437" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wingtip_2</Name>
+    <Tag value="51518" />
+    <Index value="756" />
+    <ParentIndex value="752" />
+    <SiblingIndex value="757" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="5.585001" y="-4.59959" z="-0.420589" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_2</Name>
+    <Tag value="8875" />
+    <Index value="757" />
+    <ParentIndex value="752" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>rudder</Name>
+    <Tag value="30979" />
+    <Index value="758" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="759" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.33008" y="-7.725078" z="1.245013" />
+    <Rotation x="0.2548863" y="-0.16773096" z="-0.044943247" w="0.9512515" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>rudder_2</Name>
+    <Tag value="30200" />
+    <Index value="759" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="760" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.330082" y="-7.725326" z="1.245012" />
+    <Rotation x="0.25488633" y="0.1677315" z="0.044943385" w="0.9512514" />
+    <Scale x="1.0" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>nose</Name>
+    <Tag value="15642" />
+    <Index value="760" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="761" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.483404" y="5.530812" z="-0.047405" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>attach_female</Name>
+    <Tag value="52286" />
+    <Index value="761" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="762" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="5e-05" y="-3.179158" z="-0.319797" />
+    <Rotation x="8.9407024e-07" y="5.000005e-07" z="5.000047e-07" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>door_pside_r</Name>
+    <Tag value="35230" />
+    <Index value="762" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="764" />
+    <Flags>RotX, RotY, RotZ, Unk0, LimitRotation</Flags>
+    <Translation x="0.985831" y="-0.047268" z="0.681913" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>handle_pside_r</Name>
+    <Tag value="23419" />
+    <Index value="763" />
+    <ParentIndex value="762" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.05658102" y="-0.79556596" z="0.0031319857" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>handle_dside_r</Name>
+    <Tag value="49132" />
+    <Index value="764" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="765" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.042412" y="-0.842834" z="0.685046" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extralight_1</Name>
+    <Tag value="51309" />
+    <Index value="765" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="766" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.371191" y="0.636838" z="1.442808" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extralight_2</Name>
+    <Tag value="51310" />
+    <Index value="766" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="767" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.371291" y="0.636838" z="1.442808" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>turret_1mod</Name>
+    <Tag value="50559" />
+    <Index value="767" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="782" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>turret_1base</Name>
+    <Tag value="65015" />
+    <Index value="768" />
+    <ParentIndex value="767" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0, LimitRotation</Flags>
+    <Translation x="5e-05" y="-0.658478" z="1.536061" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>seat_dside_r4</Name>
+    <Tag value="35186" />
+    <Index value="769" />
+    <ParentIndex value="768" />
+    <SiblingIndex value="770" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-0.147129" z="0.13009799" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>mod_col_1</Name>
+    <Tag value="17880" />
+    <Index value="770" />
+    <ParentIndex value="768" />
+    <SiblingIndex value="771" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="-0.0015664118" y="0.0" z="0.0" w="0.99999887" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>mod_col_2</Name>
+    <Tag value="17881" />
+    <Index value="771" />
+    <ParentIndex value="768" />
+    <SiblingIndex value="772" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="-0.0015664118" y="0.0" z="0.0" w="0.99999887" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hatch</Name>
+    <Tag value="55156" />
+    <Index value="772" />
+    <ParentIndex value="768" />
+    <SiblingIndex value="773" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>turret_1barrel</Name>
+    <Tag value="45666" />
+    <Index value="773" />
+    <ParentIndex value="768" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, Unk0, LimitRotation</Flags>
+    <Translation x="0.00317394" y="0.73855376" z="0.32512498" />
+    <Rotation x="0.0" y="0.0" z="-0.043619152" w="0.99904823" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>turret_grip_r</Name>
+    <Tag value="40306" />
+    <Index value="774" />
+    <ParentIndex value="773" />
+    <SiblingIndex value="775" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.13184291" y="-0.5048696" z="0.20276308" />
+    <Rotation x="0.0" y="0.0" z="0.043619107" w="0.99904823" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>turret_grip_l</Name>
+    <Tag value="40396" />
+    <Index value="775" />
+    <ParentIndex value="773" />
+    <SiblingIndex value="776" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.04849426" y="-0.5206469" z="0.20276308" />
+    <Rotation x="0.0" y="0.0" z="0.043619145" w="0.99904823" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_l</Name>
+    <Tag value="58625" />
+    <Index value="776" />
+    <ParentIndex value="773" />
+    <SiblingIndex value="777" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.0031620022" y="-0.00027498655" z="-0.017245054" />
+    <Rotation x="0.0" y="0.0" z="0.04361914" w="0.99904823" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>turret_grip2_r</Name>
+    <Tag value="29411" />
+    <Index value="777" />
+    <ParentIndex value="773" />
+    <SiblingIndex value="778" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.13184327" y="-0.50487006" z="0.20276308" />
+    <Rotation x="0.0" y="0.0" z="0.043619107" w="0.99904823" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>turret_grip2_l</Name>
+    <Tag value="29341" />
+    <Index value="778" />
+    <ParentIndex value="773" />
+    <SiblingIndex value="779" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.048494894" y="-0.5206476" z="0.20276308" />
+    <Rotation x="0.0" y="0.0" z="0.043619145" w="0.99904823" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>weapon_2a_rot</Name>
+    <Tag value="32051" />
+    <Index value="779" />
+    <ParentIndex value="773" />
+    <SiblingIndex value="781" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-0.086842" y="0.9530131" z="0.20434403" />
+    <Rotation x="0.0" y="0.0" z="0.043619107" w="0.99904823" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_n</Name>
+    <Tag value="58627" />
+    <Index value="780" />
+    <ParentIndex value="779" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="7.345733e-10" y="1.19188954e-07" z="2.3841858e-07" />
+    <Rotation x="0.0" y="0.0" z="7.450552e-09" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>misc_m</Name>
+    <Tag value="58626" />
+    <Index value="781" />
+    <ParentIndex value="773" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.086842" y="0.9530131" z="0.20434403" />
+    <Rotation x="0.0" y="0.0" z="0.043619107" w="0.99904823" />
+    <Scale x="0.99999994" y="0.99999994" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_11</Name>
+    <Tag value="10843" />
+    <Index value="782" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="783" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren14</Name>
+    <Tag value="5718" />
+    <Index value="783" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="784" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.465954" y="-1.197925" z="0.72286" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren13</Name>
+    <Tag value="5717" />
+    <Index value="784" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="785" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.353307" y="-1.197925" z="0.72286" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren12</Name>
+    <Tag value="5716" />
+    <Index value="785" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="786" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.353306" y="-1.197925" z="0.72286" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren11</Name>
+    <Tag value="5715" />
+    <Index value="786" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="787" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.465954" y="-1.197925" z="0.72286" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren5</Name>
+    <Tag value="25003" />
+    <Index value="787" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="788" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.34555802" y="-0.1297" z="0.892627" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren6</Name>
+    <Tag value="25004" />
+    <Index value="788" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="789" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.484952" y="-0.1297" z="0.892628" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren_glass2</Name>
+    <Tag value="63113" />
+    <Index value="789" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="790" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.000258" y="-0.109659" z="0.899928" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren_glass1</Name>
+    <Tag value="63112" />
+    <Index value="790" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="791" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.35879198" y="-0.109659" z="0.899928" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren_glass3</Name>
+    <Tag value="63114" />
+    <Index value="791" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="792" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.358282" y="-0.109659" z="0.899928" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren10</Name>
+    <Tag value="5714" />
+    <Index value="792" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="793" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.219821" y="2.537767" z="0.108632" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren9</Name>
+    <Tag value="25007" />
+    <Index value="793" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="794" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.219821" y="2.537767" z="0.108632" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren8</Name>
+    <Tag value="25006" />
+    <Index value="794" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="795" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.043962" y="0.400766" z="0.728431" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren7</Name>
+    <Tag value="25005" />
+    <Index value="795" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="796" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.043962" y="0.400766" z="0.728431" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren15</Name>
+    <Tag value="5719" />
+    <Index value="796" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="797" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.440723" y="-0.128235" z="0.92468905" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren16</Name>
+    <Tag value="5720" />
+    <Index value="797" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="798" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.31086898" y="-0.125983" z="0.92468905" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren17</Name>
+    <Tag value="5721" />
+    <Index value="798" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="799" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.17264" y="-0.126738" z="0.92468905" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren18</Name>
+    <Tag value="5722" />
+    <Index value="799" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="800" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.173506" y="-0.129597" z="0.92468905" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren19</Name>
+    <Tag value="5723" />
+    <Index value="800" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="801" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.31313202" y="-0.12930499" z="0.92468905" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren20</Name>
+    <Tag value="5698" />
+    <Index value="801" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="802" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.444554" y="-0.128235" z="0.92468905" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren_glass16</Name>
+    <Tag value="16458" />
+    <Index value="802" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="803" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.326756" y="-0.124971" z="0.94447404" />
+    <Rotation x="0.70710665" y="0.0" z="0.0" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren_glass4</Name>
+    <Tag value="63115" />
+    <Index value="803" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="804" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="-0.124971" z="0.94495004" />
+    <Rotation x="0.70710665" y="0.0" z="0.0" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>siren_glass19</Name>
+    <Tag value="16461" />
+    <Index value="804" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="805" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.326756" y="-0.124971" z="0.94447404" />
+    <Rotation x="0.70710665" y="0.0" z="0.0" w="0.7071069" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_lm1</Name>
+    <Tag value="63020" />
+    <Index value="805" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="806" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.371607" y="1.25697" z="-0.47873" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_lm2</Name>
+    <Tag value="63021" />
+    <Index value="806" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="807" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.371607" y="0.117872" z="-0.47873" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_lm3</Name>
+    <Tag value="63022" />
+    <Index value="807" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="808" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.371607" y="-1.021225" z="-0.478731" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_rm1</Name>
+    <Tag value="64556" />
+    <Index value="808" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="809" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.371607" y="1.25697" z="-0.478537" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_rm2</Name>
+    <Tag value="64557" />
+    <Index value="809" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="810" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.371607" y="0.117872" z="-0.47873" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>hub_rm3</Name>
+    <Tag value="64558" />
+    <Index value="810" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="811" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.371607" y="-1.021225" z="-0.47873" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_lm2</Name>
+    <Tag value="29922" />
+    <Index value="811" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="812" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.371607" y="0.117872" z="-0.47873" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_lm3</Name>
+    <Tag value="29923" />
+    <Index value="812" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="813" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.371607" y="-1.021225" z="-0.478731" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_rm2</Name>
+    <Tag value="5858" />
+    <Index value="813" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="814" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.371608" y="0.117872" z="-0.47873" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>wheel_rm3</Name>
+    <Tag value="5859" />
+    <Index value="814" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="815" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.371608" y="-1.021225" z="-0.47873" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_3</Name>
+    <Tag value="8876" />
+    <Index value="815" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="816" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.3591241" y="-1.3929579" z="1.236748" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_5</Name>
+    <Tag value="8878" />
+    <Index value="816" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="817" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-0.489164" y="-1.9913821" z="1.2180159" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_7</Name>
+    <Tag value="8880" />
+    <Index value="817" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="818" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="1.413659" y="-1.079369" z="1.325372" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_6</Name>
+    <Tag value="8879" />
+    <Index value="818" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="819" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.589505" y="-2.000807" z="1.329078" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>extra_8</Name>
+    <Tag value="8881" />
+    <Index value="819" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="820" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-1.734715" y="-1.5085" z="0.009532" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_1</Name>
+    <Tag value="1408" />
+    <Index value="820" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="823" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-10.47111" y="0.52252007" z="2.447641" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_1_slow</Name>
+    <Tag value="23195" />
+    <Index value="821" />
+    <ParentIndex value="820" />
+    <SiblingIndex value="822" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-9.536743e-07" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_1_fast</Name>
+    <Tag value="8446" />
+    <Index value="822" />
+    <ParentIndex value="820" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-9.536743e-07" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_2</Name>
+    <Tag value="1409" />
+    <Index value="823" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="826" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="-4.831914" y="0.52252007" z="2.31038" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_2_slow</Name>
+    <Tag value="17291" />
+    <Index value="824" />
+    <ParentIndex value="823" />
+    <SiblingIndex value="825" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_2_fast</Name>
+    <Tag value="2542" />
+    <Index value="825" />
+    <ParentIndex value="823" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>tail</Name>
+    <Tag value="36481" />
+    <Index value="826" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="827" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_4</Name>
+    <Tag value="1411" />
+    <Index value="827" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="830" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="10.464259" y="0.52252007" z="2.447641" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_4_slow</Name>
+    <Tag value="11164" />
+    <Index value="828" />
+    <ParentIndex value="827" />
+    <SiblingIndex value="829" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-9.536743e-07" y="-1.013279e-06" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_4_fast</Name>
+    <Tag value="61582" />
+    <Index value="829" />
+    <ParentIndex value="827" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-9.536743e-07" y="-1.013279e-06" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_3</Name>
+    <Tag value="1410" />
+    <Index value="830" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="833" />
+    <Flags>RotX, RotY, RotZ, Unk0</Flags>
+    <Translation x="4.8250637" y="0.52252007" z="2.31038" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_3_slow</Name>
+    <Tag value="17068" />
+    <Index value="831" />
+    <ParentIndex value="830" />
+    <SiblingIndex value="832" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="0.0" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>prop_3_fast</Name>
+    <Tag value="2319" />
+    <Index value="832" />
+    <ParentIndex value="830" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ</Flags>
+    <Translation x="-9.536743e-07" y="0.0" z="0.0" />
+    <Rotation x="0.0" y="0.0" z="0.0" w="1.0" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_door_rl1</Name>
+    <Tag value="994" />
+    <Index value="833" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="834" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="-2.187385" y="-2.645466" z="-0.610869" />
+    <Rotation x="0.0" y="0.50000024" z="0.0" w="0.86602527" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+  <Item>
+    <Name>gear_door_rr1</Name>
+    <Tag value="834" />
+    <Index value="834" />
+    <ParentIndex value="591" />
+    <SiblingIndex value="-1" />
+    <Flags>RotX, RotY, RotZ, TransX, TransY, TransZ</Flags>
+    <Translation x="2.187385" y="-2.645466" z="-0.610869" />
+    <Rotation x="0.0" y="-0.50000024" z="0.0" w="0.86602527" />
+    <Scale x="1.0" y="1.0" z="1.0" />
+    <TransformUnk x="0.0" y="4.0" z="-3.0" w="0.0" />
+  </Item>
+</Bones>

--- a/cwxml/drawable.py
+++ b/cwxml/drawable.py
@@ -28,6 +28,7 @@ from .bound import (
 from collections import namedtuple
 from collections.abc import MutableSequence
 from enum import Enum
+import os
 
 
 class YDD:
@@ -659,3 +660,19 @@ class DrawableDictionary(MutableSequence, Element):
                     f"{type(self).__name__}s can only hold '{Drawable.__name__}' objects, not '{type(drawable)}'!")
 
         return element
+
+
+class BonePropertiesManager:
+    dictionary_xml = os.path.join(
+        os.path.dirname(__file__), "BoneProperties.xml")
+    bones = {}
+
+    @staticmethod
+    def load_bones():
+        tree = ET.parse(BonePropertiesManager.dictionary_xml)
+        for node in tree.getroot():
+            bone = BoneItem.from_xml(node)
+            BonePropertiesManager.bones[bone.name] = bone
+
+
+BonePropertiesManager.load_bones()

--- a/tools/drawablehelper.py
+++ b/tools/drawablehelper.py
@@ -2,6 +2,7 @@ import bpy
 from ..ydr.shader_materials import create_shader, try_get_node, ShaderManager
 from ..sollumz_properties import SollumType, SOLLUMZ_UI_NAMES, MaterialType
 from ..tools.blenderhelper import join_objects, get_children_recursive
+from ..cwxml.drawable import BonePropertiesManager
 from mathutils import Vector
 
 
@@ -217,3 +218,19 @@ def convert_shader_to_shader(material, shader_name):
             tonode_w.outputs[0].default_value = node_w.outputs[0].default_value
 
     return new_material
+
+
+def set_recommended_bone_properties(bone):
+    bone_item = BonePropertiesManager.bones.get(bone.name)
+    if bone_item is None:
+        return
+
+    bone.bone_properties.tag = bone_item.tag
+    bone.bone_properties.flags.clear()
+    flags_restricted = set(["LimitRotation", "Unk0"])
+    for flag_name in bone_item.flags:
+        if flag_name in flags_restricted:
+            continue
+
+        flag = bone.bone_properties.flags.add()
+        flag.name = flag_name

--- a/ydr/operators.py
+++ b/ydr/operators.py
@@ -6,7 +6,8 @@ from ..tools.drawablehelper import (
     convert_selected_to_drawable,
     create_drawable,
     convert_material,
-    convert_material_to_selected
+    convert_material_to_selected,
+    set_recommended_bone_properties
 )
 from ..tools.blenderhelper import get_children_recursive
 from ..tools.boundhelper import convert_selected_to_bound
@@ -251,3 +252,44 @@ class SOLLUMZ_OT_LIGHT_TIME_FLAGS_clear(ClearTimeFlags, bpy.types.Operator):
     def get_flags(self, context):
         light = context.light
         return light.time_flags
+
+
+class SOLLUMZ_OT_apply_bone_properties_to_armature(SOLLUMZ_OT_base, bpy.types.Operator):
+    bl_idname = "sollumz.apply_bone_properties_to_armature"
+    bl_label = "To Armature"
+    bl_action = bl_label
+
+    def run(self, context):
+        armature = context.active_object
+        if armature is None or armature.type != "ARMATURE":
+            return
+
+        if armature.pose is None:
+            return
+
+        for pbone in armature.pose.bones:
+            bone = pbone.bone
+            set_recommended_bone_properties(bone)
+
+        self.message(f"Apply bone properties to armature: {armature.name}")
+        return True
+
+
+class SOLLUMZ_OT_apply_bone_properties_to_selected_bones(SOLLUMZ_OT_base, bpy.types.Operator):
+    bl_idname = "sollumz.apply_bone_properties_to_selected_bones"
+    bl_label = "To Selected Bones"
+    bl_action = bl_label
+
+    def run(self, context):
+        pbones = context.selected_pose_bones
+        if pbones is None:
+            return
+
+        count = 0
+        for pbone in pbones:
+            bone = pbone.bone
+            set_recommended_bone_properties(bone)
+            count += 1
+
+        self.message(f"Apply bone properties to {count} bone(s)")
+        return True

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -228,6 +228,28 @@ class SOLLUMZ_PT_CREATE_LIGHT_PANEL(bpy.types.Panel):
         row.prop(context.scene, "create_light_type", text="")
 
 
+class SOLLUMZ_PT_APPLY_BONE_PROPERTIES_PANEL(bpy.types.Panel):
+    bl_label = "Apply Bone Properties"
+    bl_idname = "SOLLUMZ_PT_APPLY_BONE_PROPERTIES_PANEL"
+    bl_category = "Sollumz Tools"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_options = {"DEFAULT_CLOSED"}
+    bl_parent_id = SOLLUMZ_PT_DRAWABLE_TOOL_PANEL.bl_idname
+
+    def draw_header(self, context):
+        self.layout.label(text="", icon="BONE_DATA")
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.operator(
+            ydr_ops.SOLLUMZ_OT_apply_bone_properties_to_armature.bl_idname, icon='ARMATURE_DATA')
+        row2 = layout.row()
+        row2.operator(
+            ydr_ops.SOLLUMZ_OT_apply_bone_properties_to_selected_bones.bl_idname, icon='BONE_DATA')
+
+
 class SOLLUMZ_UL_BONE_FLAGS(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
         custom_icon = "FILE"


### PR DESCRIPTION
useful for when user somehow lost the bone properties (e.g. export into another format other than xml and import back) and want them back without filling in the blanks one-by-one