### PR TITLE
fix(ymap): set default parentIndex to -1

### DIFF
--- a/cwxml/ymap.py
+++ b/cwxml/ymap.py
@@ -348,7 +348,7 @@ class EntityItem(ElementTree):
         self.rotation = QuaternionProperty("rotation")
         self.scale_xy = ValueProperty("scaleXY", 0)
         self.scale_z = ValueProperty("scaleZ", 0)
-        self.parent_index = ValueProperty("parentIndex", 0)
+        self.parent_index = ValueProperty("parentIndex", -1)
         self.lod_dist = ValueProperty("lodDist", 0)
         self.child_lod_dist = ValueProperty("childLodDist", 0)
         self.lod_level = TextProperty("lodLevel")

--- a/sollumz_properties.py
+++ b/sollumz_properties.py
@@ -455,7 +455,7 @@ class EntityProperties:
     archetype_name: bpy.props.StringProperty(name="Archetype Name")
     flags: bpy.props.IntProperty(name="Flags")
     guid: bpy.props.FloatProperty(name="GUID")
-    parent_index: bpy.props.IntProperty(name="Parent Index")
+    parent_index: bpy.props.IntProperty(name="Parent Index", default=-1)
     lod_dist: bpy.props.FloatProperty(name="Lod Distance", default=200)
     child_lod_dist: bpy.props.FloatProperty(name="Child Lod Distance")
     lod_level: bpy.props.EnumProperty(


### PR DESCRIPTION
Default parentIndex should be -1 and not 0.
This caused an issue in each generated YMAPs where the first entity was visible in CW but invisible in game.