### PR TITLE
refactor: remove "pack:/" prefix and add it back before export

### DIFF
--- a/sollumz_operators.py
+++ b/sollumz_operators.py
@@ -256,10 +256,8 @@ class SOLLUMZ_OT_export(SOLLUMZ_OT_base, bpy.types.Operator):
                 export_ydd(self, obj, filepath, self.export_settings)
                 valid_type = True
             elif obj.sollum_type == SollumType.FRAGMENT:
-                name = obj.name if "/" not in obj.name else obj.name.replace(
-                    "pack:/", "")
                 filepath = self.get_filepath(
-                    remove_number_suffix(name.lower()), YFT.file_extension)
+                    remove_number_suffix(obj.name.lower()), YFT.file_extension)
                 export_yft(self, obj, filepath, self.export_settings)
                 valid_type = True
             elif obj.sollum_type == SollumType.CLIP_DICTIONARY:

--- a/sollumz_ui.py
+++ b/sollumz_ui.py
@@ -121,7 +121,7 @@ class SOLLUMZ_UL_armature_list(bpy.types.UIList):
         if self.layout_type in {"DEFAULT", "COMPACT"}:
             row = layout.row()
 
-            # Armature is contained in "skel" object, so we need its parent (which is pack:/... or ped root..)
+            # Armature is contained in "skel" object, so we need its parent
             armature_obj = get_armature_obj(item)
             if armature_obj is not None:
                 armature_parent = armature_obj.parent

--- a/ycd/properties.py
+++ b/ycd/properties.py
@@ -40,7 +40,7 @@ def update_hashes(self, context):
 
     anim_hash = anim_drawable_model + "_uv_" + str(material_index)
     clip_hash = "hash_" + hex(Generate(anim_drawable_model) + (material_index + 1)).strip("0x").upper()
-    clip_name = "pack:/" + anim_hash + ".clip"
+    clip_name = anim_hash + ".clip"
     
     animation.animation_properties.hash = anim_hash
 

--- a/ycd/ycdexport.py
+++ b/ycd/ycdexport.py
@@ -445,7 +445,7 @@ def clip_from_object(clip_obj):
             clip.animations.append(clip_animation)
 
     clip.hash = clip_properties.hash
-    clip.name = clip_properties.name
+    clip.name = "pack:/" + clip_properties.name
     clip.unknown30 = 0
 
     return clip

--- a/ycd/ycdimport.py
+++ b/ycd/ycdimport.py
@@ -451,6 +451,7 @@ def clip_dictionary_to_obj(clip_dictionary, name, armature, armature_obj):
         animations_obj_map[animation.hash] = animation_obj
 
     for clip in clip_dictionary.clips:
+        clip.name = clip.name.replace("pack:/", "")
         clip_obj = clip_to_obj(clip, animations_map, animations_obj_map)
         clip_obj.parent = clips_obj
 

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -686,8 +686,7 @@ def drawable_from_object(exportop, obj, exportpath, bones=None, materials=None, 
 
             foldername = remove_number_suffix(obj.name.lower())
             if is_frag:
-                foldername = remove_number_suffix(
-                    obj.parent.name.lower()).replace("pack:/", "")
+                foldername = remove_number_suffix(obj.parent.name.lower())
 
             td, messages = texture_dictionary_from_materials(
                 foldername, materials, os.path.dirname(exportpath))

--- a/yft/yftexport.py
+++ b/yft/yftexport.py
@@ -8,6 +8,7 @@ from ..sollumz_helper import get_sollumz_objects_from_objects
 from ..tools.fragmenthelper import image_to_shattermap
 from ..tools.meshhelper import get_bound_center, get_sphere_radius
 from ..tools.utils import divide_vector_inv, prop_array_to_vector
+from ..tools.blenderhelper import remove_number_suffix
 
 
 def get_fragment_drawable(fragment):
@@ -148,7 +149,7 @@ def fragment_from_object(exportop, fobj, exportpath):
 
     lights_from_object(fobj, fragment.lights, armature_obj=dobj)
 
-    fragment.name = fobj.name.split(".")[0]
+    fragment.name = "pack:/" + remove_number_suffix(fobj.name)
     fragment.bounding_sphere_center = get_bound_center(fobj)
     fragment.bounding_sphere_radius = get_sphere_radius(
         fragment.drawable.bounding_box_max, fragment.drawable.bounding_sphere_center)

--- a/yft/yftimport.py
+++ b/yft/yftimport.py
@@ -23,7 +23,7 @@ def import_yft(filepath: str, import_operator: bpy.types.Operator):
 
 
 def fragment_to_obj(frag_xml: Fragment, filepath: str):
-    frag_obj = create_empty_object(SollumType.FRAGMENT, frag_xml.name)
+    frag_obj = create_empty_object(SollumType.FRAGMENT, frag_xml.name.replace("pack:/", ""))
 
     set_fragment_properties(frag_xml, frag_obj)
 


### PR DESCRIPTION
This will just hide the `pack:/` prefix while working on `Fragments` or `Clip dictionaries`