### PR TITLE
fix(ydrimport): add armature modifers to all models

### DIFF
--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -613,12 +613,12 @@ def drawable_to_obj(drawable, filepath, name, bones_override=None, materials=Non
             if model.sollum_type != SollumType.DRAWABLE_MODEL:
                 continue
 
-        for child in model.children:
-            if child.sollum_type != SollumType.DRAWABLE_GEOMETRY:
-                continue
+            for child in model.children:
+                if child.sollum_type != SollumType.DRAWABLE_GEOMETRY:
+                    continue
 
-            mod = child.modifiers.new("Armature", "ARMATURE")
-            mod.object = obj
+                mod = child.modifiers.new("Armature", "ARMATURE")
+                mod.object = obj
 
     if len(drawable.lights) > 0:
         create_lights(drawable.lights, obj)


### PR DESCRIPTION
The loop iterating the model children was indented outside the loop iterating the models, so it was only adding modifiers to the last model. Broken since 52f4850a974b3582f38571c6b414f20caaadd944.