### PR TITLE
fix(ytyp): fix audio emitter format in YTYP export

### DIFF
--- a/cwxml/ymap.py
+++ b/cwxml/ymap.py
@@ -164,7 +164,7 @@ class ExtensionAudioEmitter(Extension):
     def __init__(self):
         super().__init__()
         self.offset_rotation = QuaternionProperty("offsetRotation")
-        self.effect_hash = TextProperty("effectHash")
+        self.effect_hash = ValueProperty("effectHash")
 
 
 class ExtensionExplosionEffect(Extension):


### PR DESCRIPTION
Fixes incorrect audio emitter format in YTYP export.