### PR TITLE
Strict shader parameter order to prevent OpenIV crashes

### DIFF
--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -933,25 +933,31 @@ def get_shaders_from_blender(materials):
         shader.name = material.shader_properties.name
         shader.filename = material.shader_properties.filename
         shader.render_bucket = material.shader_properties.renderbucket
-
+        shader_name = material.shader_properties.filename
+        # check to make sure it exists before commit
+        shader_parameters = ShaderManager.shaders[shader_name].parameters
+        shader.parameters = shader_parameters
+        print("ALL CAPS SO I CAN SEE WHAT'S HAPPENING ")
+        # print(shader_name_test.parameters)
         for node in material.node_tree.nodes:
             if isinstance(node, bpy.types.ShaderNodeTexImage):
                 param = TextureShaderParameter()
                 param.name = node.name
+                param_name = node.name
                 param.type = "Texture"
                 # Disable extra material writing to xml
                 if param.name == "Extra":
                     continue
-                elif param.name == "DiffuseSampler":
-                    param.texture_name = node.sollumz_texture_name
-                    shader.parameters.insert(0, param)
                 else:
                     param.texture_name = node.sollumz_texture_name
-                    shader.parameters.append(param)
+                
+                parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param_name)
+                shader.parameters[parameter_index] = param
             elif isinstance(node, bpy.types.ShaderNodeValue):
                 if node.name[-1] == "x":
                     param = VectorShaderParameter()
                     param.name = node.name[:-2]
+                    param_name = node.name[:-2]
                     param.type = "Vector"
 
                     x = node
@@ -964,13 +970,15 @@ def get_shaders_from_blender(materials):
                     param.z = z.outputs[0].default_value
                     param.w = w.outputs[0].default_value
 
-                    shader.parameters.append(param)
+                    parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param_name)
+                    shader.parameters[parameter_index] = param
             elif isinstance(node, bpy.types.ShaderNodeGroup) and node.is_sollumz:
                 # Only perform logic if its ArrayNode
                 if node.node_tree.name == "ArrayNode" and node.name[-1] == "1":
                     node_name = node.name[:-2]
                     param = ArrayShaderParameter()
                     param.name = node_name
+                    param_name = node_name
                     param.type = "Array"
 
                     all_array_nodes = [
@@ -985,7 +993,8 @@ def get_shaders_from_blender(materials):
                         all_array_values.append(Vector((x, y, z, w)))
 
                     param.values = all_array_values
-                    shader.parameters.append(param)
+                    parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param_name)
+                    shader.parameters[parameter_index] = param
 
         shaders.append(shader)
 

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -942,9 +942,12 @@ def get_shaders_from_blender(materials):
                 # Disable extra material writing to xml
                 if param.name == "Extra":
                     continue
+                elif param.name == "DiffuseSampler":
+                    param.texture_name = node.sollumz_texture_name
+                    shader.parameters.insert(0, param)
                 else:
                     param.texture_name = node.sollumz_texture_name
-                shader.parameters.append(param)
+                    shader.parameters.append(param)
             elif isinstance(node, bpy.types.ShaderNodeValue):
                 if node.name[-1] == "x":
                     param = VectorShaderParameter()

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -933,10 +933,11 @@ def get_shaders_from_blender(materials):
         shader.name = material.shader_properties.name
         shader.filename = material.shader_properties.filename
         shader.render_bucket = material.shader_properties.renderbucket
-        # check to make sure it exists before commit
-        shader.parameters = ShaderManager.shaders[shader.filename].parameters
+        shader.parameters = list(ShaderManager.shaders[shader.filename].parameters)
 
         for node in material.node_tree.nodes:
+            param = None
+
             if isinstance(node, bpy.types.ShaderNodeTexImage):
                 param = TextureShaderParameter()
                 param.name = node.name
@@ -947,8 +948,6 @@ def get_shaders_from_blender(materials):
                 else:
                     param.texture_name = node.sollumz_texture_name
                 
-                parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param.name)
-                shader.parameters[parameter_index] = param
             elif isinstance(node, bpy.types.ShaderNodeValue):
                 if node.name[-1] == "x":
                     param = VectorShaderParameter()
@@ -965,8 +964,6 @@ def get_shaders_from_blender(materials):
                     param.z = z.outputs[0].default_value
                     param.w = w.outputs[0].default_value
 
-                    parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param.name)
-                    shader.parameters[parameter_index] = param
             elif isinstance(node, bpy.types.ShaderNodeGroup) and node.is_sollumz:
                 # Only perform logic if its ArrayNode
                 if node.node_tree.name == "ArrayNode" and node.name[-1] == "1":
@@ -987,7 +984,13 @@ def get_shaders_from_blender(materials):
                         all_array_values.append(Vector((x, y, z, w)))
 
                     param.values = all_array_values
-                    parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param.name)
+
+            if param is not None:
+                parameter_index = next((i for i, x in enumerate(shader.parameters) if x.name == param.name), None)
+                
+                if parameter_index == None:
+                    shader.parameters.append(param)
+                else:
                     shader.parameters[parameter_index] = param
 
         shaders.append(shader)

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -933,17 +933,13 @@ def get_shaders_from_blender(materials):
         shader.name = material.shader_properties.name
         shader.filename = material.shader_properties.filename
         shader.render_bucket = material.shader_properties.renderbucket
-        shader_name = material.shader_properties.filename
         # check to make sure it exists before commit
-        shader_parameters = ShaderManager.shaders[shader_name].parameters
-        shader.parameters = shader_parameters
-        print("ALL CAPS SO I CAN SEE WHAT'S HAPPENING ")
-        # print(shader_name_test.parameters)
+        shader.parameters = ShaderManager.shaders[shader.filename].parameters
+
         for node in material.node_tree.nodes:
             if isinstance(node, bpy.types.ShaderNodeTexImage):
                 param = TextureShaderParameter()
                 param.name = node.name
-                param_name = node.name
                 param.type = "Texture"
                 # Disable extra material writing to xml
                 if param.name == "Extra":
@@ -951,13 +947,12 @@ def get_shaders_from_blender(materials):
                 else:
                     param.texture_name = node.sollumz_texture_name
                 
-                parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param_name)
+                parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param.name)
                 shader.parameters[parameter_index] = param
             elif isinstance(node, bpy.types.ShaderNodeValue):
                 if node.name[-1] == "x":
                     param = VectorShaderParameter()
                     param.name = node.name[:-2]
-                    param_name = node.name[:-2]
                     param.type = "Vector"
 
                     x = node
@@ -970,7 +965,7 @@ def get_shaders_from_blender(materials):
                     param.z = z.outputs[0].default_value
                     param.w = w.outputs[0].default_value
 
-                    parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param_name)
+                    parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param.name)
                     shader.parameters[parameter_index] = param
             elif isinstance(node, bpy.types.ShaderNodeGroup) and node.is_sollumz:
                 # Only perform logic if its ArrayNode
@@ -978,7 +973,6 @@ def get_shaders_from_blender(materials):
                     node_name = node.name[:-2]
                     param = ArrayShaderParameter()
                     param.name = node_name
-                    param_name = node_name
                     param.type = "Array"
 
                     all_array_nodes = [
@@ -993,7 +987,7 @@ def get_shaders_from_blender(materials):
                         all_array_values.append(Vector((x, y, z, w)))
 
                     param.values = all_array_values
-                    parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param_name)
+                    parameter_index = next(i for i, x in enumerate(shader.parameters) if x.name == param.name)
                     shader.parameters[parameter_index] = param
 
         shaders.append(shader)


### PR DESCRIPTION
Although we are aware oiv is an unsupported program, many modders suffer when making public mods that crash oiv as they get alot of reports about this issue and people (who use oiv) assume the mods are bugged. 

In an exported XML in <Shaders> it seems like the issue is that OIV depends on DiffuseSampler to be in front of other samplers and especially the Vector value parameters. Sollumz does not currently guarantee this order, so this is a change to make sure that the DiffuseSampler is placed in front instead of appended when exporting. 