### PR TITLE
fix(ydr): Capsule lights properties

### DIFF
--- a/ydr/lights.py
+++ b/ydr/lights.py
@@ -110,6 +110,9 @@ def set_light_bpy_properties(light_xml: Light, light_data: bpy.types.Light):
         light_data.spot_blend = abs(
             (radians(light_xml.cone_inner_angle) / pi) - 1)
         light_data.spot_size = radians(light_xml.cone_outer_angle) * 2
+    elif light_data.sollum_type == LightType.CAPSULE:
+        light_data.light_properties.cone_inner_angle = light_xml.cone_inner_angle
+        light_data.light_properties.cone_outer_angle = light_xml.cone_outer_angle
 
 
 def set_light_rage_properties(light_xml: Light, light_data: bpy.types.Light):
@@ -227,6 +230,8 @@ def set_light_xml_properties(light_xml: Light, light_data: bpy.types.Light):
     light_xml.projected_texture_hash = light_props.projected_texture_hash
 
     if light_data.sollum_type == LightType.SPOT:
-        light_xml.cone_inner_angle = degrees(
-            abs((light_data.spot_blend * pi) - pi))
+        light_xml.cone_inner_angle = degrees(abs((light_data.spot_blend * pi) - pi))
         light_xml.cone_outer_angle = degrees(light_data.spot_size) / 2
+    elif light_data.sollum_type == LightType.CAPSULE:
+        light_xml.cone_inner_angle = light_data.light_properties.cone_inner_angle
+        light_xml.cone_outer_angle = light_data.light_properties.cone_outer_angle

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -158,15 +158,19 @@ class SOLLUMZ_PT_LIGHT_PANEL(bpy.types.Panel):
         row.prop(light, "sollum_type")
         if light.sollum_type == LightType.NONE:
             return
+        elif light.sollum_type == LightType.CAPSULE:
+            layout.separator()
+            box = layout.box()
+            box.label(text="Capsule Properties", icon="MESH_CAPSULE")
+            box.prop(light.light_properties, "cone_inner_angle")
+            box.prop(light.light_properties, "cone_outer_angle")
+            box.prop(light.light_properties, "extent")
         layout.separator()
         layout.prop(light.light_properties, "light_hash")
         layout.prop(light.light_properties, "group_id")
         layout.prop(light.light_properties, "projected_texture_hash")
         layout.separator()
         layout.prop(light.light_properties, "flashiness")
-        if light.sollum_type == LightType.CAPSULE:
-            layout.separator()
-            layout.prop(light.light_properties, "extent")
         layout.separator()
         layout.prop(light.light_properties, "volume_size_scale")
         layout.prop(light.light_properties, "volume_outer_color")


### PR DESCRIPTION
I realized that Sollumz was missing 2 important values when exporting capsule lights: `Cone Inner Angle` and `Cone Outer Angle`.

So I added fields for them in light properties only for capsule light type. Also added a UI box to make it more user friendly:

![blender_view](https://media.discordapp.net/attachments/899092494195769344/1154004890595631195/1671_20-09-23_12-36.png?width=1299&height=671)
![game_view](https://media.discordapp.net/attachments/899092494195769344/1154004890918604850/1670_20-09-23_12-36.jpg?width=1193&height=671)
