### PR TITLE
Fixing imports and exports ConeOuterAngle value

### DIFF
--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -629,8 +629,8 @@ def light_from_object(obj, armature_obj=None):
     light.corona_z_bias = obj.data.light_properties.corona_z_bias
     if obj.data.sollum_type == LightType.SPOT:
         light.cone_inner_angle = degrees(
-            abs((obj.data.spot_blend * pi) - pi)) / 2
-        light.cone_outer_angle = degrees(obj.data.spot_size) / 2
+            abs((obj.data.spot_blend * pi) - pi))
+        light.cone_outer_angle = degrees(obj.data.spot_size)
     light.extent = Vector(obj.data.light_properties.extent)
     light.projected_texture_hash = obj.data.light_properties.projected_texture_hash
 

--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -289,8 +289,8 @@ def light_to_obj(light, armature_obj=None):
     lobj.data.light_properties.corona_z_bias = light.corona_z_bias
     if light_type == LightType.SPOT:
         lobj.data.spot_blend = abs(
-            (radians(light.cone_inner_angle) / pi) - 1) * 2
-        lobj.data.spot_size = radians(light.cone_outer_angle) * 2
+            (radians(light.cone_inner_angle) / pi) - 1)
+        lobj.data.spot_size = radians(light.cone_outer_angle)
     lobj.data.light_properties.extent = light.extent
     lobj.data.light_properties.projected_texture_hash = light.projected_texture_hash
 


### PR DESCRIPTION
Removed multiplication when importing into blender and exporting from blender ConeOuterAngle value.
Maybe it was forced to do this, but I did not see anything broken when exporting