### PR TITLE
Fix tint shaders displaying with incorrect colors

### DIFF
--- a/ydr/shader_materials.py
+++ b/ydr/shader_materials.py
@@ -182,6 +182,7 @@ def create_tinted_geometry_graph():  # move to blenderhelper.py?
 
     # create and link texture node
     txtn = gnt.nodes.new("GeometryNodeImageTexture")
+    txtn.interpolation = "Closest"
     gnt.links.new(cptn.outputs[3], txtn.inputs[1])
     gnt.links.new(txtn.outputs[0], output.inputs[1])
 


### PR DESCRIPTION
GeometryNodeImageTexture defaults to Linear interpolation which interpolates between the colors of the palette. Use Closest to use the colors as defined in the palette.

Before (xs_prop_x18_tool_draw_01e.ydr)
![image](https://github.com/Skylumz/Sollumz/assets/12873137/0922b1a2-005b-4692-b74d-252a6c2f918c)
After
![image](https://github.com/Skylumz/Sollumz/assets/12873137/4f292ef6-eeb1-4609-b219-78984c0ca400)
