### PR TITLE
Make TextureFormat.D3DFMT_X8R8G8B8 not break import

### DIFF
--- a/sollumz_properties.py
+++ b/sollumz_properties.py
@@ -114,6 +114,7 @@ class TextureFormat(str, Enum):
     A1R8G8B8 = "sollumz_a1r8g8b8"
     A8R8G8B8 = "sollumz_a8r8g8b8"
     A8B8G8R8 = "sollumz_a8b8g8r8"
+    X8R8G8B8 = "sollumz_x8r8g8b8"
     A8 = "sollumz_a8"
     L8 = "sollumz_l8"
 
@@ -350,6 +351,7 @@ SOLLUMZ_UI_NAMES = {
     TextureFormat.A1R8G8B8: "D3DFMT_A1R8G8B8",
     TextureFormat.A8R8G8B8: "D3DFMT_A8R8G8B8",
     TextureFormat.A8B8G8R8: "D3DFMT_A8B8G8R8",
+    TextureFormat.X8R8G8B8: "D3DFMT_X8R8G8B8",
     TextureFormat.A8: "D3DFMT_A8",
     TextureFormat.L8: "D3DFMT_L8",
 


### PR DESCRIPTION
This commit makes importing not break if textures with this format are present, but it doesn't ensure and I haven't at all (and probably won't) test if said textures are actually imported **properly** (or even if said format is supported by RAGE!!! I was just trying for my bulk import to finish).

Anyway, hope it's helpful.