### PR TITLE
Fix errors when Blender language is not English

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,14 @@ See the [wiki](https://github.com/Skylumz/Sollumz/wiki) to get started. Make sur
 ## Requirements ##
   * Latest Codewalker release from [their discord](https://discord.gg/codewalker)
   * [Blender 3.5.1 or later](http://www.blender.org/download/)
-  * Blender must be in **English** for Sollumz to function correctly
-  
+
 ## Installation ##
   1. Download the [latest release](https://github.com/Skylumz/Sollumz/releases/latest)
   2. Start Blender
-  3. Ensure Blender Language is set to English
-  4. Click menu _`Edit > Preferences...`_
-  5. Go to the  _`Addons`_ tab in the middle
-  6. Click _`Install...`_ button at the top
-  7. Select the Downloaded ZIP
-  8. The following entry should be shown: _`Import-Export: Sollumz`_
-  9. Enable the addon
-  10. Restart Blender
+  3. Click menu _`Edit > Preferences...`_
+  4. Go to the  _`Addons`_ tab in the middle
+  5. Click _`Install...`_ button at the top
+  6. Select the Downloaded ZIP
+  7. The following entry should be shown: _`Import-Export: Sollumz`_
+  8. Enable the addon
+  9. Restart Blender

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fake-bpy-module-latest==20211212
 mathutils==2.81.2
 numpy==1.21.4
+pytest==7.2.0
+pytest-blender==3.0.5

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,0 +1,13 @@
+import pytest
+import bpy
+from Sollumz.ydr.shader_materials import shadermats
+from Sollumz.ybn.collision_materials import collisionmats
+
+SOLLUMZ_SHADERS = list(map(lambda s: s.value, shadermats))
+SOLLUMZ_COLLISION_MATERIALS = list(collisionmats)
+BLENDER_LANGUAGES = ("en_US", "es")  # bpy.app.translations.locales
+
+@pytest.fixture()
+def context():
+    return bpy.context
+

--- a/tools/blenderhelper.py
+++ b/tools/blenderhelper.py
@@ -2,7 +2,7 @@ import re
 import bpy
 import bmesh
 from mathutils import Matrix, Vector
-from typing import Optional
+from typing import Optional, Tuple
 
 from ..sollumz_properties import SOLLUMZ_UI_NAMES, LODLevel
 
@@ -73,7 +73,7 @@ def material_from_image(img, name="Material", nodename="Image"):
     mat.use_nodes = True
     node_tree = mat.node_tree
     links = node_tree.links
-    bsdf = node_tree.nodes["Principled BSDF"]
+    bsdf, _ = find_bsdf_and_material_output(mat)
     imgnode = node_tree.nodes.new("ShaderNodeTexImage")
     imgnode.name = nodename
     links.new(imgnode.outputs[0], bsdf.inputs[0])
@@ -434,3 +434,16 @@ def tag_redraw(context: bpy.types.Context, space_type: str = "PROPERTIES", regio
                 for region in area.regions:
                     if region.type == region_type:
                         region.tag_redraw()
+
+
+def find_bsdf_and_material_output(material: bpy.types.Material) -> Tuple[bpy.types.ShaderNodeBsdfPrincipled, bpy.types.ShaderNodeOutputMaterial]:
+    material_output = None
+    bsdf = None
+    for node in material.node_tree.nodes:
+        if isinstance(node, bpy.types.ShaderNodeOutputMaterial):
+            material_output = node
+        elif isinstance(node, bpy.types.ShaderNodeBsdfPrincipled):
+            bsdf = node
+
+    return bsdf, material_output
+

--- a/tools/drawablehelper.py
+++ b/tools/drawablehelper.py
@@ -2,7 +2,7 @@ import bpy
 from mathutils import Vector
 from ..ydr.shader_materials import create_shader, create_tinted_shader_graph, obj_has_tint_mats, try_get_node, ShaderManager
 from ..sollumz_properties import SollumType, MaterialType, LODLevel
-from ..tools.blenderhelper import create_empty_object
+from ..tools.blenderhelper import create_empty_object, find_bsdf_and_material_output
 from ..cwxml.drawable import BonePropertiesManager, Drawable, DrawableModel, TextureShaderParameter, VectorShaderParameter
 from typing import Union
 
@@ -84,7 +84,7 @@ class MaterialConverter:
         return None
 
     def _get_nodes(self):
-        self.bsdf = try_get_node(self.material.node_tree, "Principled BSDF")
+        self.bsdf, _ = find_bsdf_and_material_output(self.material)
 
         if self.bsdf is None:
             raise Exception(

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -223,3 +223,4 @@ def reshape_mat_4x3(mat_4x4: Matrix):
         mat_4x4[2][:3],
         mat_4x4[3][:3],
     ))
+

--- a/tools/ymaphelper.py
+++ b/tools/ymaphelper.py
@@ -1,6 +1,7 @@
 import bpy
 
 from ..sollumz_properties import SOLLUMZ_UI_NAMES, SollumType
+from ..tools.blenderhelper import find_bsdf_and_material_output
 
 # TODO: This is not a real flag calculation, definitely need to do better
 def calculate_ymap_content_flags(selected_ymap=None, sollum_type=None):
@@ -59,11 +60,12 @@ def add_occluder_material(sollum_type=None):
     material = bpy.data.materials.get(mat_name) or bpy.data.materials.new(mat_name)
     material.blend_method = "BLEND"
     material.use_nodes = True
-    material.node_tree.nodes["Principled BSDF"].inputs['Alpha'].default_value = mat_transparency
-    material.node_tree.nodes["Principled BSDF"].inputs['Base Color'].default_value = mat_color
-    material.node_tree.nodes["Principled BSDF"].inputs['Roughness'].default_value = 0
-    material.node_tree.nodes["Principled BSDF"].inputs['Metallic'].default_value = 0
-    material.node_tree.nodes["Principled BSDF"].inputs['Emission'].default_value = emission_color
+    bsdf, _ = find_bsdf_and_material_output(material)
+    bsdf.inputs["Alpha"].default_value = mat_transparency
+    bsdf.inputs["Base Color"].default_value = mat_color
+    bsdf.inputs["Roughness"].default_value = 0
+    bsdf.inputs["Metallic"].default_value = 0
+    bsdf.inputs["Emission"].default_value = emission_color
 
 
     return material

--- a/ybn/collision_materials.py
+++ b/ybn/collision_materials.py
@@ -2,6 +2,7 @@ import bpy
 from ..sollumz_properties import MaterialType
 from collections import namedtuple
 from .. import logger
+from ..tools.blenderhelper import find_bsdf_and_material_output
 
 CollisionMaterial = namedtuple(
     "CollisionMaterial", "name, ui_name, color, density")
@@ -311,10 +312,10 @@ def create_collision_material_from_index(index: int):
     mat.sollum_type = MaterialType.COLLISION
     mat.collision_properties.collision_index = index
     mat.use_nodes = True
+    bsdf, _ = find_bsdf_and_material_output(mat)
     r = matinfo.color[0] / 255
     g = matinfo.color[1] / 255
     b = matinfo.color[2] / 255
-    mat.node_tree.nodes["Principled BSDF"].inputs[0].default_value = (
-        r, g, b, 1)
+    bsdf.inputs[0].default_value = (r, g, b, 1)
 
     return mat

--- a/ynv/ynvimport.py
+++ b/ynv/ynvimport.py
@@ -3,6 +3,7 @@ from ..cwxml.navmesh import YNV
 from ..sollumz_properties import SOLLUMZ_UI_NAMES, SollumType
 import os
 import bpy
+from ..tools.blenderhelper import find_bsdf_and_material_output
 
 
 def points_to_obj(points):
@@ -95,7 +96,8 @@ def get_material(flags):
     if flags1 & 65536 > 0:
         g = 0.2
 
-    mat.node_tree.nodes["Principled BSDF"].inputs[0].default_value = (
+    bsdf, _ = find_bsdf_and_material_output(mat)
+    bsdf.inputs[0].default_value = (
         r, g, b, 0.75)
     return mat
 


### PR DESCRIPTION
These errors are due to accessing nodes by name, which are localized by Blender when Sollumz does not explicitly set them. The fix is to lookup the node by its type instead.

Additionally, added some tests using pytest and pytest-blender.

Fixes #708.