### PR TITLE
Added missing properties from Archetypes

### DIFF
--- a/ytyp/properties/ytyp.py
+++ b/ytyp/properties/ytyp.py
@@ -81,12 +81,12 @@ class ArchetypeProperties(bpy.types.PropertyGroup):
     bs_radius: bpy.props.FloatProperty(name="Bound Radius")
     type: bpy.props.EnumProperty(
         items=items_from_enums(ArchetypeType), name="Type")
-    lod_dist: bpy.props.FloatProperty(name="Lod Distance", default=100)
+    lod_dist: bpy.props.FloatProperty(name="Lod Distance", default=60, min=-1)
     flags: bpy.props.PointerProperty(
         type=ArchetypeFlags, name="Flags")
     special_attribute: bpy.props.IntProperty(name="Special Attribute")
     hd_texture_dist: bpy.props.FloatProperty(
-        name="HD Texture Distance", default=100)
+        name="HD Texture Distance", default=40, min=0)
     name: bpy.props.StringProperty(name="Name")
     texture_dictionary: bpy.props.StringProperty(name="Texture Dictionary")
     clip_dictionary: bpy.props.StringProperty(name="Clip Dictionary")

--- a/ytyp/ui.py
+++ b/ytyp/ui.py
@@ -184,6 +184,8 @@ class SOLLUMZ_PT_ARCHETYPE_PANEL(bpy.types.Panel):
             layout.prop(selected_archetype, "clip_dictionary")
             layout.prop(selected_archetype, "drawable_dictionary")
             layout.prop(selected_archetype, "physics_dictionary")
+            layout.prop(selected_archetype, "hd_texture_dist")
+            layout.prop(selected_archetype, "lod_dist")
         layout.prop(selected_archetype, "asset_type")
         layout.prop(selected_archetype, "asset_name")
         layout.prop(selected_archetype, "asset", text="Linked Object")


### PR DESCRIPTION
Adds `hdTextureDist` and `lodDist` properties to Archetypes, needed for properly display changes made by #394 