### PR TITLE
fix(ytyp): add missing 2048 archetype flag label

### DIFF
--- a/ytyp/properties/flags.py
+++ b/ytyp/properties/flags.py
@@ -151,7 +151,7 @@ class ArchetypeFlags(FlagPropertyGroup, bpy.types.PropertyGroup):
     flag11: bpy.props.BoolProperty(
         name="UV anims (YCD)", update=FlagPropertyGroup.update_flag)
     flag12: bpy.props.BoolProperty(
-        name="Unknown 12", update=FlagPropertyGroup.update_flag)
+        name="Invisible but blocks lights/shadows", update=FlagPropertyGroup.update_flag)
     flag13: bpy.props.BoolProperty(
         name="Unknown 13", update=FlagPropertyGroup.update_flag)
     flag14: bpy.props.BoolProperty(


### PR DESCRIPTION
Just re-tested again to make sure, I confirm this is working.
The flag blocks lights and shadows but doesn't render the model.
Credits to DPS