### PR TITLE
feat: optional export path to quickly export objects

### DIFF
--- a/sollumz_operators.py
+++ b/sollumz_operators.py
@@ -137,12 +137,21 @@ class SOLLUMZ_OT_export(bpy.types.Operator, TimedOperator):
         options={"HIDDEN", "SKIP_SAVE"}
     )
 
+    direct_export: bpy.props.BoolProperty(
+        name="Direct Export",
+        description="Export directly to the output directory without opening the directory selection dialog.",
+        options={"HIDDEN", "SKIP_SAVE"}
+    )
+
     def draw(self, context):
         pass
 
     def invoke(self, context, event):
-        context.window_manager.fileselect_add(self)
-        return {"RUNNING_MODAL"}
+        if self.direct_export:
+            return self.execute(context)
+        else:
+            context.window_manager.fileselect_add(self)
+            return {"RUNNING_MODAL"}
 
     def execute_timed(self, context: bpy.types.Context):
         logger.set_logging_operator(self)

--- a/sollumz_properties.py
+++ b/sollumz_properties.py
@@ -682,6 +682,13 @@ def register():
     bpy.types.Scene.debug_lights_only_selected = bpy.props.BoolProperty(
         name="Limit to Selected", description="Only set intensity of the selected lights. (All instances will be affected)")
 
+    bpy.types.Scene.sollumz_export_path = bpy.props.StringProperty(
+        name="Export Path",
+        default="",
+        description="The path where files will be exported. If not set, the export dialog will be opened",
+        subtype="DIR_PATH",
+    )
+
 
 def unregister():
     del bpy.types.Object.sollum_type
@@ -691,3 +698,4 @@ def unregister():
     del bpy.types.Scene.debug_sollum_type
     del bpy.types.Scene.all_sollum_type
     del bpy.types.Scene.debug_lights_only_selected
+    del bpy.types.Scene.sollumz_export_path

--- a/sollumz_ui.py
+++ b/sollumz_ui.py
@@ -255,7 +255,13 @@ class SOLLUMZ_PT_TOOL_PANEL(bpy.types.Panel):
         layout = self.layout
         row = layout.row()
         row.operator("sollumz.import")
-        row.operator("sollumz.export")
+
+        if context.scene.sollumz_export_path != "":
+            op = row.operator("sollumz.export")
+            op.directory = context.scene.sollumz_export_path
+            op.direct_export = True
+        else:
+            row.operator("sollumz.export")
 
 
 class SOLLUMZ_PT_VIEW_PANEL(bpy.types.Panel):
@@ -451,6 +457,23 @@ class SOLLUMZ_PT_DEBUG_PANEL(bpy.types.Panel):
             text="This will join all geometries for each LOD Level into a single object.", icon="ERROR")
         layout.operator("sollumz.migrateboundgeoms")
         layout.operator("sollumz.replace_armature_constraints")
+
+
+class SOLLUMZ_PT_EXPORT_PATH_PANEL(bpy.types.Panel):
+    bl_label = "Export path"
+    bl_idname = "SOLLUMZ_PT_EXPORT_PATH_PANEL"
+    bl_category = "Sollumz Tools"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_options = {"DEFAULT_CLOSED"}
+    bl_parent_id = SOLLUMZ_PT_TOOL_PANEL.bl_idname
+    bl_order = 5
+
+    def draw_header(self, context):
+        self.layout.label(text="", icon="FILEBROWSER")
+
+    def draw(self, context):
+        self.layout.prop(context.scene, "sollumz_export_path", text="")
 
 
 class SOLLUMZ_PT_TERRAIN_PAINTER_PANEL(bpy.types.Panel):


### PR DESCRIPTION
This allows the user to set an export path (per blend file) to quickly export objects.
By default, the path is empty, which means the classic window will show up.

![Preview](https://i.imgur.com/fIctS6q.png)
