### PR TITLE
Tweak(ydr): Remove constraints and modifiers with asset import

### DIFF
--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -505,6 +505,13 @@ def create_drawable_as_asset(drawable_xml: Drawable, name: str, filepath: str):
     joined_obj = join_objects(model_objs)
     joined_obj.name = name
 
+    for modifier in joined_obj.modifiers:
+        if modifier.type == 'ARMATURE':
+            joined_obj.modifiers.remove(modifier)
+
+    for constraint in joined_obj.constraints:
+        joined_obj.constraints.remove(constraint)
+
     joined_obj.asset_mark()
     joined_obj.asset_generate_preview()
 


### PR DESCRIPTION
this just helps remove excess stuff, considering importing as an asset is 99.9% likely going to be used for props, you dont need armature modifier or constraints.