### PR TITLE
ui: possibility to fold view options + interact with all collections

### DIFF
--- a/sollumz_properties.py
+++ b/sollumz_properties.py
@@ -687,10 +687,11 @@ def get_hide_collisions(self):
 def set_hide_collisions(self, value):
     self["hide_collision"] = value
 
-    for obj in bpy.context.collection.all_objects:
-        if obj.sollum_type in BOUND_TYPES or obj.sollum_type in BOUND_POLYGON_TYPES:
-            if obj.name in bpy.context.view_layer.objects:
-                obj.hide_set(value)
+    for collection in bpy.data.collections:
+        for obj in collection.all_objects:
+            if obj.sollum_type in BOUND_TYPES or obj.sollum_type in BOUND_POLYGON_TYPES:
+                if obj.name in bpy.context.view_layer.objects:
+                    obj.hide_set(value)
 
 
 def get_hide_high_lods(self):
@@ -700,10 +701,11 @@ def get_hide_high_lods(self):
 def set_hide_high_lods(self, value):
     self["hide_high_lods"] = value
 
-    for obj in bpy.context.collection.all_objects:
-        if obj.sollum_type == SollumType.DRAWABLE_MODEL:
-            if obj.drawable_model_properties.sollum_lod == LODLevel.HIGH:
-                hide_obj_and_children(obj, value)
+    for collection in bpy.data.collections:
+        for obj in collection.all_objects:
+            if obj.sollum_type == SollumType.DRAWABLE_MODEL:
+                if obj.drawable_model_properties.sollum_lod == LODLevel.HIGH:
+                    hide_obj_and_children(obj, value)
 
 
 def get_hide_medium_lods(self):
@@ -713,10 +715,11 @@ def get_hide_medium_lods(self):
 def set_hide_medium_lods(self, value):
     self["hide_medium_lods"] = value
 
-    for obj in bpy.context.collection.all_objects:
-        if obj.sollum_type == SollumType.DRAWABLE_MODEL:
-            if obj.drawable_model_properties.sollum_lod == LODLevel.MEDIUM:
-                hide_obj_and_children(obj, value)
+    for collection in bpy.data.collections:
+        for obj in collection.all_objects:
+            if obj.sollum_type == SollumType.DRAWABLE_MODEL:
+                if obj.drawable_model_properties.sollum_lod == LODLevel.MEDIUM:
+                    hide_obj_and_children(obj, value)
 
 
 def get_hide_low_lods(self):
@@ -726,10 +729,11 @@ def get_hide_low_lods(self):
 def set_hide_low_lods(self, value):
     self["hide_low_lods"] = value
 
-    for obj in bpy.context.collection.all_objects:
-        if obj.sollum_type == SollumType.DRAWABLE_MODEL:
-            if obj.drawable_model_properties.sollum_lod == LODLevel.LOW:
-                hide_obj_and_children(obj, value)
+    for collection in bpy.data.collections:
+        for obj in collection.all_objects:
+            if obj.sollum_type == SollumType.DRAWABLE_MODEL:
+                if obj.drawable_model_properties.sollum_lod == LODLevel.LOW:
+                    hide_obj_and_children(obj, value)
 
 
 def get_hide_very_low_lods(self):
@@ -739,10 +743,11 @@ def get_hide_very_low_lods(self):
 def set_hide_very_low_lods(self, value):
     self["hide_very_low_lods"] = value
 
-    for obj in bpy.context.collection.all_objects:
-        if obj.sollum_type == SollumType.DRAWABLE_MODEL:
-            if obj.drawable_model_properties.sollum_lod == LODLevel.VERYLOW:
-                hide_obj_and_children(obj, value)
+    for collection in bpy.data.collections:
+        for obj in collection.all_objects:
+            if obj.sollum_type == SollumType.DRAWABLE_MODEL:
+                if obj.drawable_model_properties.sollum_lod == LODLevel.VERYLOW:
+                    hide_obj_and_children(obj, value)
 
 
 def get_hide_vehicle_windows(self):
@@ -752,9 +757,10 @@ def get_hide_vehicle_windows(self):
 def set_hide_vehicle_windows(self, value):
     self["hide_vehicle_windows"] = value
 
-    for obj in bpy.context.collection.all_objects:
-        if obj.sollum_type == SollumType.FRAGVEHICLEWINDOW:
-            hide_obj_and_children(obj, value)
+    for collection in bpy.data.collections:
+        for obj in collection.all_objects:
+            if obj.sollum_type == SollumType.FRAGVEHICLEWINDOW:
+                hide_obj_and_children(obj, value)
 
 
 def register():

--- a/sollumz_ui.py
+++ b/sollumz_ui.py
@@ -343,8 +343,22 @@ class SOLLUMZ_PT_TOOL_PANEL(bpy.types.Panel):
         row = layout.row()
         row.operator("sollumz.import")
         row.operator("sollumz.export")
-        layout.label(text="View")
 
+
+class SOLLUMZ_PT_VIEW_PANEL(bpy.types.Panel):
+    bl_label = "View"
+    bl_idname = "SOLLUMZ_PT_VIEW_PANEL"
+    bl_category = "Sollumz Tools"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_parent_id = SOLLUMZ_PT_TOOL_PANEL.bl_idname
+    bl_order = 0
+
+    def draw_header(self, context):
+        self.layout.label(text="", icon="PREFERENCES")
+
+    def draw(self, context):
+        layout = self.layout
         row = layout.row()
         row.prop(context.scene, "hide_high_lods")
         row.prop(context.scene, "hide_medium_lods")
@@ -355,11 +369,29 @@ class SOLLUMZ_PT_TOOL_PANEL(bpy.types.Panel):
 
         row3 = layout.row()
         row3.prop(context.scene, "hide_very_low_lods")
-        row3.prop(context.space_data.overlay,
-                  "show_bones", text="Show Skeleton")
+        row3.prop(context.space_data.overlay, "show_bones", text="Show Skeleton")
 
         row4 = layout.row()
         row4.prop(context.scene, "hide_vehicle_windows")
+
+
+class SOLLUMZ_PT_VERTEX_TOOL_PANEL(bpy.types.Panel):
+    bl_label = "Vertex Painter"
+    bl_idname = "SOLLUMZ_PT_VERTEX_TOOL_PANELL"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_options = {"DEFAULT_CLOSED"}
+    bl_parent_id = SOLLUMZ_PT_TOOL_PANEL.bl_idname
+    bl_order = 1
+
+    def draw_header(self, context):
+        self.layout.label(text="", icon="BRUSH_DATA")
+
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.prop(context.scene, "vert_paint_color")
+        row.operator("sollumz.paint_vertices")
 
 
 class SOLLUMZ_PT_DEBUG_PANEL(bpy.types.Panel):
@@ -370,6 +402,7 @@ class SOLLUMZ_PT_DEBUG_PANEL(bpy.types.Panel):
     bl_region_type = "UI"
     bl_options = {"DEFAULT_CLOSED"}
     bl_parent_id = SOLLUMZ_PT_TOOL_PANEL.bl_idname
+    bl_order = 2
 
     def draw_header(self, context):
         self.layout.label(text="", icon="PREFERENCES")
@@ -383,24 +416,6 @@ class SOLLUMZ_PT_DEBUG_PANEL(bpy.types.Panel):
         row = layout.row()
         row.operator("sollumz.debug_set_sollum_type")
         row.prop(context.scene, "all_sollum_type")
-
-
-class SOLLUMZ_PT_VERTEX_TOOL_PANEL(bpy.types.Panel):
-    bl_label = "Vertex Painter"
-    bl_idname = "SOLLUMZ_PT_VERTEX_TOOL_PANELL"
-    bl_space_type = "VIEW_3D"
-    bl_region_type = "UI"
-    bl_options = {"DEFAULT_CLOSED"}
-    bl_parent_id = SOLLUMZ_PT_TOOL_PANEL.bl_idname
-
-    def draw_header(self, context):
-        self.layout.label(text="", icon="BRUSH_DATA")
-
-    def draw(self, context):
-        layout = self.layout
-        row = layout.row()
-        row.prop(context.scene, "vert_paint_color")
-        row.operator("sollumz.paint_vertices")
 
 
 class SOLLUMZ_PT_TERRAIN_PAINTER_PANEL(bpy.types.Panel):


### PR DESCRIPTION
Fix a kind of issue where only active collection were receiving checkboxes changes.
Now it will update all objects in every collections.
*Not sure if it's possible to hide future created/loaded objects.*