### PR TITLE
Fix incorrect XML for YCD StringAttribute

### DIFF
--- a/cwxml/clipsdictionary.py
+++ b/cwxml/clipsdictionary.py
@@ -110,7 +110,7 @@ class AttributesListProperty(ItemTypeListProperty):
 
         def __init__(self):
             super().__init__()
-            self.value = ValueProperty("Value", "")
+            self.value = TextProperty("Value", "")
 
     class HashStringAttribute(Attribute):
         type = "HashString"


### PR DESCRIPTION
CodeWalker saves the StringAttribute Value as inner text not as a `value` attribute ([source](https://github.com/dexyfex/CodeWalker/blob/master/CodeWalker.Core/GameFiles/Resources/Clip.cs#L4115)).

This caused an import error with some YCDs. For example, `p_cargo_chute_s.ycd` which contains:
```xml
<Attributes>
 <Item>
  <NameHash>hash_7C5B9373</NameHash>
  <Type value="String" />
  <Value>unknown</Value>
 </Item>
</Attributes>
```