### PR TITLE
fix(export): autocalculate bonetags off by default

### DIFF
--- a/cwxml/ymap.py
+++ b/cwxml/ymap.py
@@ -164,7 +164,7 @@ class ExtensionAudioEmitter(Extension):
     def __init__(self):
         super().__init__()
         self.offset_rotation = QuaternionProperty("offsetRotation")
-        self.effect_hash = TextProperty("effectHash")
+        self.effect_hash = ValueProperty("effectHash")
 
 
 class ExtensionExplosionEffect(Extension):

--- a/sollumz_properties.py
+++ b/sollumz_properties.py
@@ -640,7 +640,7 @@ class SollumzExportSettings(bpy.types.PropertyGroup):
     auto_calculate_bone_tag: bpy.props.BoolProperty(
         name="Auto Calculate Bone Tag",
         description="Automatically calculate bone tags.",
-        default=True,
+        default=False,
     )
 
     export_with_hi: bpy.props.BoolProperty(


### PR DESCRIPTION
This should fix most issues when it comes to export custom skeletons from objects and other issues related to peds and clothing.