### PR TITLE
change drawable model "Unknown 1" property to "Bone Count"

### DIFF
--- a/ydr/properties.py
+++ b/ydr/properties.py
@@ -21,7 +21,7 @@ class DrawableProperties(bpy.types.PropertyGroup):
 class DrawableModelProperties(bpy.types.PropertyGroup):
     render_mask: bpy.props.IntProperty(name="Render Mask", default=255)
     flags: bpy.props.IntProperty(name="Flags", default=0)
-    unknown_1: bpy.props.IntProperty(name="Unknown 1", default=0)
+    unknown_1: bpy.props.IntProperty(name="Bone Count", default=0)
     sollum_lod: bpy.props.EnumProperty(
         items=items_from_enums(LODLevel),
         name="LOD Level",


### PR DESCRIPTION
The 'Unknown 1' property for ydr/ydd/yft drawable models refers to how many total bones the respective skel has (or 0 if the object has no skel, like a regular/static prop YDR). We should name it something like "Bone Count" or "Total Bones" or something of that nature.

For example, mp_m_freemode_01.yft has 128 bones. If you import base-game mp_m_freemode_01 uppr_015 (which requires external skel) and click on each of the High, Medium, and Low LOD drawable models for the YDD you will see that 'Unknown 1' is 128 in the Sollumz dropdown for Object Properties:
![image](https://user-images.githubusercontent.com/28677397/209069104-6b7f0201-8333-4409-b3b8-63a1f0c49051.png)

For a non-freemode example, a_c_poodle.yft has 59 bones. If you import a_c_poodle.ydd and check the drawable models for head, lowr, and uppr you will see that 'Unknown 1' is 59:
![image](https://user-images.githubusercontent.com/28677397/209069625-754b4a4f-9a0e-4314-b960-88600f9cc578.png)

For car YFTs, I imported kalahari_hi.yft . The skel has 57 bones, and the Unknown 1 on the drawable model is 57:
![image](https://user-images.githubusercontent.com/28677397/209070120-b9da0fb5-37ae-4128-8df0-b2535b12fe9f.png)
