### PR TITLE
Reformat repository to use black formatter standard

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,7 @@ bl_info = {
     "description": "This plugins allows you to import/export codewalker xml files.",
     "blender": (3, 5, 1),
     "version": (2, 2, 0),
-    "category": "Import-Export"
+    "category": "Import-Export",
 }
 
 
@@ -36,6 +36,7 @@ def register():
     # WorkSpaceTools need to be registered after normal modules so the keymaps
     # detect the registed operators
     sollumz_tool.register_tools()
+
 
 def unregister():
     sollumz_tool.unregister_tools()

--- a/auto_load.py
+++ b/auto_load.py
@@ -54,6 +54,7 @@ def unregister():
 # Import modules
 #################################################
 
+
 def get_all_submodules(directory):
     return list(iter_submodules(directory, directory.name))
 
@@ -78,6 +79,7 @@ def iter_submodule_names(path, root=""):
 # Find classes to register
 #################################################
 
+
 def get_ordered_classes_to_register(modules):
     return toposort(get_register_deps_dict(modules))
 
@@ -85,12 +87,14 @@ def get_ordered_classes_to_register(modules):
 def get_register_deps_dict(modules):
     my_classes = set(iter_my_classes(modules))
     my_classes_by_idname = {
-        cls.bl_idname: cls for cls in my_classes if hasattr(cls, "bl_idname")}
+        cls.bl_idname: cls for cls in my_classes if hasattr(cls, "bl_idname")
+    }
 
     deps_dict = {}
     for cls in my_classes:
-        deps_dict[cls] = set(iter_my_register_deps(
-            cls, my_classes, my_classes_by_idname))
+        deps_dict[cls] = set(
+            iter_my_register_deps(cls, my_classes, my_classes_by_idname)
+        )
     return deps_dict
 
 
@@ -150,17 +154,28 @@ def iter_classes_in_module(module):
 
 
 def get_register_base_types():
-    return set(getattr(bpy.types, name) for name in [
-        "Panel", "Operator", "PropertyGroup",
-        "Header", "Menu",
-        "Node", "NodeSocket", "NodeTree",
-        "UIList", "RenderEngine",
-        "Gizmo", "GizmoGroup",
-    ])
+    return set(
+        getattr(bpy.types, name)
+        for name in [
+            "Panel",
+            "Operator",
+            "PropertyGroup",
+            "Header",
+            "Menu",
+            "Node",
+            "NodeSocket",
+            "NodeTree",
+            "UIList",
+            "RenderEngine",
+            "Gizmo",
+            "GizmoGroup",
+        ]
+    )
 
 
 # Find order to register to solve dependencies
 #################################################
+
 
 def toposort(deps_dict):
     sorted_list = []
@@ -170,15 +185,14 @@ def toposort(deps_dict):
         # source: https://github.com/JacquesLucke/blender_vscode/pull/118/commits/f0c3a636e251a8f24f22af6f1806d338c838bcea#diff-9738ac67607466100291c17470c593209a6ad718a574d0903d9eb2e8b0a33727
         # JoseConseco forgot this code
         # https://devtalk.blender.org/t/batch-registering-multiple-classes-in-blender-2-8/3253/42
-        sorted_list_sub = []      # helper for additional sorting by bl_order - in panels
+        sorted_list_sub = []  # helper for additional sorting by bl_order - in panels
         for value, deps in deps_dict.items():
             if len(deps) == 0:
                 sorted_list_sub.append(value)
                 sorted_values.add(value)
             else:
                 unsorted.append(value)
-        deps_dict = {value: deps_dict[value] -
-                     sorted_values for value in unsorted}
-        sorted_list_sub.sort(key=lambda cls: getattr(cls, 'bl_order', 0))
+        deps_dict = {value: deps_dict[value] - sorted_values for value in unsorted}
+        sorted_list_sub.sort(key=lambda cls: getattr(cls, "bl_order", 0))
         sorted_list.extend(sorted_list_sub)
     return sorted_list

--- a/cwxml/bound.py
+++ b/cwxml/bound.py
@@ -10,12 +10,11 @@ from .element import (
     ListProperty,
     MatrixProperty,
     ValueProperty,
-    VectorProperty
+    VectorProperty,
 )
 
 
 class YBN:
-
     file_extension = ".ybn.xml"
 
     @staticmethod
@@ -106,7 +105,7 @@ class BoundCloth(BoundChild):
 
 
 class VerticesProperty(ElementProperty):
-    value_types = (list)
+    value_types = list
 
     def __init__(self, tag_name: str = "Vertices", value=None):
         super().__init__(tag_name, value or [])
@@ -122,7 +121,8 @@ class VerticesProperty(ElementProperty):
                     return VerticesProperty.read_value_error(element)
 
                 new.value.append(
-                    Vector((float(coords[0]), float(coords[1]), float(coords[2]))))
+                    Vector((float(coords[0]), float(coords[1]), float(coords[2])))
+                )
 
         return new
 
@@ -136,7 +136,8 @@ class VerticesProperty(ElementProperty):
         for vertex in self.value:
             if not isinstance(vertex, Vector):
                 raise TypeError(
-                    f"VerticesProperty can only contain Vector objects, not '{type(self.value)}'!")
+                    f"VerticesProperty can only contain Vector objects, not '{type(self.value)}'!"
+                )
             for index, component in enumerate(vertex):
                 text.append(str(component))
                 if index < len(vertex) - 1:
@@ -149,7 +150,7 @@ class VerticesProperty(ElementProperty):
 
 
 class OctantsProperty(ElementProperty):
-    value_types = (dict)
+    value_types = dict
 
     def __init__(self, tag_name: str = "Octants", value=None):
         super().__init__(tag_name, value or {})
@@ -269,7 +270,7 @@ class MaterialsList(ListProperty):
 
 
 class VertexColorProperty(ElementProperty):
-    value_types = (list[tuple[int, int, int, int]])
+    value_types = list[tuple[int, int, int, int]]
 
     def __init__(self, tag_name: str = "VertexColours", value=None):
         super().__init__(tag_name, value or [])
@@ -284,7 +285,9 @@ class VertexColorProperty(ElementProperty):
                 if len(colors) != 4:
                     return VertexColorProperty.read_value_error(element)
 
-                new.value.append((int(colors[0]), int(colors[1]), int(colors[2]), int(colors[3])))
+                new.value.append(
+                    (int(colors[0]), int(colors[1]), int(colors[2]), int(colors[3]))
+                )
 
         return new
 

--- a/cwxml/clipdictionary.py
+++ b/cwxml/clipdictionary.py
@@ -9,7 +9,7 @@ from .element import (
     TextProperty,
     ValueProperty,
     VectorProperty,
-    Vector4Property
+    Vector4Property,
 )
 from xml.etree import ElementTree as ET
 from inspect import isclass
@@ -17,7 +17,6 @@ from math import sqrt
 
 
 class YCD:
-
     file_extension = ".ycd.xml"
 
     @staticmethod
@@ -45,7 +44,11 @@ class ItemTypeList(ListProperty, AbstractClass):
         new = cls()
         type_map = {}
         for key, item_class in vars(cls).items():
-            if isclass(item_class) and issubclass(item_class, ItemTypeList.Item) and key == item_class.__name__:
+            if (
+                isclass(item_class)
+                and issubclass(item_class, ItemTypeList.Item)
+                and key == item_class.__name__
+            ):
                 type_map[item_class.type] = item_class
         for child in element:
             type_elem = child.find("Type")
@@ -125,7 +128,7 @@ class AttributesList(ItemTypeList):
 
 
 class ValuesBuffer(ElementProperty):
-    value_types = (list)
+    value_types = list
 
     def __init__(self):
         super().__init__(tag_name="Values", value=[])
@@ -160,7 +163,7 @@ class ValuesBuffer(ElementProperty):
 
 
 class FramesBuffer(ElementProperty):
-    value_types = (list)
+    value_types = list
 
     def __init__(self):
         super().__init__(tag_name="Frames", value=[])
@@ -276,7 +279,9 @@ class ChannelsList(ItemTypeList):
             self.type = "IndirectQuantizeFloat"
 
         def get_value(self, frame_id, channel_values):
-            return self.values[(self.frames[frame_id % len(self.frames)]) % len(self.values)]
+            return self.values[
+                (self.frames[frame_id % len(self.frames)]) % len(self.values)
+            ]
 
     class LinearFloat(QuantizeFloat):
         type = "LinearFloat"
@@ -297,7 +302,8 @@ class ChannelsList(ItemTypeList):
 
         def get_value(self, frame_id, channel_values):
             vec_len = Vector(
-                (channel_values[0], channel_values[1], channel_values[2])).length
+                (channel_values[0], channel_values[1], channel_values[2])
+            ).length
 
             return sqrt(max(1.0 - vec_len * vec_len, 0))
 
@@ -339,9 +345,7 @@ class Animation(ElementTree):
         tag_name = "SequenceData"
 
     class SequenceList(ListProperty):
-
         class Sequence(ElementTree):
-
             tag_name = "Item"
 
             def __init__(self):
@@ -406,7 +410,6 @@ class Clip(ItemTypeList.Item, AbstractClass):
 
 class ClipAnimationsList(ListProperty):
     class ClipAnimation(ElementTree):
-
         tag_name = "Item"
 
         def __init__(self):

--- a/cwxml/drawable.py
+++ b/cwxml/drawable.py
@@ -20,7 +20,7 @@ from .element import (
     ValueProperty,
     VectorProperty,
     Vector4Property,
-    MatrixProperty
+    MatrixProperty,
 )
 from .bound import (
     BoundBox,
@@ -31,13 +31,12 @@ from .bound import (
     BoundDisc,
     BoundGeometry,
     BoundGeometryBVH,
-    BoundSphere
+    BoundSphere,
 )
 from collections.abc import MutableSequence
 
 
 class YDD:
-
     file_extension = ".ydd.xml"
 
     @staticmethod
@@ -50,7 +49,6 @@ class YDD:
 
 
 class YDR:
-
     file_extension = ".ydr.xml"
 
     @staticmethod
@@ -132,8 +130,7 @@ class ArrayShaderParameter(ShaderParameter):
 
     @staticmethod
     def from_xml(element: ET.Element):
-        new = super(ArrayShaderParameter,
-                    ArrayShaderParameter).from_xml(element)
+        new = super(ArrayShaderParameter, ArrayShaderParameter).from_xml(element)
 
         for item in element:
             new.values.append(Vector4Property.from_xml(item).value)
@@ -150,8 +147,11 @@ class ArrayShaderParameter(ShaderParameter):
         return element
 
     def __hash__(self) -> int:
-        values_unpacked = [x for vector in self.values for x in [
-            vector.x, vector.y, vector.z, vector.w]]
+        values_unpacked = [
+            x
+            for vector in self.values
+            for x in [vector.x, vector.y, vector.z, vector.w]
+        ]
         return hash((self.name, self.type, *values_unpacked))
 
 
@@ -171,8 +171,7 @@ class ParametersList(ListProperty):
                 if param_type == VectorShaderParameter.type:
                     new.value.append(VectorShaderParameter.from_xml(child))
                 if param_type == ArrayShaderParameter.type:
-                    new.value.append(
-                        ArrayShaderParameter.from_xml(child))
+                    new.value.append(ArrayShaderParameter.from_xml(child))
 
         return new
 
@@ -192,7 +191,14 @@ class Shader(ElementTree):
 
     def __hash__(self) -> int:
         params_elem = self.get_element("parameters")
-        return hash((hash(self.name), hash(self.filename), hash(self.render_bucket), hash(params_elem)))
+        return hash(
+            (
+                hash(self.name),
+                hash(self.filename),
+                hash(self.render_bucket),
+                hash(params_elem),
+            )
+        )
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Shader):
@@ -217,7 +223,7 @@ class ShaderGroup(ElementTree):
 
 
 class BoneIDProperty(ElementProperty):
-    value_types = (list)
+    value_types = list
 
     def __init__(self, tag_name: str = "BoneIDs", value=None):
         super().__init__(tag_name, value or [])
@@ -377,7 +383,7 @@ class Lights(ListProperty):
 
 
 class VertexLayoutList(ElementProperty):
-    value_types = (list)
+    value_types = list
     tag_name = "Layout"
 
     def __init__(self, type: str = "GTAV1", value: list[str] = None):
@@ -462,8 +468,9 @@ class VertexBuffer(ElementTree):
         return element
 
     def _load_data_from_str(self, _str: str):
-        struct_dtype = np.dtype([self.VERT_ATTR_DTYPES[attr_name]
-                                 for attr_name in self.layout])
+        struct_dtype = np.dtype(
+            [self.VERT_ATTR_DTYPES[attr_name] for attr_name in self.layout]
+        )
 
         self.data = np.loadtxt(io.StringIO(_str), dtype=struct_dtype)
 
@@ -484,8 +491,7 @@ class VertexBuffer(ElementTree):
             formats.append(" ".join([attr_fmt] * column.shape[1]))
 
         fmt = ATTR_SEP.join(formats)
-        vert_arr_2d = np.column_stack(
-            [vert_arr[name] for name in vert_arr.dtype.names])
+        vert_arr_2d = np.column_stack([vert_arr[name] for name in vert_arr.dtype.names])
 
         return np_arr_to_str(vert_arr_2d, fmt)
 
@@ -531,13 +537,11 @@ class IndexBuffer(ElementTree):
         num_divisble_inds = num_inds - (num_inds % 24)
         num_rows = int(num_divisble_inds / 24)
 
-        indices_arr_2d = indices_arr[:num_divisble_inds].reshape(
-            (num_rows, 24))
+        indices_arr_2d = indices_arr[:num_divisble_inds].reshape((num_rows, 24))
 
         index_buffer_str = np_arr_to_str(indices_arr_2d, fmt="%.0u")
         # Add the last row
-        last_row_str = np_arr_to_str(
-            indices_arr[num_divisble_inds:], fmt="%.0u")
+        last_row_str = np_arr_to_str(indices_arr[num_divisble_inds:], fmt="%.0u")
 
         return f"{index_buffer_str}\n{last_row_str}"
 
@@ -591,7 +595,12 @@ class Drawable(ElementTree, AbstractClass):
 
     @property
     def all_models(self) -> list[DrawableModel]:
-        return self.drawable_models_high + self.drawable_models_med + self.drawable_models_low + self.drawable_models_vlow
+        return (
+            self.drawable_models_high
+            + self.drawable_models_med
+            + self.drawable_models_low
+            + self.drawable_models_vlow
+        )
 
     def __init__(self):
         super().__init__()
@@ -617,14 +626,10 @@ class Drawable(ElementTree, AbstractClass):
         self.shader_group = ShaderGroup()
         self.skeleton = Skeleton()
         self.joints = Joints()
-        self.drawable_models_high = DrawableModelList(
-            "DrawableModelsHigh")
-        self.drawable_models_med = DrawableModelList(
-            "DrawableModelsMedium")
-        self.drawable_models_low = DrawableModelList(
-            "DrawableModelsLow")
-        self.drawable_models_vlow = DrawableModelList(
-            "DrawableModelsVeryLow")
+        self.drawable_models_high = DrawableModelList("DrawableModelsHigh")
+        self.drawable_models_med = DrawableModelList("DrawableModelsMedium")
+        self.drawable_models_low = DrawableModelList("DrawableModelsLow")
+        self.drawable_models_vlow = DrawableModelList("DrawableModelsVeryLow")
         self.lights = Lights()
         self.bounds = []
 
@@ -719,13 +724,14 @@ class DrawableDictionary(MutableSequence, Element):
                 element.append(drawable.to_xml())
             else:
                 raise TypeError(
-                    f"{type(self).__name__}s can only hold '{Drawable.__name__}' objects, not '{type(drawable)}'!")
+                    f"{type(self).__name__}s can only hold '{Drawable.__name__}' objects, not '{type(drawable)}'!"
+                )
 
         return element
 
 
 class DrawableMatrices(ElementProperty):
-    value_types = (list)
+    value_types = list
 
     def __init__(self, tag_name: str = "Matrices", value: list[Matrix] = None):
         super().__init__(tag_name, value)
@@ -753,8 +759,7 @@ class DrawableMatrices(ElementProperty):
 
 
 class BonePropertiesManager:
-    dictionary_xml = os.path.join(
-        os.path.dirname(__file__), "BoneProperties.xml")
+    dictionary_xml = os.path.join(os.path.dirname(__file__), "BoneProperties.xml")
     bones = {}
 
     @staticmethod

--- a/cwxml/element.py
+++ b/cwxml/element.py
@@ -55,6 +55,7 @@ def get_str_type(value: str):
 
 class Element(AbstractClass):
     """Abstract XML element to base all other XML elements off of"""
+
     @property
     @abstractmethod
     def tag_name(self):
@@ -63,7 +64,8 @@ class Element(AbstractClass):
     @classmethod
     def read_value_error(cls, element):
         raise ValueError(
-            f"Invalid XML element '<{element.tag} />' for type '{cls.__name__}'!")
+            f"Invalid XML element '<{element.tag} />' for type '{cls.__name__}'!"
+        )
 
     @abstractclassmethod
     def from_xml(cls, element: ET.Element):
@@ -141,7 +143,11 @@ class ElementTree(Element):
     def __setattr__(self, name: str, value) -> None:
         # Get the full object
         obj = self.__getattribute__(name, False)
-        if obj is not None and isinstance(obj, (ElementProperty, AttributeProperty)) and not isinstance(value, (ElementProperty, AttributeProperty)):
+        if (
+            obj is not None
+            and isinstance(obj, (ElementProperty, AttributeProperty))
+            and not isinstance(value, (ElementProperty, AttributeProperty))
+        ):
             # If the object is an ElementProperty or AttributeProperty, set it's value
             obj.value = value
             super().__setattr__(name, obj)
@@ -182,14 +188,15 @@ class ElementProperty(Element, AbstractClass):
         self.tag_name = tag_name
         if value and not isinstance(value, self.value_types):
             raise TypeError(
-                f"Value of {type(self).__name__} must be one of {self.value_types}, not {type(value)}!")
+                f"Value of {type(self).__name__} must be one of {self.value_types}, not {type(value)}!"
+            )
         self.value = value
 
 
 class ListProperty(ElementProperty, AbstractClass):
     """Holds a list value. List can only contain values of one type."""
 
-    value_types = (list)
+    value_types = list
 
     @property
     @abstractmethod
@@ -227,7 +234,8 @@ class ListProperty(ElementProperty, AbstractClass):
                     element.append(item.to_xml())
                 else:
                     raise TypeError(
-                        f"{type(self).__name__} can only hold objects of type '{self.list_type.__name__}', not '{type(item)}'")
+                        f"{type(self).__name__} can only hold objects of type '{self.list_type.__name__}', not '{type(item)}'"
+                    )
 
             return element
 
@@ -253,13 +261,14 @@ class ListPropertyRequired(ListProperty):
                     element.append(item.to_xml())
                 else:
                     raise TypeError(
-                        f"{type(self).__name__} can only hold objects of type '{self.list_type.__name__}', not '{type(item)}'")
+                        f"{type(self).__name__} can only hold objects of type '{self.list_type.__name__}', not '{type(item)}'"
+                    )
 
         return element
 
 
 class TextProperty(ElementProperty):
-    value_types = (str)
+    value_types = str
 
     def __init__(self, tag_name: str = "Name", value=None):
         super().__init__(tag_name, value or "")
@@ -279,7 +288,8 @@ class TextProperty(ElementProperty):
 
 class TextPropertyRequired(ElementProperty):
     """Same as TextProperty but returns an empty element rather then None in case the passed element's value is empty or None"""
-    value_types = (str)
+
+    value_types = str
 
     def __init__(self, tag_name: str = "Name", value=None):
         super().__init__(tag_name, value or "")
@@ -297,14 +307,21 @@ class TextPropertyRequired(ElementProperty):
 
 
 class ColorProperty(ElementProperty):
-    value_types = (list)
+    value_types = list
 
     def __init__(self, tag_name: str, value=None):
         super().__init__(tag_name, value or [0, 0, 0])
 
     @staticmethod
     def from_xml(element: ET.Element):
-        return ColorProperty(element.tag, [float(element.get("r", default=0)), float(element.get("g", default=0)), float(element.get("b", default=0))])
+        return ColorProperty(
+            element.tag,
+            [
+                float(element.get("r", default=0)),
+                float(element.get("g", default=0)),
+                float(element.get("b", default=0)),
+            ],
+        )
 
     def to_xml(self):
         r = str(int(self.value.r))
@@ -314,7 +331,7 @@ class ColorProperty(ElementProperty):
 
 
 class Vector2Property(ElementProperty):
-    value_types = (Vector)
+    value_types = Vector
 
     def __init__(self, tag_name: str, value=None):
         super().__init__(tag_name, value or Vector((0, 0)))
@@ -324,7 +341,12 @@ class Vector2Property(ElementProperty):
         if not all(x in element.attrib.keys() for x in ["x", "y"]):
             return Vector2Property.read_value_error(element)
 
-        return Vector2Property(element.tag, Vector((float(element.get("x", default=0)), float(element.get("y", default=0)))))
+        return Vector2Property(
+            element.tag,
+            Vector(
+                (float(element.get("x", default=0)), float(element.get("y", default=0)))
+            ),
+        )
 
     def to_xml(self):
         x = str(float32(self.value.x))
@@ -333,14 +355,23 @@ class Vector2Property(ElementProperty):
 
 
 class VectorProperty(ElementProperty):
-    value_types = (Vector)
+    value_types = Vector
 
     def __init__(self, tag_name: str, value=None):
         super().__init__(tag_name, value or Vector((0, 0, 0)))
 
     @staticmethod
     def from_xml(element: ET.Element):
-        return VectorProperty(element.tag, Vector((float(element.get("x", default=0)), float(element.get("y", default=0)), float(element.get("z", default=0)))))
+        return VectorProperty(
+            element.tag,
+            Vector(
+                (
+                    float(element.get("x", default=0)),
+                    float(element.get("y", default=0)),
+                    float(element.get("z", default=0)),
+                )
+            ),
+        )
 
     def to_xml(self):
         x = str(float32(self.value.x))
@@ -350,14 +381,24 @@ class VectorProperty(ElementProperty):
 
 
 class Vector4Property(ElementProperty):
-    value_types = (Vector)
+    value_types = Vector
 
     def __init__(self, tag_name: str, value=None):
         super().__init__(tag_name, value or Vector((0, 0, 0, 0)))
 
     @staticmethod
     def from_xml(element: ET.Element):
-        return Vector4Property(element.tag, Vector((float(element.get("x", default=0)), float(element.get("y", default=0)), float(element.get("z", default=0)), float(element.get("w", default=0)))))
+        return Vector4Property(
+            element.tag,
+            Vector(
+                (
+                    float(element.get("x", default=0)),
+                    float(element.get("y", default=0)),
+                    float(element.get("z", default=0)),
+                    float(element.get("w", default=0)),
+                )
+            ),
+        )
 
     def to_xml(self):
         x = str(float32(self.value.x))
@@ -368,7 +409,7 @@ class Vector4Property(ElementProperty):
 
 
 class QuaternionProperty(ElementProperty):
-    value_types = (Quaternion)
+    value_types = Quaternion
 
     def __init__(self, tag_name: str, value=None):
         super().__init__(tag_name, value or Quaternion())
@@ -378,7 +419,17 @@ class QuaternionProperty(ElementProperty):
         if not all(x in element.attrib.keys() for x in ["x", "y", "z", "w"]):
             QuaternionProperty.read_value_error(element)
 
-        return QuaternionProperty(element.tag, Quaternion((float(element.get("w")), float(element.get("x")), float(element.get("y")), float(element.get("z")))))
+        return QuaternionProperty(
+            element.tag,
+            Quaternion(
+                (
+                    float(element.get("w")),
+                    float(element.get("x")),
+                    float(element.get("y")),
+                    float(element.get("z")),
+                )
+            ),
+        )
 
     def to_xml(self):
         x = str(float32(self.value.x))
@@ -389,7 +440,7 @@ class QuaternionProperty(ElementProperty):
 
 
 class MatrixProperty(ElementProperty):
-    value_types = (Matrix)
+    value_types = Matrix
 
     def __init__(self, tag_name: str, value=None):
         super().__init__(tag_name, value or Matrix())
@@ -423,7 +474,7 @@ class MatrixProperty(ElementProperty):
 
 
 class Matrix33Property(ElementProperty):
-    value_types = (Matrix)
+    value_types = Matrix
 
     def __init__(self, tag_name: str, value=None):
         super().__init__(tag_name, value or Matrix.Diagonal((0, 0, 0)))
@@ -457,7 +508,7 @@ class Matrix33Property(ElementProperty):
 
 
 class FlagsProperty(ElementProperty):
-    value_types = (list)
+    value_types = list
 
     def __init__(self, tag_name: str = "Flags", value=None):
         super().__init__(tag_name, value or [])
@@ -514,7 +565,7 @@ class ValueProperty(ElementProperty):
 
 
 class StringValueProperty(ElementProperty):
-    value_types = (str)
+    value_types = str
 
     def __init__(self, tag_name: str, value=""):
         super().__init__(tag_name, value)
@@ -532,7 +583,8 @@ class StringValueProperty(ElementProperty):
 
 class TextListProperty(ElementProperty):
     """Separates each word of an element's text into a list"""
-    value_types = (list)
+
+    value_types = list
 
     def __init__(self, tag_name, value=None):
         super().__init__(tag_name, value or [])

--- a/cwxml/fragment.py
+++ b/cwxml/fragment.py
@@ -11,14 +11,13 @@ from .element import (
     Vector4Property,
     TextProperty,
     ValueProperty,
-    VectorProperty
+    VectorProperty,
 )
 from .drawable import Drawable, Lights, VertexLayoutList
 from .bound import BoundComposite
 
 
 class YFT:
-
     file_extension = ".yft.xml"
 
     @staticmethod
@@ -112,10 +111,8 @@ class PhysicsGroup(ElementTree):
         self.glass_window_index = ValueProperty("GlassWindowIndex")
         self.glass_flags = ValueProperty("GlassFlags")
         self.strength = ValueProperty("Strength")
-        self.force_transmission_scale_up = ValueProperty(
-            "ForceTransmissionScaleUp")
-        self.force_transmission_scale_down = ValueProperty(
-            "ForceTransmissionScaleDown")
+        self.force_transmission_scale_up = ValueProperty("ForceTransmissionScaleUp")
+        self.force_transmission_scale_down = ValueProperty("ForceTransmissionScaleDown")
         self.joint_stiffness = ValueProperty("JointStiffness")
         self.min_soft_angle_1 = ValueProperty("MinSoftAngle1")
         self.max_soft_angle_1 = ValueProperty("MaxSoftAngle1")
@@ -181,7 +178,7 @@ class Physics(ElementTree):
 
 
 class ShatterMapProperty(ElementProperty):
-    value_types = (list)
+    value_types = list
 
     def __init__(self, tag_name: str = "ShatterMap", value=None):
         super().__init__(tag_name, value or "")

--- a/cwxml/light_preset.py
+++ b/cwxml/light_preset.py
@@ -1,4 +1,11 @@
-from .element import VectorProperty, AttributeProperty, ValueProperty, TextProperty, ElementTree, ListProperty
+from .element import (
+    VectorProperty,
+    AttributeProperty,
+    ValueProperty,
+    TextProperty,
+    ElementTree,
+    ListProperty,
+)
 
 
 class LightPresetsFile(ElementTree):
@@ -25,7 +32,7 @@ class LightPreset(ElementTree):
         self.shadow_buffer_clip_start = ValueProperty("ShadowBufferClipStart")
         self.spot_size = ValueProperty("SpotSize")
         self.spot_blend = ValueProperty("SpotBlend")
- 
+
         # RAGE properties
         self.time_flags = ValueProperty("TimeFlags")
         self.flags = ValueProperty("Flags")

--- a/cwxml/navmesh.py
+++ b/cwxml/navmesh.py
@@ -3,14 +3,13 @@ from .element import (
     ListProperty,
     TextProperty,
     ValueProperty,
-    VectorProperty
+    VectorProperty,
 )
 from xml.etree import ElementTree as ET
 from mathutils import Vector
 
 
 class YNV:
-
     file_extension = ".ynv.xml"
 
     @staticmethod

--- a/cwxml/nodepath.py
+++ b/cwxml/nodepath.py
@@ -5,12 +5,11 @@ from .element import (
     TextProperty,
     ValueProperty,
     VectorProperty,
-    Vector2Property
+    Vector2Property,
 )
 
 
 class YND:
-
     file_extension = ".ynd.xml"
 
     @staticmethod

--- a/cwxml/shader.py
+++ b/cwxml/shader.py
@@ -109,52 +109,207 @@ class ShaderManager:
     _shaders: dict[str, Shader] = {}
     _shaders_by_hash: dict[int, Shader] = {}
 
-    terrains = ["terrain_cb_w_4lyr.sps", "terrain_cb_w_4lyr_lod.sps", "terrain_cb_w_4lyr_spec.sps", "terrain_cb_w_4lyr_spec_pxm.sps", "terrain_cb_w_4lyr_pxm_spm.sps",
-                "terrain_cb_w_4lyr_pxm.sps", "terrain_cb_w_4lyr_cm_pxm.sps", "terrain_cb_w_4lyr_cm_tnt.sps", "terrain_cb_w_4lyr_cm_pxm_tnt.sps", "terrain_cb_w_4lyr_cm.sps",
-                "terrain_cb_w_4lyr_2tex.sps", "terrain_cb_w_4lyr_2tex_blend.sps", "terrain_cb_w_4lyr_2tex_blend_lod.sps", "terrain_cb_w_4lyr_2tex_blend_pxm.sps",
-                "terrain_cb_w_4lyr_2tex_blend_pxm_spm.sps", "terrain_cb_w_4lyr_2tex_pxm.sps", "terrain_cb_4lyr.sps", "terrain_cb_w_4lyr_spec_int_pxm.sps",
-                "terrain_cb_w_4lyr_spec_int.sps", "terrain_cb_4lyr_lod.sps"]
-    mask_only_terrains = ["terrain_cb_w_4lyr_cm.sps", "terrain_cb_w_4lyr_cm_tnt.sps",
-                          "terrain_cb_w_4lyr_cm_pxm_tnt.sps", "terrain_cb_w_4lyr_cm_pxm.sps"]
-    cutouts = ["cutout.sps", "cutout_um.sps", "cutout_tnt.sps", "cutout_fence.sps", "cutout_fence_normal.sps", "cutout_hard.sps", "cutout_spec_tnt.sps", "normal_cutout.sps",
-               "normal_cutout_tnt.sps", "normal_cutout_um.sps", "normal_spec_cutout.sps", "normal_spec_cutout_tnt.sps", "trees_lod.sps", "trees.sps", "trees_tnt.sps",
-               "trees_normal.sps", "trees_normal_spec.sps", "trees_normal_spec_tnt.sps", "trees_normal_diffspec.sps", "trees_normal_diffspec_tnt.sps"]
-    alphas = ["normal_spec_alpha.sps", "normal_spec_reflect_alpha.sps", "normal_spec_reflect_emissivenight_alpha.sps", "normal_spec_screendooralpha.sps", "normal_alpha.sps",
-              "normal_reflect_alpha.sps", "emissive_alpha.sps", "emissive_alpha_tnt.sps", "emissive_clip.sps", "emissive_additive_alpha.sps", "emissivenight_alpha.sps", "emissivestrong_alpha.sps",
-              "spec_alpha.sps", "spec_reflect_alpha.sps", "alpha.sps", "reflect_alpha.sps", "normal_screendooralpha.sps", "spec_screendooralpha.sps", "cloth_spec_alpha.sps",
-              "cloth_normal_spec_alpha.sps"]
-    glasses = ["glass.sps", "glass_pv.sps", "glass_pv_env.sps", "glass_env.sps", "glass_spec.sps", "glass_reflect.sps", "glass_emissive.sps", "glass_emissivenight.sps",
-               "glass_emissivenight_alpha.sps", "glass_breakable.sps", "glass_breakable_screendooralpha.sps", "glass_displacement.sps", "glass_normal_spec_reflect.sps",
-               "glass_emissive_alpha.sps"]
-    decals = ["decal.sps", "decal_tnt.sps", "decal_glue.sps", "decal_spec_only.sps", "decal_normal_only.sps", "decal_emissive_only.sps", "decal_emissivenight_only.sps",
-              "decal_amb_only.sps", "normal_decal.sps", "normal_decal_pxm.sps", "normal_decal_pxm_tnt.sps", "normal_decal_tnt.sps", "normal_spec_decal.sps", "normal_spec_decal_detail.sps",
-              "normal_spec_decal_nopuddle.sps", "normal_spec_decal_tnt.sps", "normal_spec_decal_pxm.sps", "spec_decal.sps", "spec_reflect_decal.sps", "reflect_decal.sps", "decal_dirt.sps",
-              "mirror_decal.sps", "grass_batch.sps"]
+    terrains = [
+        "terrain_cb_w_4lyr.sps",
+        "terrain_cb_w_4lyr_lod.sps",
+        "terrain_cb_w_4lyr_spec.sps",
+        "terrain_cb_w_4lyr_spec_pxm.sps",
+        "terrain_cb_w_4lyr_pxm_spm.sps",
+        "terrain_cb_w_4lyr_pxm.sps",
+        "terrain_cb_w_4lyr_cm_pxm.sps",
+        "terrain_cb_w_4lyr_cm_tnt.sps",
+        "terrain_cb_w_4lyr_cm_pxm_tnt.sps",
+        "terrain_cb_w_4lyr_cm.sps",
+        "terrain_cb_w_4lyr_2tex.sps",
+        "terrain_cb_w_4lyr_2tex_blend.sps",
+        "terrain_cb_w_4lyr_2tex_blend_lod.sps",
+        "terrain_cb_w_4lyr_2tex_blend_pxm.sps",
+        "terrain_cb_w_4lyr_2tex_blend_pxm_spm.sps",
+        "terrain_cb_w_4lyr_2tex_pxm.sps",
+        "terrain_cb_4lyr.sps",
+        "terrain_cb_w_4lyr_spec_int_pxm.sps",
+        "terrain_cb_w_4lyr_spec_int.sps",
+        "terrain_cb_4lyr_lod.sps",
+    ]
+    mask_only_terrains = [
+        "terrain_cb_w_4lyr_cm.sps",
+        "terrain_cb_w_4lyr_cm_tnt.sps",
+        "terrain_cb_w_4lyr_cm_pxm_tnt.sps",
+        "terrain_cb_w_4lyr_cm_pxm.sps",
+    ]
+    cutouts = [
+        "cutout.sps",
+        "cutout_um.sps",
+        "cutout_tnt.sps",
+        "cutout_fence.sps",
+        "cutout_fence_normal.sps",
+        "cutout_hard.sps",
+        "cutout_spec_tnt.sps",
+        "normal_cutout.sps",
+        "normal_cutout_tnt.sps",
+        "normal_cutout_um.sps",
+        "normal_spec_cutout.sps",
+        "normal_spec_cutout_tnt.sps",
+        "trees_lod.sps",
+        "trees.sps",
+        "trees_tnt.sps",
+        "trees_normal.sps",
+        "trees_normal_spec.sps",
+        "trees_normal_spec_tnt.sps",
+        "trees_normal_diffspec.sps",
+        "trees_normal_diffspec_tnt.sps",
+    ]
+    alphas = [
+        "normal_spec_alpha.sps",
+        "normal_spec_reflect_alpha.sps",
+        "normal_spec_reflect_emissivenight_alpha.sps",
+        "normal_spec_screendooralpha.sps",
+        "normal_alpha.sps",
+        "normal_reflect_alpha.sps",
+        "emissive_alpha.sps",
+        "emissive_alpha_tnt.sps",
+        "emissive_clip.sps",
+        "emissive_additive_alpha.sps",
+        "emissivenight_alpha.sps",
+        "emissivestrong_alpha.sps",
+        "spec_alpha.sps",
+        "spec_reflect_alpha.sps",
+        "alpha.sps",
+        "reflect_alpha.sps",
+        "normal_screendooralpha.sps",
+        "spec_screendooralpha.sps",
+        "cloth_spec_alpha.sps",
+        "cloth_normal_spec_alpha.sps",
+    ]
+    glasses = [
+        "glass.sps",
+        "glass_pv.sps",
+        "glass_pv_env.sps",
+        "glass_env.sps",
+        "glass_spec.sps",
+        "glass_reflect.sps",
+        "glass_emissive.sps",
+        "glass_emissivenight.sps",
+        "glass_emissivenight_alpha.sps",
+        "glass_breakable.sps",
+        "glass_breakable_screendooralpha.sps",
+        "glass_displacement.sps",
+        "glass_normal_spec_reflect.sps",
+        "glass_emissive_alpha.sps",
+    ]
+    decals = [
+        "decal.sps",
+        "decal_tnt.sps",
+        "decal_glue.sps",
+        "decal_spec_only.sps",
+        "decal_normal_only.sps",
+        "decal_emissive_only.sps",
+        "decal_emissivenight_only.sps",
+        "decal_amb_only.sps",
+        "normal_decal.sps",
+        "normal_decal_pxm.sps",
+        "normal_decal_pxm_tnt.sps",
+        "normal_decal_tnt.sps",
+        "normal_spec_decal.sps",
+        "normal_spec_decal_detail.sps",
+        "normal_spec_decal_nopuddle.sps",
+        "normal_spec_decal_tnt.sps",
+        "normal_spec_decal_pxm.sps",
+        "spec_decal.sps",
+        "spec_reflect_decal.sps",
+        "reflect_decal.sps",
+        "decal_dirt.sps",
+        "mirror_decal.sps",
+        "grass_batch.sps",
+    ]
     veh_cutouts = ["vehicle_cutout.sps", "vehicle_badges.sps"]
     veh_glasses = ["vehicle_vehglass.sps", "vehicle_vehglass_inner.sps"]
-    veh_decals = ["vehicle_decal.sps", "vehicle_decal2.sps",
-                  "vehicle_blurredrotor_emissive.sps"]
+    veh_decals = [
+        "vehicle_decal.sps",
+        "vehicle_decal2.sps",
+        "vehicle_blurredrotor_emissive.sps",
+    ]
     shadow_proxies = ["trees_shadow_proxy.sps"]
     # Tint shaders that use colour1 instead of colour0 to index the tint palette
-    tint_colour1_shaders = ["trees_normal_diffspec_tnt.sps", "trees_tnt.sps", "trees_normal_spec_tnt.sps"]
-    palette_shaders = ["ped_palette.sps", "ped_default_palette.sps", "weapon_normal_spec_cutout_palette.sps",
-                       "weapon_normal_spec_detail_palette.sps", "weapon_normal_spec_palette.sps"]
-    em_shaders = ["normal_spec_emissive.sps", "normal_spec_reflect_emissivenight.sps", "emissive.sps", "emissive_speclum.sps", "emissive_tnt.sps", "emissivenight.sps",
-                  "emissivenight_geomnightonly.sps", "emissivestrong_alpha.sps", "emissivestrong.sps", "glass_emissive.sps", "glass_emissivenight.sps", "glass_emissivenight_alpha.sps",
-                  "glass_emissive_alpha.sps", "decal_emissive_only.sps", "decal_emissivenight_only.sps"]
-    water_shaders = ["water_fountain.sps",
-                     "water_poolenv.sps", "water_decal.sps", "water_terrainfoam.sps", "water_riverlod.sps", "water_shallow.sps", "water_riverfoam.sps", "water_riverocean.sps", "water_rivershallow.sps"]
+    tint_colour1_shaders = [
+        "trees_normal_diffspec_tnt.sps",
+        "trees_tnt.sps",
+        "trees_normal_spec_tnt.sps",
+    ]
+    palette_shaders = [
+        "ped_palette.sps",
+        "ped_default_palette.sps",
+        "weapon_normal_spec_cutout_palette.sps",
+        "weapon_normal_spec_detail_palette.sps",
+        "weapon_normal_spec_palette.sps",
+    ]
+    em_shaders = [
+        "normal_spec_emissive.sps",
+        "normal_spec_reflect_emissivenight.sps",
+        "emissive.sps",
+        "emissive_speclum.sps",
+        "emissive_tnt.sps",
+        "emissivenight.sps",
+        "emissivenight_geomnightonly.sps",
+        "emissivestrong_alpha.sps",
+        "emissivestrong.sps",
+        "glass_emissive.sps",
+        "glass_emissivenight.sps",
+        "glass_emissivenight_alpha.sps",
+        "glass_emissive_alpha.sps",
+        "decal_emissive_only.sps",
+        "decal_emissivenight_only.sps",
+    ]
+    water_shaders = [
+        "water_fountain.sps",
+        "water_poolenv.sps",
+        "water_decal.sps",
+        "water_terrainfoam.sps",
+        "water_riverlod.sps",
+        "water_shallow.sps",
+        "water_riverfoam.sps",
+        "water_riverocean.sps",
+        "water_rivershallow.sps",
+    ]
 
-    veh_paints = ["vehicle_paint1.sps", "vehicle_paint1_enveff.sps",
-                  "vehicle_paint2.sps", "vehicle_paint2_enveff.sps", "vehicle_paint3.sps", "vehicle_paint3_enveff.sps", "vehicle_paint3_lvr.sps", "vehicle_paint4.sps", "vehicle_paint4_emissive.sps",
-                  "vehicle_paint4_enveff.sps", "vehicle_paint5_enveff.sps", "vehicle_paint6.sps", "vehicle_paint6_enveff.sps", "vehicle_paint7.sps", "vehicle_paint7_enveff.sps", "vehicle_paint8.sps",
-                  "vehicle_paint9.sps",]
+    veh_paints = [
+        "vehicle_paint1.sps",
+        "vehicle_paint1_enveff.sps",
+        "vehicle_paint2.sps",
+        "vehicle_paint2_enveff.sps",
+        "vehicle_paint3.sps",
+        "vehicle_paint3_enveff.sps",
+        "vehicle_paint3_lvr.sps",
+        "vehicle_paint4.sps",
+        "vehicle_paint4_emissive.sps",
+        "vehicle_paint4_enveff.sps",
+        "vehicle_paint5_enveff.sps",
+        "vehicle_paint6.sps",
+        "vehicle_paint6_enveff.sps",
+        "vehicle_paint7.sps",
+        "vehicle_paint7_enveff.sps",
+        "vehicle_paint8.sps",
+        "vehicle_paint9.sps",
+    ]
 
     def tinted_shaders():
-        return ShaderManager.cutouts + ShaderManager.alphas + ShaderManager.glasses + ShaderManager.decals + ShaderManager.veh_cutouts + ShaderManager.veh_glasses + ShaderManager.veh_decals + ShaderManager.shadow_proxies
+        return (
+            ShaderManager.cutouts
+            + ShaderManager.alphas
+            + ShaderManager.glasses
+            + ShaderManager.decals
+            + ShaderManager.veh_cutouts
+            + ShaderManager.veh_glasses
+            + ShaderManager.veh_decals
+            + ShaderManager.shadow_proxies
+        )
 
     def cutout_shaders():
-        return ShaderManager.cutouts + ShaderManager.veh_cutouts + ShaderManager.shadow_proxies
+        return (
+            ShaderManager.cutouts
+            + ShaderManager.veh_cutouts
+            + ShaderManager.shadow_proxies
+        )
 
     @staticmethod
     def load_shaders():

--- a/cwxml/ymap.py
+++ b/cwxml/ymap.py
@@ -20,7 +20,6 @@ from .element import (
 
 
 class YMAP:
-
     file_extension = ".ymap.xml"
 
     @staticmethod
@@ -33,17 +32,17 @@ class YMAP:
 
 
 class HexColorProperty(ElementProperty):
-    value_types = (tuple)
+    value_types = tuple
 
     def __init__(self, tag_name=None, value=None):
         super().__init__(tag_name or "color", value or (0, 0, 0, 0))
 
     def hex_to_rgb(hex: str) -> tuple:
         hex = hex.replace("0x", "")
-        return tuple(int(hex[i:i + 2], 16) / 255 for i in (0, 2, 4, 6))
+        return tuple(int(hex[i : i + 2], 16) / 255 for i in (0, 2, 4, 6))
 
     def rgb_to_hex(rgb: tuple) -> str:
-        return ('{:02X}{:02X}{:02X}{:02X}').format(*[int(x * 255) for x in rgb])
+        return ("{:02X}{:02X}{:02X}{:02X}").format(*[int(x * 255) for x in rgb])
 
     @staticmethod
     def from_xml(element: ET.Element):
@@ -204,12 +203,10 @@ class ExtensionExpression(Extension):
 
     def __init__(self):
         super().__init__()
-        self.expression_dictionary_name = TextProperty(
-            "expressionDictionaryName")
+        self.expression_dictionary_name = TextProperty("expressionDictionaryName")
         self.expression_name = TextProperty("expressionName")
         self.creature_metadata_name = TextProperty("creatureMetadataname")
-        self.intialize_on_collision = ValueProperty(
-            "initialiseOnCollision", False)
+        self.intialize_on_collision = ValueProperty("initialiseOnCollision", False)
 
 
 class ExtensionLightShaft(Extension):
@@ -239,8 +236,7 @@ class ExtensionLightShaft(Extension):
         # CExtensionDefLightShaftVolumeType
         self.volume_type = TextProperty("volumeType")
         self.softness = ValueProperty("softness")
-        self.scale_by_sun_intensity = ValueProperty(
-            "scaleBySunIntensity", False)
+        self.scale_by_sun_intensity = ValueProperty("scaleBySunIntensity", False)
 
 
 class ExtensionDoor(Extension):
@@ -333,7 +329,9 @@ class ExtensionsList(ListProperty):
     tag_name = "extensions"
 
     @staticmethod
-    def get_extension_xml_class_from_type(ext_type: str) -> Union[Type[Extension], None]:
+    def get_extension_xml_class_from_type(
+        ext_type: str,
+    ) -> Union[Type[Extension], None]:
         if ext_type == ExtensionLightEffect.type:
             return ExtensionLightEffect
         elif ext_type == ExtensionParticleEffect.type:
@@ -372,8 +370,7 @@ class ExtensionsList(ListProperty):
         for child in element.iter():
             if "type" in child.attrib:
                 ext_type = child.get("type")
-                ext_class = ExtensionsList.get_extension_xml_class_from_type(
-                    ext_type)
+                ext_class = ExtensionsList.get_extension_xml_class_from_type(ext_type)
 
                 if ext_class is None:
                     print(f"Unknown extension type '{ext_type}'! Skipping...")
@@ -405,9 +402,11 @@ class Entity(ElementTree):
         self.priority_level = TextProperty("priorityLevel")
         self.extensions = ExtensionsList()
         self.ambient_occlusion_multiplier = ValueProperty(
-            "ambientOcclusionMultiplier", 0)
+            "ambientOcclusionMultiplier", 0
+        )
         self.artificial_ambient_occlusion = ValueProperty(
-            "artificialAmbientOcclusion", 0)
+            "artificialAmbientOcclusion", 0
+        )
         self.tint_value = ValueProperty("tintValue", 0)
 
 
@@ -418,12 +417,12 @@ class EntityList(ListPropertyRequired):
 
 class ContainerLodsList(ElementTree):
     """This is not used by GTA5 but added for completion"""
+
     tag_name = "containerLods"
 
     def __init__(self):
         super().__init__()
-        self.item_type = AttributeProperty(
-            "itemType", "rage__fwContainerLodDef")
+        self.item_type = AttributeProperty("itemType", "rage__fwContainerLodDef")
 
 
 class BoxOccluder(ElementTree):
@@ -453,7 +452,8 @@ class BoxOccludersList(ListPropertyRequired):
 class OccludeModel(ElementTree):
     class VertsProperty(ElementProperty):
         """Same as a TextProperty but formats the input and output and returns an empty element rather than None"""
-        value_types = (str)
+
+        value_types = str
 
         def __init__(self, tag_name: str = "verts", value=None):
             super().__init__(tag_name, value or "")
@@ -463,7 +463,8 @@ class OccludeModel(ElementTree):
             text = element.text.replace("\n", "").replace(" ", "")
             if not text:
                 raise ValueError(
-                    f'Missing verts data on {OccludeModel.VertsProperty.__name__}')
+                    f"Missing verts data on {OccludeModel.VertsProperty.__name__}"
+                )
             return OccludeModel.VertsProperty(element.tag, text)
 
         def to_xml(self):
@@ -472,9 +473,12 @@ class OccludeModel(ElementTree):
                 return element
 
             text = []
-            for chunk in [self.value[i:i + 64] for i in range(0, len(self.value), 64)]:
-                text.append(" ".join([chunk[j:j + 2]
-                            for j in range(0, len(chunk), 2)]))
+            for chunk in [
+                self.value[i : i + 64] for i in range(0, len(self.value), 64)
+            ]:
+                text.append(
+                    " ".join([chunk[j : j + 2] for j in range(0, len(chunk), 2)])
+                )
                 text.append("\n")
             element.text = "".join(text)
 
@@ -506,6 +510,7 @@ class PhysicsDictionariesList(ListProperty):
     """
     Same as ListPropertyRequired but only accepts items of type TextProperty.
     """
+
     class PhysicsDictionarie(TextProperty):
         tag_name = "Item"
 
@@ -525,7 +530,8 @@ class PhysicsDictionariesList(ListProperty):
                     element.append(item.to_xml())
                 else:
                     raise TypeError(
-                        f"{type(self).__name__} can only hold objects of type '{self.list_type.__name__}', not '{type(item)}'")
+                        f"{type(self).__name__} can only hold objects of type '{self.list_type.__name__}', not '{type(item)}'"
+                    )
 
         return element
 

--- a/cwxml/ytyp.py
+++ b/cwxml/ytyp.py
@@ -7,14 +7,13 @@ from .element import (
     QuaternionProperty,
     TextProperty,
     ValueProperty,
-    VectorProperty
+    VectorProperty,
 )
 from .ymap import EntityList, ExtensionsList
 from numpy import float32
 
 
 class YTYP:
-
     file_extension = ".ytyp.xml"
 
     @staticmethod
@@ -58,7 +57,7 @@ class TimeArchetype(BaseArchetype):
 
 
 class Corner(ElementProperty):
-    value_types = (tuple)
+    value_types = tuple
     tag_name = "Item"
 
     def __init__(self, tag_name=None, value=None):
@@ -87,7 +86,7 @@ class CornersList(ListProperty):
 
 
 class AttachedObjectsBuffer(ElementProperty):
-    value_types = (int)
+    value_types = int
 
     def __init__(self):
         super().__init__(tag_name="attachedObjects", value=[])
@@ -156,8 +155,7 @@ class Room(ElementTree):
         self.flags = ValueProperty("flags")
         self.portal_count = ValueProperty("portalCount")
         self.floor_id = ValueProperty("floorId")
-        self.exterior_visibility_depth = ValueProperty(
-            "exteriorVisibiltyDepth", -1)
+        self.exterior_visibility_depth = ValueProperty("exteriorVisibiltyDepth", -1)
         self.attached_objects = AttachedObjectsBuffer()
 
 
@@ -171,7 +169,7 @@ class RoomsList(ListProperty):
 
 
 class LocationsBuffer(ElementProperty):
-    value_types = (int)
+    value_types = int
 
     def __init__(self):
         super().__init__(tag_name="locations", value=[])

--- a/icons.py
+++ b/icons.py
@@ -23,7 +23,7 @@ class IconManager:
         pcoll = bpy.utils.previews.new()
         for icon_name in self._icons:
             icon_path = path / f"{icon_name}{ICON_EXT}"
-            pcoll.load(icon_name, str(icon_path), 'IMAGE')
+            pcoll.load(icon_name, str(icon_path), "IMAGE")
         self._preview_collections[PREVIEW_COLLECTION_NAME] = pcoll
 
     def load_icon(self, name: str) -> int:
@@ -53,6 +53,7 @@ class IconManager:
 icon_manager = IconManager(ICON_DIR)
 
 ICON_GEOM_TOOL = str(ICON_DIR / "sollumz.tool")
+
 
 def register():
     pass  # Icons are already loaded during the instantiation of icon_manager

--- a/lods.py
+++ b/lods.py
@@ -1,7 +1,16 @@
 """LOD Management system."""
 import bpy
 from typing import Callable, Optional
-from .sollumz_properties import SollumType, LODLevel, FRAGMENT_TYPES, DRAWABLE_TYPES, SOLLUMZ_UI_NAMES, BOUND_TYPES, BOUND_POLYGON_TYPES, items_from_enums
+from .sollumz_properties import (
+    SollumType,
+    LODLevel,
+    FRAGMENT_TYPES,
+    DRAWABLE_TYPES,
+    SOLLUMZ_UI_NAMES,
+    BOUND_TYPES,
+    BOUND_POLYGON_TYPES,
+    items_from_enums,
+)
 from .tools.blenderhelper import get_all_collections, lod_level_enum_flag_prop_factory
 from .sollumz_helper import find_sollumz_parent
 from .icons import icon_manager
@@ -21,10 +30,8 @@ class ObjectLODProps(bpy.types.PropertyGroup):
             if obj.name in context.view_layer.objects:
                 obj.hide_set(True)
 
-    level: bpy.props.EnumProperty(
-        items=items_from_enums(LODLevel))
-    mesh: bpy.props.PointerProperty(
-        type=bpy.types.Mesh, update=update_mesh)
+    level: bpy.props.EnumProperty(items=items_from_enums(LODLevel))
+    mesh: bpy.props.PointerProperty(type=bpy.types.Mesh, update=update_mesh)
 
 
 class LODLevels(bpy.types.PropertyGroup):
@@ -33,13 +40,17 @@ class LODLevels(bpy.types.PropertyGroup):
             if lod.level == lod_level:
                 return lod
 
-    def set_lod_mesh(self, lod_level: str, mesh: bpy.types.Mesh) -> ObjectLODProps | None:
+    def set_lod_mesh(
+        self, lod_level: str, mesh: bpy.types.Mesh
+    ) -> ObjectLODProps | None:
         for lod in self.lods:
             if lod.level == lod_level:
                 lod.mesh = mesh
                 return lod
 
-    def add_lod(self, lod_level: str, mesh: Optional[bpy.types.Mesh] = None) -> ObjectLODProps | None:
+    def add_lod(
+        self, lod_level: str, mesh: Optional[bpy.types.Mesh] = None
+    ) -> ObjectLODProps | None:
         # Can't have multiple lods with the same type
         if self.get_lod(lod_level):
             return None
@@ -55,8 +66,13 @@ class LODLevels(bpy.types.PropertyGroup):
         return obj_lod
 
     def set_highest_lod_active(self):
-        lod_levels = [LODLevel.VERYHIGH, LODLevel.HIGH,
-                      LODLevel.MEDIUM, LODLevel.LOW, LODLevel.VERYLOW]
+        lod_levels = [
+            LODLevel.VERYHIGH,
+            LODLevel.HIGH,
+            LODLevel.MEDIUM,
+            LODLevel.LOW,
+            LODLevel.VERYLOW,
+        ]
 
         for lod_level in lod_levels:
             lod = self.get_lod(lod_level)
@@ -87,12 +103,12 @@ class LODLevels(bpy.types.PropertyGroup):
             return self.lods[self.active_lod_index]
 
     lods: bpy.props.CollectionProperty(type=ObjectLODProps)
-    active_lod_index: bpy.props.IntProperty(
-        min=0, update=update_active_lod)
+    active_lod_index: bpy.props.IntProperty(min=0, update=update_active_lod)
 
 
 class SetLodLevelHelper:
     """Helper class for setting the LOD level of Sollumz objects."""
+
     LOD_LEVEL: LODLevel = LODLevel.HIGH
     bl_description = "Set the viewing level for the selected Fragment/Drawable"
 
@@ -160,7 +176,11 @@ class SOLLUMZ_OT_HIDE_OBJECT(bpy.types.Operator, SetLodLevelHelper):
 
         for child in obj.children_recursive:
             active_lod = child.sollumz_lods.active_lod
-            if child.sollum_type != SollumType.DRAWABLE_MODEL or not active_lod or active_lod.mesh is None:
+            if (
+                child.sollum_type != SollumType.DRAWABLE_MODEL
+                or not active_lod
+                or active_lod.mesh is None
+            ):
                 continue
 
             child.hide_set(do_hide)
@@ -246,7 +266,8 @@ class SOLLUMZ_OT_copy_lod(bpy.types.Operator):
 
             if lod.mesh is not None:
                 self.report(
-                    {"INFO"}, f"{SOLLUMZ_UI_NAMES[lod_level]} already has a mesh!")
+                    {"INFO"}, f"{SOLLUMZ_UI_NAMES[lod_level]} already has a mesh!"
+                )
                 return {"CANCELLED"}
 
             lod.mesh = active_lod.mesh.copy()
@@ -261,7 +282,15 @@ class SOLLUMZ_UL_OBJ_LODS_LIST(bpy.types.UIList):
     bl_idname = "SOLLUMZ_UL_OBJ_LODS_LIST"
 
     def draw_item(
-        self, context, layout: bpy.types.UILayout, data, item, icon, active_data, active_propname, index
+        self,
+        context,
+        layout: bpy.types.UILayout,
+        data,
+        item,
+        icon,
+        active_data,
+        active_propname,
+        index,
     ):
         col = layout.column()
         col.scale_x = 0.35
@@ -281,7 +310,11 @@ class SOLLUMZ_PT_LOD_LEVEL_PANEL(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         active_obj = context.view_layer.objects.active
-        return active_obj is not None and active_obj.type == "MESH" and active_obj.sollum_type in [*FRAGMENT_TYPES, *DRAWABLE_TYPES]
+        return (
+            active_obj is not None
+            and active_obj.type == "MESH"
+            and active_obj.sollum_type in [*FRAGMENT_TYPES, *DRAWABLE_TYPES]
+        )
 
     def draw_header(self, context):
         icon_manager.icon_label("sollumz_icon", self)
@@ -294,7 +327,12 @@ class SOLLUMZ_PT_LOD_LEVEL_PANEL(bpy.types.Panel):
 
         row = layout.row()
         row.template_list(
-            SOLLUMZ_UL_OBJ_LODS_LIST.bl_idname, "", active_obj.sollumz_lods, "lods", active_obj.sollumz_lods, "active_lod_index"
+            SOLLUMZ_UL_OBJ_LODS_LIST.bl_idname,
+            "",
+            active_obj.sollumz_lods,
+            "lods",
+            active_obj.sollumz_lods,
+            "active_lod_index",
         )
 
         row.operator("sollumz.copy_lod", icon="COPYDOWN", text="")
@@ -303,7 +341,9 @@ class SOLLUMZ_PT_LOD_LEVEL_PANEL(bpy.types.Panel):
 def set_collision_visibility(is_visible: bool):
     """Set visibility of all collision objects in the scene"""
     for obj in bpy.context.view_layer.objects:
-        obj_is_collision = obj.sollum_type in BOUND_TYPES or obj.sollum_type in BOUND_POLYGON_TYPES
+        obj_is_collision = (
+            obj.sollum_type in BOUND_TYPES or obj.sollum_type in BOUND_POLYGON_TYPES
+        )
 
         if not obj_is_collision:
             continue
@@ -335,6 +375,7 @@ def operates_on_lod_level(func: Callable):
     """Decorator for functions that operate on a particular LOD level of an object.
     Will automatically set the LOD level to ``lod_level`` at the beginning of execution
     and will set it back to the original LOD level at the end."""
+
     def wrapper(model_obj: bpy.types.Object, lod_level: LODLevel, *args, **kwargs):
         current_lod_level = model_obj.sollumz_lods.active_lod.level
 
@@ -353,15 +394,13 @@ def operates_on_lod_level(func: Callable):
 
 
 def register():
-    bpy.types.Object.sollumz_lods = bpy.props.PointerProperty(
-        type=LODLevels)
+    bpy.types.Object.sollumz_lods = bpy.props.PointerProperty(type=LODLevels)
     bpy.types.Object.sollumz_obj_is_hidden = bpy.props.BoolProperty()
-    bpy.types.Scene.sollumz_show_collisions = bpy.props.BoolProperty(
-        default=True)
-    bpy.types.Scene.sollumz_show_shattermaps = bpy.props.BoolProperty(
-        default=True)
+    bpy.types.Scene.sollumz_show_collisions = bpy.props.BoolProperty(default=True)
+    bpy.types.Scene.sollumz_show_shattermaps = bpy.props.BoolProperty(default=True)
     bpy.types.Scene.sollumz_copy_lod_level = bpy.props.EnumProperty(
-        items=items_from_enums(LODLevel))
+        items=items_from_enums(LODLevel)
+    )
 
 
 def unregister():

--- a/logger.py
+++ b/logger.py
@@ -6,7 +6,9 @@ from bpy.types import Operator
 from typing import Optional
 
 _logging_operator: Optional[Operator] = None
-_NO_LOGGING_OPERATOR_WARNING = "LOGGER WARNING: No active logging operator has been set!"
+_NO_LOGGING_OPERATOR_WARNING = (
+    "LOGGER WARNING: No active logging operator has been set!"
+)
 
 
 def _log(msg: str, level: str):

--- a/sollumz_helper.py
+++ b/sollumz_helper.py
@@ -34,12 +34,14 @@ class SOLLUMZ_OT_base:
         except:
             result = False
             self.error(
-                f"Error occured running operator : {self.bl_idname} \n {traceback.format_exc()}")
+                f"Error occured running operator : {self.bl_idname} \n {traceback.format_exc()}"
+            )
         end = time.time()
 
         if self.bl_showtime and result == True:
             self.message(
-                f"{self.bl_label} took {round(end - start, 3)} seconds to {self.bl_action}.")
+                f"{self.bl_label} took {round(end - start, 3)} seconds to {self.bl_action}."
+            )
 
         if len(self.messages) > 0:
             self.message("\n".join(self.messages))
@@ -112,12 +114,24 @@ def duplicate_object_with_children(obj):
     return new_objs[0]
 
 
-def find_sollumz_parent(obj: bpy.types.Object, parent_type: Optional[SollumType] = None) -> bpy.types.Object | None:
+def find_sollumz_parent(
+    obj: bpy.types.Object, parent_type: Optional[SollumType] = None
+) -> bpy.types.Object | None:
     """Find parent Fragment or Drawable if one exists. Returns None otherwise."""
-    parent_types = [SollumType.FRAGMENT, SollumType.DRAWABLE, SollumType.DRAWABLE_DICTIONARY,
-                    SollumType.CLIP_DICTIONARY, SollumType.YMAP, *BOUND_TYPES]
+    parent_types = [
+        SollumType.FRAGMENT,
+        SollumType.DRAWABLE,
+        SollumType.DRAWABLE_DICTIONARY,
+        SollumType.CLIP_DICTIONARY,
+        SollumType.YMAP,
+        *BOUND_TYPES,
+    ]
 
-    if parent_type is not None and obj.parent is not None and obj.parent.sollum_type == parent_type:
+    if (
+        parent_type is not None
+        and obj.parent is not None
+        and obj.parent.sollum_type == parent_type
+    ):
         return obj.parent
 
     if obj.parent is None and obj.sollum_type in parent_types:

--- a/sollumz_operators.py
+++ b/sollumz_operators.py
@@ -8,7 +8,14 @@ import re
 from bpy_extras.io_utils import ImportHelper
 from mathutils import Matrix, Quaternion
 from .sollumz_helper import SOLLUMZ_OT_base, find_sollumz_parent
-from .sollumz_properties import SollumType, SOLLUMZ_UI_NAMES, BOUND_TYPES, TimeFlags, ArchetypeType, LODLevel
+from .sollumz_properties import (
+    SollumType,
+    SOLLUMZ_UI_NAMES,
+    BOUND_TYPES,
+    TimeFlags,
+    ArchetypeType,
+    LODLevel,
+)
 from .sollumz_preferences import get_export_settings
 from .cwxml.drawable import YDR, YDD
 from .cwxml.fragment import YFT
@@ -30,7 +37,14 @@ from .ycd.ycdimport import import_ycd
 from .ycd.ycdexport import export_ycd
 from .ymap.ymapimport import import_ymap
 from .ymap.ymapexport import export_ymap
-from .tools.blenderhelper import add_child_of_bone_constraint, get_child_of_pose_bone, get_terrain_texture_brush, remove_number_suffix, create_blender_object, join_objects
+from .tools.blenderhelper import (
+    add_child_of_bone_constraint,
+    get_child_of_pose_bone,
+    get_terrain_texture_brush,
+    remove_number_suffix,
+    create_blender_object,
+    join_objects,
+)
 from .tools.ytyphelper import ytyp_from_objects
 from .ybn.properties import BoundProperties
 from .ybn.properties import BoundFlags
@@ -57,6 +71,7 @@ class TimedOperator:
 
 class SOLLUMZ_OT_import(bpy.types.Operator, ImportHelper, TimedOperator):
     """Imports xml files exported by codewalker"""
+
     bl_idname = "sollumz.import"
     bl_label = "Import Codewalker XML"
     bl_options = {"UNDO"}
@@ -64,7 +79,7 @@ class SOLLUMZ_OT_import(bpy.types.Operator, ImportHelper, TimedOperator):
     files: bpy.props.CollectionProperty(
         name="File Path",
         type=bpy.types.OperatorFileListElement,
-        options={"HIDDEN", "SKIP_SAVE"}
+        options={"HIDDEN", "SKIP_SAVE"},
     )
 
     filter_glob: bpy.props.StringProperty(
@@ -88,7 +103,6 @@ class SOLLUMZ_OT_import(bpy.types.Operator, ImportHelper, TimedOperator):
             filepath = os.path.join(directory, file.name)
 
             try:
-
                 if YDR.file_extension in filepath:
                     import_ydr(filepath)
                 elif YDD.file_extension in filepath:
@@ -108,19 +122,21 @@ class SOLLUMZ_OT_import(bpy.types.Operator, ImportHelper, TimedOperator):
 
                 self.report({"INFO"}, f"Successfully imported '{filepath}'")
             except:
-                self.report({"ERROR"},
-                            f"Error importing: {filepath} \n {traceback.format_exc()}")
+                self.report(
+                    {"ERROR"},
+                    f"Error importing: {filepath} \n {traceback.format_exc()}",
+                )
 
                 return {"CANCELLED"}
 
-        self.report(
-            {"INFO"}, f"Imported in {self.time_elapsed} seconds")
+        self.report({"INFO"}, f"Imported in {self.time_elapsed} seconds")
 
         return {"FINISHED"}
 
 
 class SOLLUMZ_OT_export(bpy.types.Operator, TimedOperator):
     """Exports codewalker xml files"""
+
     bl_idname = "sollumz.export"
     bl_label = "Export Codewalker XML"
 
@@ -134,13 +150,13 @@ class SOLLUMZ_OT_export(bpy.types.Operator, TimedOperator):
         name="Output directory",
         description="Select export output directory",
         subtype="DIR_PATH",
-        options={"HIDDEN"}
+        options={"HIDDEN"},
     )
 
     direct_export: bpy.props.BoolProperty(
         name="Direct Export",
         description="Export directly to the output directory without opening the directory selection dialog.",
-        options={"HIDDEN", "SKIP_SAVE"}
+        options={"HIDDEN", "SKIP_SAVE"},
     )
 
     def draw(self, context):
@@ -160,11 +176,9 @@ class SOLLUMZ_OT_export(bpy.types.Operator, TimedOperator):
 
         if not objs:
             if export_settings.limit_to_selected:
-                self.report(
-                    {"INFO"}, "No Sollumz objects selected for export!")
+                self.report({"INFO"}, "No Sollumz objects selected for export!")
             else:
-                self.report(
-                    {"INFO"}, "No Sollumz objects in the scene to export!")
+                self.report({"INFO"}, "No Sollumz objects in the scene to export!")
 
             return {"CANCELLED"}
 
@@ -196,21 +210,22 @@ class SOLLUMZ_OT_export(bpy.types.Operator, TimedOperator):
                 if success:
                     self.report({"INFO"}, f"Successfully exported '{filepath}'")
             except:
-                self.report({"ERROR"},
-                            f"Error exporting: {filepath or obj.name} \n {traceback.format_exc()}")
+                self.report(
+                    {"ERROR"},
+                    f"Error exporting: {filepath or obj.name} \n {traceback.format_exc()}",
+                )
 
                 return {"CANCELLED"}
 
             if export_settings.export_with_ytyp:
                 ytyp = ytyp_from_objects(objs)
-                filepath = os.path.join(
-                    self.directory, f"{ytyp.name}.ytyp.xml")
+                filepath = os.path.join(self.directory, f"{ytyp.name}.ytyp.xml")
                 ytyp.write_xml(filepath)
                 self.report(
-                    {"INFO"}, f"Successfully exported '{filepath}' (auto-generated)")
+                    {"INFO"}, f"Successfully exported '{filepath}' (auto-generated)"
+                )
 
-        self.report(
-            {"INFO"}, f"Exported in {self.time_elapsed} seconds")
+        self.report({"INFO"}, f"Exported in {self.time_elapsed} seconds")
 
         return {"FINISHED"}
 
@@ -246,16 +261,13 @@ class SOLLUMZ_OT_export(bpy.types.Operator, TimedOperator):
 
 class SOLLUMZ_OT_paint_vertices(SOLLUMZ_OT_base, bpy.types.Operator):
     """Paint All Vertices Of Selected Object"""
+
     bl_idname = "sollumz.paint_vertices"
     bl_label = "Paint"
     bl_action = "Paint Vertices"
 
     color: bpy.props.FloatVectorProperty(
-        subtype="COLOR_GAMMA",
-        default=(1.0, 1.0, 1.0, 1.0),
-        min=0,
-        max=1,
-        size=4
+        subtype="COLOR_GAMMA", default=(1.0, 1.0, 1.0, 1.0), min=0, max=1, size=4
     )
 
     def paint_map(self, color_attr, color):
@@ -266,7 +278,7 @@ class SOLLUMZ_OT_paint_vertices(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def paint_mesh(self, mesh, color):
         if not mesh.color_attributes:
-            mesh.color_attributes.new("Color", 'BYTE_COLOR', 'CORNER')
+            mesh.color_attributes.new("Color", "BYTE_COLOR", "CORNER")
         self.paint_map(mesh.attributes.active_color, color)
 
     def run(self, context):
@@ -276,11 +288,11 @@ class SOLLUMZ_OT_paint_vertices(SOLLUMZ_OT_base, bpy.types.Operator):
             for obj in objs:
                 if obj.sollum_type == SollumType.DRAWABLE_MODEL:
                     self.paint_mesh(obj.data, self.color)
-                    self.messages.append(
-                        f"{obj.name} was successfully painted.")
+                    self.messages.append(f"{obj.name} was successfully painted.")
                 else:
                     self.messages.append(
-                        f"{obj.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_MODEL]} type.")
+                        f"{obj.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_MODEL]} type."
+                    )
         else:
             self.message("No objects selected to paint.")
             return False
@@ -290,6 +302,7 @@ class SOLLUMZ_OT_paint_vertices(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_paint_terrain_tex1(SOLLUMZ_OT_base, bpy.types.Operator):
     """Paint Texture 1 On Selected Object"""
+
     bl_idname = "sollumz.paint_tex1"
     bl_label = "Paint Texture 1"
 
@@ -300,6 +313,7 @@ class SOLLUMZ_OT_paint_terrain_tex1(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_paint_terrain_tex2(SOLLUMZ_OT_base, bpy.types.Operator):
     """Paint Texture 2 On Selected Object"""
+
     bl_idname = "sollumz.paint_tex2"
     bl_label = "Paint Texture 2"
 
@@ -310,6 +324,7 @@ class SOLLUMZ_OT_paint_terrain_tex2(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_paint_terrain_tex3(SOLLUMZ_OT_base, bpy.types.Operator):
     """Paint Texture 3 On Selected Object"""
+
     bl_idname = "sollumz.paint_tex3"
     bl_label = "Paint Texture 3"
 
@@ -320,6 +335,7 @@ class SOLLUMZ_OT_paint_terrain_tex3(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_paint_terrain_tex4(SOLLUMZ_OT_base, bpy.types.Operator):
     """Paint Texture 4 On Selected Object"""
+
     bl_idname = "sollumz.paint_tex4"
     bl_label = "Paint Texture 4"
 
@@ -330,6 +346,7 @@ class SOLLUMZ_OT_paint_terrain_tex4(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_paint_terrain_alpha(SOLLUMZ_OT_base, bpy.types.Operator):
     """Paint Lookup Sampler Alpha On Selected Object"""
+
     bl_idname = "sollumz.paint_a"
     bl_label = "Paint Alpha"
 
@@ -340,6 +357,7 @@ class SOLLUMZ_OT_paint_terrain_alpha(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SelectTimeFlagsRange(SOLLUMZ_OT_base):
     """Select range of time flags"""
+
     bl_label = "Select"
 
     def get_flags(self, context):
@@ -369,6 +387,7 @@ class SelectTimeFlagsRange(SOLLUMZ_OT_base):
 
 class ClearTimeFlags(SOLLUMZ_OT_base):
     """Clear all time flags"""
+
     bl_label = "Clear Selection"
 
     def get_flags(self, context):
@@ -385,17 +404,22 @@ class ClearTimeFlags(SOLLUMZ_OT_base):
 
 
 def sollumz_menu_func_import(self, context):
-    self.layout.operator(SOLLUMZ_OT_import.bl_idname,
-                         text=f"Codewalker XML({YDR.file_extension}, {YDD.file_extension}, {YFT.file_extension}, {YBN.file_extension}, {YCD.file_extension})")
+    self.layout.operator(
+        SOLLUMZ_OT_import.bl_idname,
+        text=f"Codewalker XML({YDR.file_extension}, {YDD.file_extension}, {YFT.file_extension}, {YBN.file_extension}, {YCD.file_extension})",
+    )
 
 
 def sollumz_menu_func_export(self, context):
-    self.layout.operator(SOLLUMZ_OT_export.bl_idname,
-                         text=f"Codewalker XML({YDR.file_extension}, {YDD.file_extension}, {YFT.file_extension}, {YBN.file_extension}, {YCD.file_extension})")
+    self.layout.operator(
+        SOLLUMZ_OT_export.bl_idname,
+        text=f"Codewalker XML({YDR.file_extension}, {YDD.file_extension}, {YFT.file_extension}, {YBN.file_extension}, {YCD.file_extension})",
+    )
 
 
 class SOLLUMZ_OT_debug_hierarchy(bpy.types.Operator):
     """Debug: Fix incorrect Sollum Type after update. Must set correct type for top-level object first."""
+
     bl_idname = "sollumz.debug_hierarchy"
     bl_label = "Fix Hierarchy"
     bl_options = {"UNDO"}
@@ -405,8 +429,7 @@ class SOLLUMZ_OT_debug_hierarchy(bpy.types.Operator):
         sollum_type = context.scene.debug_sollum_type
         for obj in context.selected_objects:
             if len(obj.children) < 1:
-                self.report(
-                    {"INFO"}, f"{obj.name} has no children! Skipping...")
+                self.report({"INFO"}, f"{obj.name} has no children! Skipping...")
                 continue
 
             obj.sollum_type = sollum_type
@@ -482,12 +505,19 @@ class SOLLUMZ_OT_debug_fix_light_intensity(bpy.types.Operator):
         only_selected = context.scene.debug_lights_only_selected
 
         objects = context.selected_objects if only_selected else context.scene.objects
-        light_objs = [obj for obj in objects if obj.type ==
-                      "LIGHT" and obj.sollum_type == SollumType.LIGHT]
+        light_objs = [
+            obj
+            for obj in objects
+            if obj.type == "LIGHT" and obj.sollum_type == SollumType.LIGHT
+        ]
 
         if not light_objs:
             self.report(
-                {"INFO"}, "No Sollumz lights selected" if only_selected else "No Sollumz lights in the scene.")
+                {"INFO"},
+                "No Sollumz lights selected"
+                if only_selected
+                else "No Sollumz lights in the scene.",
+            )
             return {"CANCELLED"}
 
         lights: list[bpy.types.Light] = []
@@ -503,33 +533,34 @@ class SOLLUMZ_OT_debug_fix_light_intensity(bpy.types.Operator):
 
 class SOLLUMZ_OT_copy_location(bpy.types.Operator):
     """Copy the location of an object to the clipboard"""
+
     bl_idname = "wm.sollumz_copy_location"
     bl_label = ""
     location: bpy.props.StringProperty()
 
     def execute(self, context):
         bpy.context.window_manager.clipboard = self.location
-        self.report(
-            {'INFO'}, "Location copied to clipboard: {}".format(self.location))
-        return {'FINISHED'}
+        self.report({"INFO"}, "Location copied to clipboard: {}".format(self.location))
+        return {"FINISHED"}
 
 
 class SOLLUMZ_OT_copy_rotation(bpy.types.Operator):
     """Copy the quaternion rotation of an object to the clipboard"""
+
     bl_idname = "wm.sollumz_copy_rotation"
     bl_label = ""
     rotation: bpy.props.StringProperty()
 
     def execute(self, context):
-        rotation = self.rotation.strip('[]')
+        rotation = self.rotation.strip("[]")
         bpy.context.window_manager.clipboard = rotation
-        self.report(
-            {'INFO'}, "Rotation copied to clipboard: {}".format(rotation))
-        return {'FINISHED'}
+        self.report({"INFO"}, "Rotation copied to clipboard: {}".format(rotation))
+        return {"FINISHED"}
 
 
 class SOLLUMZ_OT_paste_location(bpy.types.Operator):
     """Paste the location of an object from the clipboard"""
+
     bl_idname = "wm.sollumz_paste_location"
     bl_label = ""
 
@@ -549,19 +580,20 @@ class SOLLUMZ_OT_paste_location(bpy.types.Operator):
             selected_object = bpy.context.object
 
             selected_object.location = location
-            self.report({'INFO'}, "Location set successfully.")
+            self.report({"INFO"}, "Location set successfully.")
         else:
-            self.report({'ERROR'}, "Invalid location string.")
+            self.report({"ERROR"}, "Invalid location string.")
 
-        return {'FINISHED'}
-    
+        return {"FINISHED"}
+
+
 class SOLLUMZ_OT_paste_rotation(bpy.types.Operator):
     """Paste the rotation (as quaternion) of an object from the clipboard and apply it"""
+
     bl_idname = "wm.sollumz_paste_rotation"
     bl_label = "Paste Rotation"
 
     def execute(self, context):
-
         rotation_string = bpy.context.window_manager.clipboard
 
         rotation_quaternion = parse_rotation_string(rotation_string)
@@ -577,6 +609,7 @@ class SOLLUMZ_OT_paste_rotation(bpy.types.Operator):
         else:
             self.report({"ERROR"}, "Invalid rotation quaternion string.")
         return {"FINISHED"}
+
 
 def parse_rotation_string(rotation_string):
     values = rotation_string.split(",")
@@ -617,13 +650,17 @@ class SOLLUMZ_OT_debug_reload_entity_sets(bpy.types.Operator):
 
 class SOLLUMZ_OT_debug_migrate_drawable_models(bpy.types.Operator):
     """Convert old drawable model to use new LOD system"""
+
     bl_idname = "sollumz.migratedrawable"
     bl_label = "Migrate Drawable Model(s)"
     bl_options = {"UNDO"}
 
     def execute(self, context):
         selected_models = [
-            obj for obj in context.selected_objects if obj.sollum_type == SollumType.DRAWABLE_MODEL]
+            obj
+            for obj in context.selected_objects
+            if obj.sollum_type == SollumType.DRAWABLE_MODEL
+        ]
 
         if not selected_models:
             self.report({"INFO"}, "No drawable models selected!")
@@ -631,12 +668,10 @@ class SOLLUMZ_OT_debug_migrate_drawable_models(bpy.types.Operator):
 
         parent = selected_models[0].parent
 
-        models_by_lod: dict[LODLevel,
-                            list[bpy.types.Object]] = defaultdict(list)
+        models_by_lod: dict[LODLevel, list[bpy.types.Object]] = defaultdict(list)
 
         for obj in selected_models:
-            models_by_lod[obj.drawable_model_properties.sollum_lod].extend(
-                obj.children)
+            models_by_lod[obj.drawable_model_properties.sollum_lod].extend(obj.children)
             bpy.data.objects.remove(obj)
 
         model_obj = create_blender_object(SollumType.DRAWABLE_MODEL)
@@ -644,7 +679,6 @@ class SOLLUMZ_OT_debug_migrate_drawable_models(bpy.types.Operator):
         old_mesh = model_obj.data
 
         for lod_level, geometries in models_by_lod.items():
-
             if len(geometries) > 1:
                 joined_obj = join_objects(geometries)
             else:
@@ -656,7 +690,7 @@ class SOLLUMZ_OT_debug_migrate_drawable_models(bpy.types.Operator):
             context.view_layer.objects.active = joined_obj
             model_obj.select_set(True)
 
-            bpy.ops.object.make_links_data(type='MODIFIERS')
+            bpy.ops.object.make_links_data(type="MODIFIERS")
             bpy.data.objects.remove(joined_obj)
 
         bpy.data.meshes.remove(old_mesh)
@@ -664,7 +698,12 @@ class SOLLUMZ_OT_debug_migrate_drawable_models(bpy.types.Operator):
         model_obj.parent = parent
 
         # Set highest lod level
-        for lod_level in [LODLevel.HIGH, LODLevel.MEDIUM, LODLevel.LOW, LODLevel.VERYLOW]:
+        for lod_level in [
+            LODLevel.HIGH,
+            LODLevel.MEDIUM,
+            LODLevel.LOW,
+            LODLevel.VERYLOW,
+        ]:
             if model_obj.sollumz_lods.get_lod(lod_level) != None:
                 model_obj.sollumz_lods.set_active_lod(lod_level)
                 break
@@ -674,13 +713,17 @@ class SOLLUMZ_OT_debug_migrate_drawable_models(bpy.types.Operator):
 
 class SOLLUMZ_OT_debug_migrate_bound_geometries(bpy.types.Operator):
     """Convert old bound geometries to new hiearchy using shape keys for damaged layers"""
+
     bl_idname = "sollumz.migrateboundgeoms"
     bl_label = "Migrate Bound Geometry(s)"
     bl_options = {"UNDO"}
 
     def execute(self, context):
         selected = [
-            obj for obj in context.selected_objects if obj.sollum_type == SollumType.BOUND_GEOMETRY]
+            obj
+            for obj in context.selected_objects
+            if obj.sollum_type == SollumType.BOUND_GEOMETRY
+        ]
 
         if not selected:
             self.report({"INFO"}, "No bound geometries selected!")
@@ -722,7 +765,9 @@ class SOLLUMZ_OT_debug_migrate_bound_geometries(bpy.types.Operator):
 
         return {"FINISHED"}
 
-    def set_bound_geometry_properties(self, old_obj: bpy.types.Object, new_obj: bpy.types.Object):
+    def set_bound_geometry_properties(
+        self, old_obj: bpy.types.Object, new_obj: bpy.types.Object
+    ):
         for prop_name in BoundProperties.__annotations__.keys():
             value = getattr(old_obj.bound_properties, prop_name)
             setattr(new_obj.bound_properties, prop_name, value)
@@ -739,7 +784,9 @@ class SOLLUMZ_OT_debug_migrate_bound_geometries(bpy.types.Operator):
         set_flags("composite_flags1")
         set_flags("composite_flags2")
 
-    def set_shape_keys(self, bound_obj: bpy.types.Object, damaged_obj: bpy.types.Object):
+    def set_shape_keys(
+        self, bound_obj: bpy.types.Object, damaged_obj: bpy.types.Object
+    ):
         bound_obj.shape_key_add(name="Basis")
         deformed_key = bound_obj.shape_key_add(name="Deformed")
 
@@ -749,6 +796,7 @@ class SOLLUMZ_OT_debug_migrate_bound_geometries(bpy.types.Operator):
 
 class SOLLUMZ_OT_debug_replace_armature_constraints(bpy.types.Operator):
     """Replace the Armature constraints in all selected objects for Child Of constraints (for migrating pre version 0.3 projects)"""
+
     bl_idname = "sollumz.replace_armature_constraints"
     bl_label = "Replace Armature Constraints"
     bl_options = {"REGISTER", "UNDO"}
@@ -776,7 +824,9 @@ class SOLLUMZ_OT_debug_replace_armature_constraints(bpy.types.Operator):
         return {"FINISHED"}
 
     @staticmethod
-    def get_armature_constraint(obj: bpy.types.Object) -> Optional[bpy.types.ArmatureConstraint]:
+    def get_armature_constraint(
+        obj: bpy.types.Object,
+    ) -> Optional[bpy.types.ArmatureConstraint]:
         for constraint in obj.constraints:
             if constraint.type == "ARMATURE":
                 return constraint
@@ -796,6 +846,7 @@ class SOLLUMZ_OT_debug_replace_armature_constraints(bpy.types.Operator):
 
 class SOLLUMZ_OT_set_sollum_type(bpy.types.Operator):
     """Set the sollum type of all selected objects"""
+
     bl_idname = "sollumz.setsollumtype"
     bl_label = "Set Sollum Type"
 
@@ -806,13 +857,15 @@ class SOLLUMZ_OT_set_sollum_type(bpy.types.Operator):
             obj.sollum_type = sollum_type
 
         self.report(
-            {"INFO"}, f"Sollum Type successfuly set to {SOLLUMZ_UI_NAMES[sollum_type]}.")
+            {"INFO"}, f"Sollum Type successfuly set to {SOLLUMZ_UI_NAMES[sollum_type]}."
+        )
 
         return {"FINISHED"}
 
 
 class SearchEnumHelper:
     """Helper class for searching and setting enums"""
+
     bl_label = "Search"
 
     def get_data_block(self, context):
@@ -826,13 +879,13 @@ class SearchEnumHelper:
 
         setattr(data_block, prop_name, enum_value)
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     def invoke(self, context, event):
         wm = context.window_manager
         wm.invoke_search_popup(self)
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 def register():

--- a/sollumz_pie.py
+++ b/sollumz_pie.py
@@ -4,7 +4,7 @@ from bpy.types import Menu
 
 def find_missing_files(filepath):
     bpy.ops.file.find_missing_files(directory=filepath)
-    return {'FINISHED'}
+    return {"FINISHED"}
 
 
 class SOLLUMZ_MT_pie_menu(Menu):
@@ -12,36 +12,39 @@ class SOLLUMZ_MT_pie_menu(Menu):
     bl_label = "Sollumz Pie Menu"
 
     def draw(self, context):
-
         layout = self.layout
 
         pie = layout.menu_pie()
         # Left
-        pie.operator("sollumz.autoconvertmaterial",
-                     text="Convert Material", icon='NODE_MATERIAL')
+        pie.operator(
+            "sollumz.autoconvertmaterial", text="Convert Material", icon="NODE_MATERIAL"
+        )
         # Right
-        pie.operator("sollumz.addobjasentity", icon='OBJECT_DATA')
+        pie.operator("sollumz.addobjasentity", icon="OBJECT_DATA")
 
         # Bottom
-        pie.operator("sollumz.load_flag_preset",
-                     text="Apply Flag Preset", icon='ALIGN_TOP')
+        pie.operator(
+            "sollumz.load_flag_preset", text="Apply Flag Preset", icon="ALIGN_TOP"
+        )
         # Top
-        pie.operator("file.find_missing_files",
-                     text="Find Missing Textures", icon='VIEWZOOM')
+        pie.operator(
+            "file.find_missing_files", text="Find Missing Textures", icon="VIEWZOOM"
+        )
         # Top-left
-        pie.operator("sollumz.import",
-                     text="Import CodeWalker XML", icon='IMPORT')
+        pie.operator("sollumz.import", text="Import CodeWalker XML", icon="IMPORT")
         # Top-right
         if context.scene.sollumz_export_path != "":
-            op = pie.operator("sollumz.export", text="Export CodeWalker XML", icon='EXPORT')
+            op = pie.operator(
+                "sollumz.export", text="Export CodeWalker XML", icon="EXPORT"
+            )
             op.directory = context.scene.sollumz_export_path
             op.direct_export = True
         else:
-            pie.operator("sollumz.export", text="Export CodeWalker XML", icon='EXPORT')
+            pie.operator("sollumz.export", text="Export CodeWalker XML", icon="EXPORT")
         # Bottom-left
-        pie.operator("sollumz.converttodrawable", icon='CUBE')
+        pie.operator("sollumz.converttodrawable", icon="CUBE")
         # Bottom-right
-        pie.operator("sollumz.converttocomposite", icon='CUBE')
+        pie.operator("sollumz.converttocomposite", icon="CUBE")
 
 
 class SOLLUMZ_MT_view_pie_menu(Menu):
@@ -80,27 +83,27 @@ addon_keymaps = []
 
 
 def register():
-
     # Assigns default keybinding
     wm = bpy.context.window_manager
     kc = wm.keyconfigs.addon
     if kc:
-        km = kc.keymaps.new(name='3D View', space_type='VIEW_3D')
+        km = kc.keymaps.new(name="3D View", space_type="VIEW_3D")
         kmi = km.keymap_items.new(
-            "wm.call_menu_pie", type='V', value='PRESS', shift=False)
+            "wm.call_menu_pie", type="V", value="PRESS", shift=False
+        )
         kmi.properties.name = "SOLLUMZ_MT_pie_menu"
 
         addon_keymaps.append((km, kmi))
 
         kmi = km.keymap_items.new(
-            "wm.call_menu_pie", type='V', value='PRESS', shift=True)
+            "wm.call_menu_pie", type="V", value="PRESS", shift=True
+        )
         kmi.properties.name = "SOLLUMZ_MT_view_pie_menu"
 
         addon_keymaps.append((km, kmi))
 
 
 def unregister():
-
     # default keybinding
     for km, kmi in addon_keymaps:
         km.keymap_items.remove(kmi)

--- a/sollumz_preferences.py
+++ b/sollumz_preferences.py
@@ -35,63 +35,63 @@ class SollumzExportSettings(bpy.types.PropertyGroup):
         name="Limit to Selected",
         description="Export selected and visible objects only",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     auto_calculate_inertia: bpy.props.BoolProperty(
         name="Auto Calculate Inertia",
         description="Automatically calculate inertia for physics objects (applies to yfts and ydrs too)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     auto_calculate_volume: bpy.props.BoolProperty(
         name="Auto Calculate Volume",
         description="Automatically calculate volume for physics objects (applies to yfts and ydrs too)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     exclude_skeleton: bpy.props.BoolProperty(
         name="Exclude Skeleton",
         description="Exclude skeleton from export. Usually done with mp ped components",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     export_with_ytyp: bpy.props.BoolProperty(
         name="Export with ytyp",
         description="Exports a .ytyp.xml with an archetype for every drawable or drawable dictionary being exported",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_exclude_entities: bpy.props.BoolProperty(
         name="Exclude Entities",
         description="If enabled, ignore all Entities from the selected ymap(s)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_box_occluders: bpy.props.BoolProperty(
         name="Exclude Box Occluders",
         description="If enabled, ignore all Box occluders from the selected ymap(s)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_model_occluders: bpy.props.BoolProperty(
         name="Exclude Model Occluders",
         description="If enabled, ignore all Model occluders from the selected ymap(s)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_car_generators: bpy.props.BoolProperty(
         name="Exclude Car Generators",
         description="If enabled, ignore all Car Generators from the selected ymap(s)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     export_lods: bpy.props.EnumProperty(
@@ -100,19 +100,25 @@ class SollumzExportSettings(bpy.types.PropertyGroup):
         options={"ENUM_FLAG"},
         default=({"sollumz_export_very_high", "sollumz_export_main_lods"}),
         items=(
-            ("sollumz_export_very_high", "Very High",
-             "Export Very High LODs into a _hi.yft"),
-            ("sollumz_export_main_lods", "High - Very Low",
-             "Export all LODs except Very High")
+            (
+                "sollumz_export_very_high",
+                "Very High",
+                "Export Very High LODs into a _hi.yft",
+            ),
+            (
+                "sollumz_export_main_lods",
+                "High - Very Low",
+                "Export all LODs except Very High",
+            ),
         ),
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     apply_transforms: bpy.props.BoolProperty(
         name="Apply Parent Transforms",
         description="Apply Drawable/Fragment scale and rotation",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     @property
@@ -129,63 +135,63 @@ class SollumzImportSettings(bpy.types.PropertyGroup):
         name="Import as asset",
         description="Create an asset from the .ydr/.yft high LOD",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     import_with_hi: bpy.props.BoolProperty(
         name="Import with _hi",
         description="Import the selected .yft.xml with the <name>_hi.yft.xml placed in the very high LOD (must be in the same directory)",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     split_by_group: bpy.props.BoolProperty(
         name="Split Mesh by Group",
         description="Splits the mesh by vertex groups",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     import_ext_skeleton: bpy.props.BoolProperty(
         name="Import External Skeleton",
         description="Imports the first found yft skeleton in the same folder as the selected file",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_skip_missing_entities: bpy.props.BoolProperty(
         name="Skip Missing Entities",
         description="If enabled, missing entities wont be created as an empty object",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_exclude_entities: bpy.props.BoolProperty(
         name="Exclude Entities",
         description="If enabled, ignore all entities from the selected ymap(s)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_box_occluders: bpy.props.BoolProperty(
         name="Exclude Box Occluders",
         description="If enabled, ignore all Box occluders from the selected ymap(s)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_model_occluders: bpy.props.BoolProperty(
         name="Exclude Model Occluders",
         description="If enabled, ignore all Model occluders from the selected ymap(s)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_car_generators: bpy.props.BoolProperty(
         name="Exclude Car Generators",
         description="If enabled, ignore all Car Generators from the selected ymap(s)",
         default=False,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     ymap_instance_entities: bpy.props.BoolProperty(
@@ -202,40 +208,42 @@ class SollumzAddonPreferences(bpy.types.AddonPreferences):
         name="Scale Light Intensity",
         description="Scale light intensity by 500 on import/export",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     show_vertex_painter: bpy.props.BoolProperty(
         name="Show Vertex Painter",
         description="Show the Vertex Painter panel in General Tools (Includes Terrain Painter)",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     extra_color_swatches: bpy.props.BoolProperty(
         name="Extra Vertex Color Swatches",
         description="Add 3 extra color swatches to the Vertex Painter Panel (Max 6)",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     sollumz_icon_header: bpy.props.BoolProperty(
         name="Show Sollumz icon",
         description="Show the Sollumz icon in properties section headers",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
     use_text_name_as_mat_name: bpy.props.BoolProperty(
         name="Use Texture Name as Material Name",
         description="Use the name of the texture as the material name",
         default=True,
-        update=_save_preferences
+        update=_save_preferences,
     )
 
     export_settings: bpy.props.PointerProperty(
-        type=SollumzExportSettings, name="Export Settings")
+        type=SollumzExportSettings, name="Export Settings"
+    )
     import_settings: bpy.props.PointerProperty(
-        type=SollumzImportSettings, name="Import Settings")
+        type=SollumzImportSettings, name="Import Settings"
+    )
 
     def draw(self, context):
         layout = self.layout
@@ -249,15 +257,21 @@ class SollumzAddonPreferences(bpy.types.AddonPreferences):
         _load_preferences()
 
 
-def get_addon_preferences(context: Optional[bpy.types.Context] = None) -> SollumzAddonPreferences:
+def get_addon_preferences(
+    context: Optional[bpy.types.Context] = None,
+) -> SollumzAddonPreferences:
     return context.preferences.addons[__package__.split(".")[0]].preferences
 
 
-def get_import_settings(context: Optional[bpy.types.Context] = None) -> SollumzImportSettings:
+def get_import_settings(
+    context: Optional[bpy.types.Context] = None,
+) -> SollumzImportSettings:
     return get_addon_preferences(context or bpy.context).import_settings
 
 
-def get_export_settings(context: Optional[bpy.types.Context] = None) -> SollumzExportSettings:
+def get_export_settings(
+    context: Optional[bpy.types.Context] = None,
+) -> SollumzExportSettings:
     return get_addon_preferences(context or bpy.context).export_settings
 
 
@@ -285,8 +299,7 @@ def _load_preferences():
             continue
 
         if not hasattr(addon_prefs, section):
-            print(
-                f"Unknown preferences pointer property '{section}'! Skipping...")
+            print(f"Unknown preferences pointer property '{section}'! Skipping...")
             continue
 
         prop_group = getattr(addon_prefs, section)
@@ -319,7 +332,9 @@ def _get_data_block_as_dict(data_block: bpy.types.ID):
 
 
 def get_prefs_path():
-    return os.path.join(bpy.utils.user_resource(resource_type='CONFIG'), PREFS_FILE_NAME)
+    return os.path.join(
+        bpy.utils.user_resource(resource_type="CONFIG"), PREFS_FILE_NAME
+    )
 
 
 def register():

--- a/sollumz_properties.py
+++ b/sollumz_properties.py
@@ -65,8 +65,8 @@ class LightType(str, Enum):
 
 
 class MaterialType(str, Enum):
-    NONE = "sollumz_material_none",
-    SHADER = "sollumz_material_shader",
+    NONE = ("sollumz_material_none",)
+    SHADER = ("sollumz_material_shader",)
     COLLISION = "sollumz_material_collision"
     SHATTER_MAP = "sollumz_material_shard"
 
@@ -264,20 +264,17 @@ SOLLUMZ_UI_NAMES = {
     SollumType.BOUND_GEOMETRY: "Bound Geometry",
     SollumType.BOUND_GEOMETRYBVH: "Bound GeometryBVH",
     SollumType.BOUND_COMPOSITE: "Bound Composite",
-
     SollumType.BOUND_POLY_BOX: "Bound Poly Box",
     SollumType.BOUND_POLY_SPHERE: "Bound Poly Sphere",
     SollumType.BOUND_POLY_CAPSULE: "Bound Poly Capsule",
     SollumType.BOUND_POLY_CYLINDER: "Bound Poly Cylinder",
     SollumType.BOUND_POLY_TRIANGLE: "Bound Poly Mesh",
     SollumType.BOUND_POLY_TRIANGLE2: "Bound Poly Mesh Damaged",
-
     SollumType.FRAGMENT: "Fragment",
     SollumType.FRAGGROUP: "Fragment Group",
     SollumType.FRAGCHILD: "Fragment Child",
     SollumType.FRAGLOD: "Fragment LOD",
     SollumType.SHATTERMAP: "Shattermap",
-
     SollumType.NONE: "None",
     SollumType.DRAWABLE_DICTIONARY: "Drawable Dictionary",
     SollumType.DRAWABLE: "Drawable",
@@ -285,18 +282,15 @@ SOLLUMZ_UI_NAMES = {
     SollumType.DRAWABLE_GEOMETRY: "Drawable Geometry",
     SollumType.SKELETON: "Skeleton",
     SollumType.LIGHT: "Light",
-
     SollumType.NAVMESH: "NavMesh",
     SollumType.NAVMESH_POLY_MESH: "NavMesh Poly Mesh",
     SollumType.NAVMESH_PORTAL: "NavMesh Portal",
     SollumType.NAVMESH_POINT: "NavMesh Point",
-
     SollumType.CLIP_DICTIONARY: "Clip Dictionary",
     SollumType.CLIPS: "Clips",
     SollumType.CLIP: "Clip",
     SollumType.ANIMATIONS: "Animations",
     SollumType.ANIMATION: "Animation",
-
     SollumType.YMAP: "Ymap",
     SollumType.YMAP_ENTITY_GROUP: "Entity Group",
     SollumType.YMAP_BOX_OCCLUDER_GROUP: "Box Occluder Group",
@@ -305,12 +299,10 @@ SOLLUMZ_UI_NAMES = {
     SollumType.YMAP_BOX_OCCLUDER: "Box Occluder",
     SollumType.YMAP_MODEL_OCCLUDER: "Model Occluder",
     SollumType.YMAP_CAR_GENERATOR: "Car Generator",
-
     MaterialType.NONE: "None",
     MaterialType.SHADER: "Sollumz Material",
     MaterialType.COLLISION: "Sollumz Collision Material",
     MaterialType.SHATTER_MAP: "Sollumz Shatter Map",
-
     TextureUsage.UNKNOWN: "UNKNOWN",
     TextureUsage.TINTPALETTE: "TINTPALETTE",
     TextureUsage.DEFAULT: "DEFAULT",
@@ -340,7 +332,6 @@ SOLLUMZ_UI_NAMES = {
     TextureUsage.TEST: "TEST",
     TextureUsage.COUNT: "COUNT",
     TextureUsage.DIFFUSE: "DIFFUSE",
-
     TextureFormat.DXT1: "D3DFMT_DXT1",
     TextureFormat.DXT3: "D3DFMT_DXT3",
     TextureFormat.DXT5: "D3DFMT_DXT5",
@@ -354,13 +345,11 @@ SOLLUMZ_UI_NAMES = {
     TextureFormat.X8R8G8B8: "D3DFMT_X8R8G8B8",
     TextureFormat.A8: "D3DFMT_A8",
     TextureFormat.L8: "D3DFMT_L8",
-
     LODLevel.VERYHIGH: "Very High",
     LODLevel.HIGH: "High",
     LODLevel.MEDIUM: "Med",
     LODLevel.LOW: "Low",
     LODLevel.VERYLOW: "Very Low",
-
     EntityLodLevel.LODTYPES_DEPTH_HD: "DEPTH HD",
     EntityLodLevel.LODTYPES_DEPTH_LOD: "DEPTH LOD",
     EntityLodLevel.LODTYPES_DEPTH_SLOD1: "DEPTH SLOD1",
@@ -368,27 +357,22 @@ SOLLUMZ_UI_NAMES = {
     EntityLodLevel.LODTYPES_DEPTH_SLOD3: "DEPTH SLOD3",
     EntityLodLevel.LODTYPES_DEPTH_SLOD4: "DEPTH SLOD4",
     EntityLodLevel.LODTYPES_DEPTH_ORPHANHD: "DEPTH ORPHAN HD",
-
     EntityPriorityLevel.PRI_REQUIRED: "REQUIRED",
     EntityPriorityLevel.PRI_OPTIONAL_HIGH: "OPTIONAL HIGH",
     EntityPriorityLevel.PRI_OPTIONAL_MEDIUM: "OPTIONAL MEDIUM",
     EntityPriorityLevel.PRI_OPTIONAL_LOW: "OPTIONAL LOW",
-
     LightType.NONE: "None",
     LightType.POINT: "Point",
     LightType.SPOT: "Spot",
     LightType.CAPSULE: "Capsule",
-
     ArchetypeType.BASE: "Base",
     ArchetypeType.TIME: "Time",
     ArchetypeType.MLO: "MLO",
-
     AssetType.UNITIALIZED: "Uninitialized",
     AssetType.FRAGMENT: "Fragment",
     AssetType.DRAWABLE: "Drawable",
     AssetType.DRAWABLE_DICTIONARY: "Drawable Dictionary",
     AssetType.ASSETLESS: "Assetless",
-
     VehicleLightID.NONE: "None",
     VehicleLightID.CUSTOM: "Custom",
     VehicleLightID.ALWAYS_ON: "Always On",
@@ -409,13 +393,12 @@ SOLLUMZ_UI_NAMES = {
     VehicleLightID.EXTRA_FRONT_RIGHT: "Extra Front Right (extralight_2)",
     VehicleLightID.EXTRA_REAR_LEFT: "Extra Rear Left (extralight_3)",
     VehicleLightID.EXTRA_REAR_RIGHT: "Extra Rear Right (extralight_4)",
-
     VehiclePaintLayer.NOT_PAINTABLE: "Not Paintable",
     VehiclePaintLayer.PRIMARY: "Primary",
     VehiclePaintLayer.SECONDARY: "Secondary",
     VehiclePaintLayer.WHEEL: "Wheel",
     VehiclePaintLayer.INTERIOR_DASH: "Dashboard",
-    VehiclePaintLayer.INTERIOR_TRIM: "Interior Trim"
+    VehiclePaintLayer.INTERIOR_TRIM: "Interior Trim",
 }
 
 
@@ -427,10 +410,8 @@ def items_from_enums(*enums, exclude=None):
             if exclude is not None and item in exclude:
                 continue
             if item not in SOLLUMZ_UI_NAMES:
-                raise KeyError(
-                    f"UI name mapping not found for key {item} of {enum}.")
-            items.append(
-                (item.value, SOLLUMZ_UI_NAMES[item], ""))
+                raise KeyError(f"UI name mapping not found for key {item} of {enum}.")
+            items.append((item.value, SOLLUMZ_UI_NAMES[item], ""))
     return items
 
 
@@ -454,105 +435,122 @@ class FlagPropertyGroup:
 
     size = 32
     total: bpy.props.StringProperty(
-        name="Flags", update=update_flags_total, default="0")
+        name="Flags", update=update_flags_total, default="0"
+    )
 
 
-time_items = [("0", "12:00 AM", ""),
-              ("1", "1:00 AM", ""),
-              ("2", "2:00 AM", ""),
-              ("3", "3:00 AM", ""),
-              ("4", "4:00 AM", ""),
-              ("5", "5:00 AM", ""),
-              ("6", "6:00 AM", ""),
-              ("7", "7:00 AM", ""),
-              ("8", "8:00 AM", ""),
-              ("9", "9:00 AM", ""),
-              ("10", "10:00 AM", ""),
-              ("11", "11:00 AM", ""),
-              ("12", "12:00 PM", ""),
-              ("13", "1:00 PM", ""),
-              ("14", "2:00 PM", ""),
-              ("15", "3:00 PM", ""),
-              ("16", "4:00 PM", ""),
-              ("17", "5:00 PM", ""),
-              ("18", "6:00 PM", ""),
-              ("19", "7:00 PM", ""),
-              ("20", "8:00 PM", ""),
-              ("21", "9:00 PM", ""),
-              ("22", "10:00 PM", ""),
-              ("23", "11:00 PM", "")]
+time_items = [
+    ("0", "12:00 AM", ""),
+    ("1", "1:00 AM", ""),
+    ("2", "2:00 AM", ""),
+    ("3", "3:00 AM", ""),
+    ("4", "4:00 AM", ""),
+    ("5", "5:00 AM", ""),
+    ("6", "6:00 AM", ""),
+    ("7", "7:00 AM", ""),
+    ("8", "8:00 AM", ""),
+    ("9", "9:00 AM", ""),
+    ("10", "10:00 AM", ""),
+    ("11", "11:00 AM", ""),
+    ("12", "12:00 PM", ""),
+    ("13", "1:00 PM", ""),
+    ("14", "2:00 PM", ""),
+    ("15", "3:00 PM", ""),
+    ("16", "4:00 PM", ""),
+    ("17", "5:00 PM", ""),
+    ("18", "6:00 PM", ""),
+    ("19", "7:00 PM", ""),
+    ("20", "8:00 PM", ""),
+    ("21", "9:00 PM", ""),
+    ("22", "10:00 PM", ""),
+    ("23", "11:00 PM", ""),
+]
 
 
 class TimeFlags(FlagPropertyGroup, bpy.types.PropertyGroup):
     hour1: bpy.props.BoolProperty(
-        name="12:00 AM - 1:00 AM", update=FlagPropertyGroup.update_flag)
+        name="12:00 AM - 1:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour2: bpy.props.BoolProperty(
-        name="1:00 AM - 2:00 AM", update=FlagPropertyGroup.update_flag)
+        name="1:00 AM - 2:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour3: bpy.props.BoolProperty(
-        name="2:00 AM - 3:00 AM", update=FlagPropertyGroup.update_flag)
+        name="2:00 AM - 3:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour4: bpy.props.BoolProperty(
-        name="3:00 AM - 4:00 AM", update=FlagPropertyGroup.update_flag)
+        name="3:00 AM - 4:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour5: bpy.props.BoolProperty(
-        name="4:00 AM - 5:00 AM", update=FlagPropertyGroup.update_flag)
+        name="4:00 AM - 5:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour6: bpy.props.BoolProperty(
-        name="5:00 AM - 6:00 AM", update=FlagPropertyGroup.update_flag)
+        name="5:00 AM - 6:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour7: bpy.props.BoolProperty(
-        name="6:00 AM - 7:00 AM", update=FlagPropertyGroup.update_flag)
+        name="6:00 AM - 7:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour8: bpy.props.BoolProperty(
-        name="7:00 AM - 8:00 AM", update=FlagPropertyGroup.update_flag)
+        name="7:00 AM - 8:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour9: bpy.props.BoolProperty(
-        name="8:00 AM - 9:00 AM", update=FlagPropertyGroup.update_flag)
+        name="8:00 AM - 9:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour10: bpy.props.BoolProperty(
-        name="9:00 AM - 10:00 AM", update=FlagPropertyGroup.update_flag)
+        name="9:00 AM - 10:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour11: bpy.props.BoolProperty(
-        name="10:00 AM - 11:00 AM", update=FlagPropertyGroup.update_flag)
+        name="10:00 AM - 11:00 AM", update=FlagPropertyGroup.update_flag
+    )
     hour12: bpy.props.BoolProperty(
-        name="11:00 AM - 12:00 PM", update=FlagPropertyGroup.update_flag)
+        name="11:00 AM - 12:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour13: bpy.props.BoolProperty(
-        name="12:00 PM - 1:00 PM", update=FlagPropertyGroup.update_flag)
+        name="12:00 PM - 1:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour14: bpy.props.BoolProperty(
-        name="1:00 PM - 2:00 PM", update=FlagPropertyGroup.update_flag)
+        name="1:00 PM - 2:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour15: bpy.props.BoolProperty(
-        name="2:00 PM - 3:00 PM", update=FlagPropertyGroup.update_flag)
+        name="2:00 PM - 3:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour16: bpy.props.BoolProperty(
-        name="3:00 PM - 4:00 PM", update=FlagPropertyGroup.update_flag)
+        name="3:00 PM - 4:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour17: bpy.props.BoolProperty(
-        name="4:00 PM - 5:00 PM", update=FlagPropertyGroup.update_flag)
+        name="4:00 PM - 5:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour18: bpy.props.BoolProperty(
-        name="5:00 PM - 6:00 PM", update=FlagPropertyGroup.update_flag)
+        name="5:00 PM - 6:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour19: bpy.props.BoolProperty(
-        name="6:00 PM - 7:00 PM", update=FlagPropertyGroup.update_flag)
+        name="6:00 PM - 7:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour20: bpy.props.BoolProperty(
-        name="7:00 PM - 8:00 PM", update=FlagPropertyGroup.update_flag)
+        name="7:00 PM - 8:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour21: bpy.props.BoolProperty(
-        name="8:00 PM - 9:00 PM", update=FlagPropertyGroup.update_flag)
+        name="8:00 PM - 9:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour22: bpy.props.BoolProperty(
-        name="9:00 PM - 10:00 PM", update=FlagPropertyGroup.update_flag)
+        name="9:00 PM - 10:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour23: bpy.props.BoolProperty(
-        name="10:00 PM - 11:00 PM", update=FlagPropertyGroup.update_flag)
+        name="10:00 PM - 11:00 PM", update=FlagPropertyGroup.update_flag
+    )
     hour24: bpy.props.BoolProperty(
-        name="11:00 PM - 12:00 AM", update=FlagPropertyGroup.update_flag)
-    unk1: bpy.props.BoolProperty(
-        name="Unknown 1", update=FlagPropertyGroup.update_flag)
-    unk2: bpy.props.BoolProperty(
-        name="Unknown 2", update=FlagPropertyGroup.update_flag)
-    unk3: bpy.props.BoolProperty(
-        name="Unknown 3", update=FlagPropertyGroup.update_flag)
-    unk4: bpy.props.BoolProperty(
-        name="Unknown 4", update=FlagPropertyGroup.update_flag)
-    unk5: bpy.props.BoolProperty(
-        name="Unknown 5", update=FlagPropertyGroup.update_flag)
-    unk6: bpy.props.BoolProperty(
-        name="Unknown 6", update=FlagPropertyGroup.update_flag)
-    unk7: bpy.props.BoolProperty(
-        name="Unknown 7", update=FlagPropertyGroup.update_flag)
-    unk8: bpy.props.BoolProperty(
-        name="Unknown 8", update=FlagPropertyGroup.update_flag)
+        name="11:00 PM - 12:00 AM", update=FlagPropertyGroup.update_flag
+    )
+    unk1: bpy.props.BoolProperty(name="Unknown 1", update=FlagPropertyGroup.update_flag)
+    unk2: bpy.props.BoolProperty(name="Unknown 2", update=FlagPropertyGroup.update_flag)
+    unk3: bpy.props.BoolProperty(name="Unknown 3", update=FlagPropertyGroup.update_flag)
+    unk4: bpy.props.BoolProperty(name="Unknown 4", update=FlagPropertyGroup.update_flag)
+    unk5: bpy.props.BoolProperty(name="Unknown 5", update=FlagPropertyGroup.update_flag)
+    unk6: bpy.props.BoolProperty(name="Unknown 6", update=FlagPropertyGroup.update_flag)
+    unk7: bpy.props.BoolProperty(name="Unknown 7", update=FlagPropertyGroup.update_flag)
+    unk8: bpy.props.BoolProperty(name="Unknown 8", update=FlagPropertyGroup.update_flag)
 
-    time_flags_start: bpy.props.EnumProperty(
-        items=time_items, name="Time Start")
-    time_flags_end: bpy.props.EnumProperty(
-        items=time_items, name="Time End")
+    time_flags_start: bpy.props.EnumProperty(items=time_items, name="Time Start")
+    time_flags_end: bpy.props.EnumProperty(items=time_items, name="Time End")
 
 
 class EntityProperties:
@@ -566,19 +564,21 @@ class EntityProperties:
         items=items_from_enums(EntityLodLevel),
         name="LOD Level",
         default=EntityLodLevel.LODTYPES_DEPTH_ORPHANHD,
-        options={"HIDDEN"}
+        options={"HIDDEN"},
     )
     num_children: bpy.props.IntProperty(name="Number of Children")
     priority_level: bpy.props.EnumProperty(
         items=items_from_enums(EntityPriorityLevel),
         name="Priority Level",
         default=EntityPriorityLevel.PRI_REQUIRED,
-        options={"HIDDEN"}
+        options={"HIDDEN"},
     )
     ambient_occlusion_multiplier: bpy.props.FloatProperty(
-        name="Ambient Occlusion Multiplier", default=255)
+        name="Ambient Occlusion Multiplier", default=255
+    )
     artificial_ambient_occlusion: bpy.props.FloatProperty(
-        name="Artificial Ambient Occlusion", default=255)
+        name="Artificial Ambient Occlusion", default=255
+    )
     tint_value: bpy.props.FloatProperty(name="Tint Value")
 
 
@@ -591,20 +591,21 @@ def register():
         items=items_from_enums(SollumType),
         name="Sollumz Type",
         default=SollumType.NONE,
-        options={"HIDDEN"}
+        options={"HIDDEN"},
     )
 
     bpy.types.Material.sollum_type = bpy.props.EnumProperty(
         items=items_from_enums(MaterialType),
         name="Sollumz Material Type",
         default=MaterialType.NONE,
-        options={"HIDDEN"}
+        options={"HIDDEN"},
     )
 
     bpy.types.ShaderNode.is_sollumz = bpy.props.BoolProperty(default=False)
 
     bpy.types.Object.entity_properties = bpy.props.PointerProperty(
-        type=ObjectEntityProperties)
+        type=ObjectEntityProperties
+    )
 
     bpy.types.Scene.vert_paint_color1 = bpy.props.FloatVectorProperty(
         name="Vert Color 1",
@@ -612,7 +613,7 @@ def register():
         default=(1.0, 1.0, 1.0, 1.0),
         min=0,
         max=1,
-        size=4
+        size=4,
     )
 
     bpy.types.Scene.vert_paint_color2 = bpy.props.FloatVectorProperty(
@@ -621,7 +622,7 @@ def register():
         default=(0.0, 0.0, 1.0, 1.0),
         min=0,
         max=1,
-        size=4
+        size=4,
     )
 
     bpy.types.Scene.vert_paint_color3 = bpy.props.FloatVectorProperty(
@@ -630,7 +631,7 @@ def register():
         default=(0.0, 1.0, 0.0, 1.0),
         min=0,
         max=1,
-        size=4
+        size=4,
     )
 
     bpy.types.Scene.vert_paint_color4 = bpy.props.FloatVectorProperty(
@@ -639,7 +640,7 @@ def register():
         default=(1.0, 0.0, 0.0, 1.0),
         min=0,
         max=1,
-        size=4
+        size=4,
     )
 
     bpy.types.Scene.vert_paint_color5 = bpy.props.FloatVectorProperty(
@@ -648,7 +649,7 @@ def register():
         default=(0.0, 1.0, 0.0, 1.0),
         min=0,
         max=1,
-        size=4
+        size=4,
     )
 
     bpy.types.Scene.vert_paint_color6 = bpy.props.FloatVectorProperty(
@@ -657,30 +658,46 @@ def register():
         default=(1.0, 0.0, 0.0, 1.0),
         min=0,
         max=1,
-        size=4
+        size=4,
     )
 
     bpy.types.Scene.vert_paint_alpha = bpy.props.FloatProperty(
-        name="Alpha", min=-1, max=1)
+        name="Alpha", min=-1, max=1
+    )
 
     bpy.types.Scene.debug_sollum_type = bpy.props.EnumProperty(
-        items=[(SollumType.DRAWABLE.value, SOLLUMZ_UI_NAMES[SollumType.DRAWABLE], SOLLUMZ_UI_NAMES[SollumType.DRAWABLE]),
-               (SollumType.DRAWABLE_DICTIONARY.value,
-                SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_DICTIONARY], SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_DICTIONARY]),
-               (SollumType.BOUND_COMPOSITE.value, SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE], SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE])],
+        items=[
+            (
+                SollumType.DRAWABLE.value,
+                SOLLUMZ_UI_NAMES[SollumType.DRAWABLE],
+                SOLLUMZ_UI_NAMES[SollumType.DRAWABLE],
+            ),
+            (
+                SollumType.DRAWABLE_DICTIONARY.value,
+                SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_DICTIONARY],
+                SOLLUMZ_UI_NAMES[SollumType.DRAWABLE_DICTIONARY],
+            ),
+            (
+                SollumType.BOUND_COMPOSITE.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE],
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE],
+            ),
+        ],
         name="Hierarchy Type",
         default=SollumType.DRAWABLE,
-        options={"HIDDEN"}
+        options={"HIDDEN"},
     )
 
     bpy.types.Scene.all_sollum_type = bpy.props.EnumProperty(
         items=sorted(items_from_enums(SollumType), key=lambda i: i[0]),
         name="Sollum Types",
-        options={"HIDDEN"}
+        options={"HIDDEN"},
     )
 
     bpy.types.Scene.debug_lights_only_selected = bpy.props.BoolProperty(
-        name="Limit to Selected", description="Only set intensity of the selected lights. (All instances will be affected)")
+        name="Limit to Selected",
+        description="Only set intensity of the selected lights. (All instances will be affected)",
+    )
 
     bpy.types.Scene.sollumz_export_path = bpy.props.StringProperty(
         name="Export Path",

--- a/sollumz_tool.py
+++ b/sollumz_tool.py
@@ -2,19 +2,23 @@ import bpy
 from typing import NamedTuple, Optional
 from .ytyp.tools import ArchetypeExtensionTool
 
+
 class SollumzToolDef(NamedTuple):
     cls: type
     separator: bool = False
     group: bool = False
     after: Optional[str] = None
 
-tools = (
-    SollumzToolDef(ArchetypeExtensionTool, separator=True, group=True),
-)
+
+tools = (SollumzToolDef(ArchetypeExtensionTool, separator=True, group=True),)
+
 
 def register_tools():
     for tool in tools:
-        bpy.utils.register_tool(tool.cls, separator=tool.separator, group=tool.group, after=tool.after)
+        bpy.utils.register_tool(
+            tool.cls, separator=tool.separator, group=tool.group, after=tool.after
+        )
+
 
 def unregister_tools():
     for tool in tools:

--- a/sollumz_ui.py
+++ b/sollumz_ui.py
@@ -1,13 +1,41 @@
 import bpy
-from .sollumz_preferences import get_addon_preferences, get_export_settings, get_import_settings, SollumzImportSettings, SollumzExportSettings
-from .sollumz_operators import SOLLUMZ_OT_copy_location, SOLLUMZ_OT_copy_rotation, SOLLUMZ_OT_paste_location, SOLLUMZ_OT_paste_rotation
+from .sollumz_preferences import (
+    get_addon_preferences,
+    get_export_settings,
+    get_import_settings,
+    SollumzImportSettings,
+    SollumzExportSettings,
+)
+from .sollumz_operators import (
+    SOLLUMZ_OT_copy_location,
+    SOLLUMZ_OT_copy_rotation,
+    SOLLUMZ_OT_paste_location,
+    SOLLUMZ_OT_paste_rotation,
+)
 from .tools.blenderhelper import get_armature_obj
 from .sollumz_properties import SollumType, MaterialType
-from .lods import (SOLLUMZ_OT_SET_LOD_HIGH, SOLLUMZ_OT_SET_LOD_MED, SOLLUMZ_OT_SET_LOD_LOW, SOLLUMZ_OT_SET_LOD_VLOW,
-                   SOLLUMZ_OT_SET_LOD_VERY_HIGH, SOLLUMZ_OT_HIDE_COLLISIONS, SOLLUMZ_OT_HIDE_SHATTERMAPS, SOLLUMZ_OT_HIDE_OBJECT, SOLLUMZ_OT_SHOW_COLLISIONS, SOLLUMZ_OT_SHOW_SHATTERMAPS)
+from .lods import (
+    SOLLUMZ_OT_SET_LOD_HIGH,
+    SOLLUMZ_OT_SET_LOD_MED,
+    SOLLUMZ_OT_SET_LOD_LOW,
+    SOLLUMZ_OT_SET_LOD_VLOW,
+    SOLLUMZ_OT_SET_LOD_VERY_HIGH,
+    SOLLUMZ_OT_HIDE_COLLISIONS,
+    SOLLUMZ_OT_HIDE_SHATTERMAPS,
+    SOLLUMZ_OT_HIDE_OBJECT,
+    SOLLUMZ_OT_SHOW_COLLISIONS,
+    SOLLUMZ_OT_SHOW_SHATTERMAPS,
+)
 from .icons import icon_manager
 
-def draw_list_with_add_remove(layout: bpy.types.UILayout, add_operator: str, remove_operator: str, *temp_list_args, **temp_list_kwargs):
+
+def draw_list_with_add_remove(
+    layout: bpy.types.UILayout,
+    add_operator: str,
+    remove_operator: str,
+    *temp_list_args,
+    **temp_list_kwargs,
+):
     """Draw a UIList with an add and remove button on the right column. Returns the left column."""
     row = layout.row()
     list_col = row.column()
@@ -22,6 +50,7 @@ def draw_list_with_add_remove(layout: bpy.types.UILayout, add_operator: str, rem
 
 class BasicListHelper:
     """Provides functionality for drawing simple lists where each item has a name and icon"""
+
     name_prop: str = "name"
     item_icon: str = "NONE"
     name_editable: bool = True
@@ -30,12 +59,10 @@ class BasicListHelper:
         self, context, layout, data, item, icon, active_data, active_propname, index
     ):
         if not self.name_editable:
-            layout.label(text=getattr(item, self.name_prop),
-                         icon=self.item_icon)
+            layout.label(text=getattr(item, self.name_prop), icon=self.item_icon)
             return
 
-        layout.prop(item, self.name_prop, text="",
-                    emboss=False, icon=self.item_icon)
+        layout.prop(item, self.name_prop, text="", emboss=False, icon=self.item_icon)
 
 
 class FilterListHelper:
@@ -69,7 +96,8 @@ class FilterListHelper:
             name = getattr(item, self.order_by_name_key)
         except:
             AttributeError(
-                f"Invalid order_by_name_key for {self.__class__.__name__}! This should be the 'name' attribute for the list item.")
+                f"Invalid order_by_name_key for {self.__class__.__name__}! This should be the 'name' attribute for the list item."
+            )
 
         return not self.filter_name or self.filter_name.lower() in name.lower()
 
@@ -112,7 +140,9 @@ class SollumzImportSettingsPanel(SollumzFileSettingsPanel):
     def get_settings(self, context: bpy.types.Context):
         return get_import_settings(context)
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzImportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzImportSettings
+    ):
         ...
 
 
@@ -122,7 +152,9 @@ class SollumzExportSettingsPanel(SollumzFileSettingsPanel):
     def get_settings(self, context: bpy.types.Context):
         return get_export_settings(context)
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzExportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzExportSettings
+    ):
         ...
 
 
@@ -130,7 +162,9 @@ class SOLLUMZ_PT_import_asset(bpy.types.Panel, SollumzImportSettingsPanel):
     bl_label = "Import Asset"
     bl_order = 0
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzImportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzImportSettings
+    ):
         layout.prop(settings, "import_as_asset")
 
 
@@ -138,7 +172,9 @@ class SOLLUMZ_PT_import_fragment(bpy.types.Panel, SollumzImportSettingsPanel):
     bl_label = "Fragment"
     bl_order = 1
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzImportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzImportSettings
+    ):
         layout.prop(settings, "split_by_group")
         layout.prop(settings, "import_with_hi")
 
@@ -147,7 +183,9 @@ class SOLLUMZ_PT_import_ydd(bpy.types.Panel, SollumzImportSettingsPanel):
     bl_label = "Drawable Dictionary"
     bl_order = 2
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzImportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzImportSettings
+    ):
         layout.prop(settings, "import_ext_skeleton")
 
 
@@ -165,19 +203,30 @@ class SOLLUMZ_UL_armature_list(bpy.types.UIList):
             if armature_obj is not None:
                 armature_parent = armature_obj.parent
 
-                row.label(text=item.name if armature_parent is None else f"{armature_parent.name} - {item.name}",
-                          icon="OUTLINER_DATA_ARMATURE")
+                row.label(
+                    text=item.name
+                    if armature_parent is None
+                    else f"{armature_parent.name} - {item.name}",
+                    icon="OUTLINER_DATA_ARMATURE",
+                )
         elif self.layout_type in {"GRID"}:
             layout.alignment = "CENTER"
-            layout.prop(item, "name",
-                        text=item.name, emboss=False, icon="OUTLINER_DATA_ARMATURE")
+            layout.prop(
+                item,
+                "name",
+                text=item.name,
+                emboss=False,
+                icon="OUTLINER_DATA_ARMATURE",
+            )
 
 
 class SOLLUMZ_PT_import_ymap(bpy.types.Panel, SollumzImportSettingsPanel):
     bl_label = "Ymap"
     bl_order = 3
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzImportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzImportSettings
+    ):
         layout.prop(settings, "ymap_skip_missing_entities")
         layout.prop(settings, "ymap_exclude_entities")
         layout.prop(settings, "ymap_instance_entities")
@@ -190,7 +239,9 @@ class SOLLUMZ_PT_export_include(bpy.types.Panel, SollumzExportSettingsPanel):
     bl_label = "Include"
     bl_order = 0
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzExportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzExportSettings
+    ):
         row = layout.row(heading="Limit To")
         row.prop(settings, "limit_to_selected", text="Selected Objects")
 
@@ -199,7 +250,9 @@ class SOLLUMZ_PT_export_drawable(bpy.types.Panel, SollumzExportSettingsPanel):
     bl_label = "Drawable"
     bl_order = 1
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzExportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzExportSettings
+    ):
         layout.prop(settings, "apply_transforms")
         layout.prop(settings, "export_with_ytyp")
 
@@ -208,7 +261,9 @@ class SOLLUMZ_PT_export_fragment(bpy.types.Panel, SollumzExportSettingsPanel):
     bl_label = "Fragment"
     bl_order = 2
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzExportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzExportSettings
+    ):
         layout.column().prop(settings, "export_lods")
 
 
@@ -216,7 +271,9 @@ class SOLLUMZ_PT_export_collision(bpy.types.Panel, SollumzExportSettingsPanel):
     bl_label = "Collisions"
     bl_order = 3
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzExportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzExportSettings
+    ):
         layout.prop(settings, "auto_calculate_inertia")
         layout.prop(settings, "auto_calculate_volume")
 
@@ -225,7 +282,9 @@ class SOLLUMZ_PT_export_ydd(bpy.types.Panel, SollumzExportSettingsPanel):
     bl_label = "Drawable Dictionary"
     bl_order = 4
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzExportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzExportSettings
+    ):
         layout.prop(settings, "exclude_skeleton")
 
 
@@ -233,7 +292,9 @@ class SOLLUMZ_PT_export_ymap(bpy.types.Panel, SollumzExportSettingsPanel):
     bl_label = "Ymap"
     bl_order = 5
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzExportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzExportSettings
+    ):
         layout.prop(settings, "ymap_exclude_entities")
         layout.prop(settings, "ymap_box_occluders")
         layout.prop(settings, "ymap_model_occluders")
@@ -305,7 +366,10 @@ class SOLLUMZ_PT_VIEW_PANEL(bpy.types.Panel):
         grid.operator(SOLLUMZ_OT_SET_LOD_VLOW.bl_idname)
         grid.operator(SOLLUMZ_OT_HIDE_OBJECT.bl_idname)
 
-        grid.enabled = context.view_layer.objects.active is not None and context.view_layer.objects.active.mode == "OBJECT"
+        grid.enabled = (
+            context.view_layer.objects.active is not None
+            and context.view_layer.objects.active.mode == "OBJECT"
+        )
 
 
 class SOLLUMZ_PT_OBJ_YMAP_LOCATION(bpy.types.Panel):
@@ -337,17 +401,19 @@ class SOLLUMZ_PT_OBJ_YMAP_LOCATION(bpy.types.Panel):
             row = box.row(align=True)
             row.prop(obj, "name", text="", emboss=False)
 
-            row.operator(SOLLUMZ_OT_copy_location.bl_idname, text="", icon='COPYDOWN') \
-               .location = "{:.6f}, {:.6f}, {:.6f}".format(loc[0], loc[1], loc[2])
-            
-            row.operator(SOLLUMZ_OT_copy_rotation.bl_idname, text="", icon='COPYDOWN') \
-               .rotation = "{:.6f}, {:.6f}, {:.6f}, {:.6f}".format(rot.x, rot.y, rot.z, rot.w)
+            row.operator(
+                SOLLUMZ_OT_copy_location.bl_idname, text="", icon="COPYDOWN"
+            ).location = "{:.6f}, {:.6f}, {:.6f}".format(loc[0], loc[1], loc[2])
 
-            row.operator(SOLLUMZ_OT_paste_location.bl_idname, text="", icon='PASTEDOWN')
+            row.operator(
+                SOLLUMZ_OT_copy_rotation.bl_idname, text="", icon="COPYDOWN"
+            ).rotation = "{:.6f}, {:.6f}, {:.6f}, {:.6f}".format(
+                rot.x, rot.y, rot.z, rot.w
+            )
 
-            row.operator(SOLLUMZ_OT_paste_rotation.bl_idname, text="", icon='PASTEDOWN')
+            row.operator(SOLLUMZ_OT_paste_location.bl_idname, text="", icon="PASTEDOWN")
 
-
+            row.operator(SOLLUMZ_OT_paste_rotation.bl_idname, text="", icon="PASTEDOWN")
 
 
 class SOLLUMZ_PT_VERTEX_TOOL_PANEL(bpy.types.Panel):
@@ -373,18 +439,15 @@ class SOLLUMZ_PT_VERTEX_TOOL_PANEL(bpy.types.Panel):
 
         row = layout.row()
         row.prop(context.scene, "vert_paint_color1", text="")
-        row.operator(
-            "sollumz.paint_vertices").color = context.scene.vert_paint_color1
+        row.operator("sollumz.paint_vertices").color = context.scene.vert_paint_color1
 
         row2 = layout.row()
         row2.prop(context.scene, "vert_paint_color2", text="")
-        row2.operator(
-            "sollumz.paint_vertices").color = context.scene.vert_paint_color2
+        row2.operator("sollumz.paint_vertices").color = context.scene.vert_paint_color2
 
         row3 = layout.row()
         row3.prop(context.scene, "vert_paint_color3", text="")
-        row3.operator(
-            "sollumz.paint_vertices").color = context.scene.vert_paint_color3
+        row3.operator("sollumz.paint_vertices").color = context.scene.vert_paint_color3
 
         preferences = get_addon_preferences(bpy.context)
         extra = preferences.extra_color_swatches
@@ -392,17 +455,20 @@ class SOLLUMZ_PT_VERTEX_TOOL_PANEL(bpy.types.Panel):
             row4 = layout.row()
             row4.prop(context.scene, "vert_paint_color4", text="")
             row4.operator(
-                "sollumz.paint_vertices").color = context.scene.vert_paint_color4
+                "sollumz.paint_vertices"
+            ).color = context.scene.vert_paint_color4
 
             row5 = layout.row()
             row5.prop(context.scene, "vert_paint_color5", text="")
             row5.operator(
-                "sollumz.paint_vertices").color = context.scene.vert_paint_color5
+                "sollumz.paint_vertices"
+            ).color = context.scene.vert_paint_color5
 
             row6 = layout.row()
             row6.prop(context.scene, "vert_paint_color6", text="")
             row6.operator(
-                "sollumz.paint_vertices").color = context.scene.vert_paint_color6
+                "sollumz.paint_vertices"
+            ).color = context.scene.vert_paint_color6
 
 
 class SOLLUMZ_PT_SET_SOLLUM_TYPE_PANEL(bpy.types.Panel):
@@ -455,7 +521,9 @@ class SOLLUMZ_PT_DEBUG_PANEL(bpy.types.Panel):
         layout.label(text="Migration")
         layout.operator("sollumz.migratedrawable")
         layout.label(
-            text="This will join all geometries for each LOD Level into a single object.", icon="ERROR")
+            text="This will join all geometries for each LOD Level into a single object.",
+            icon="ERROR",
+        )
         layout.operator("sollumz.migrateboundgeoms")
         layout.operator("sollumz.replace_armature_constraints")
 
@@ -521,8 +589,7 @@ class SOLLUMZ_PT_OBJECT_PANEL(bpy.types.Panel):
         row.prop(obj, "sollum_type")
 
         if not obj or obj.sollum_type == SollumType.NONE:
-            layout.label(
-                text="No sollumz objects in scene selected.", icon="ERROR")
+            layout.label(text="No sollumz objects in scene selected.", icon="ERROR")
 
 
 class SOLLUMZ_PT_ENTITY_PANEL(bpy.types.Panel):
@@ -592,7 +659,8 @@ class FlagsPanel:
 
     def get_flags(self, context):
         raise NotImplementedError(
-            f"Failed to display flags. '{self.__class__.__name__}.get_flags()' method not defined.")
+            f"Failed to display flags. '{self.__class__.__name__}.get_flags()' method not defined."
+        )
 
     def draw(self, context):
         data_block = self.get_flags(context)
@@ -614,7 +682,8 @@ class TimeFlagsPanel(FlagsPanel):
         super().draw(context)
         if self.select_operator is None or self.clear_operator is None:
             raise NotImplementedError(
-                f"'select_operator' and 'clear_operator' bl_idnames must be defined for {self.__class__.__name__}!")
+                f"'select_operator' and 'clear_operator' bl_idnames must be defined for {self.__class__.__name__}!"
+            )
         flags = self.get_flags(context)
         row = self.layout.row()
         row.operator(self.select_operator)

--- a/tabbed_panels.py
+++ b/tabbed_panels.py
@@ -23,8 +23,11 @@ class TabbedPanelHelper:
         ...
 
     def _draw_toggle_buttons(self, context: bpy.types.Context):
-        layout = self.layout.grid_flow(
-            align=True, row_major=True, columns=4) if self.use_grid else self.layout.row(align=True)
+        layout = (
+            self.layout.grid_flow(align=True, row_major=True, columns=4)
+            if self.use_grid
+            else self.layout.row(align=True)
+        )
 
         for tab_id, op_cls in self._panel_toggle_ops.items():
             if tab_id not in self._tab_panels:
@@ -37,8 +40,12 @@ class TabbedPanelHelper:
 
             is_active = tab_panel._get_active_tab() == op_cls.tab_id
 
-            layout.operator(op_cls.bl_idname, text=tab_panel.bl_label,
-                            icon=tab_panel.icon, depress=is_active)
+            layout.operator(
+                op_cls.bl_idname,
+                text=tab_panel.bl_label,
+                icon=tab_panel.icon,
+                depress=is_active,
+            )
 
     @classmethod
     def register(cls):
@@ -76,7 +83,10 @@ class TabPanel:
         if active_tab:
             return active_tab
 
-        if tabbed_panel.default_tab is not None and tabbed_panel.default_tab in tabbed_panel._tab_panels:
+        if (
+            tabbed_panel.default_tab is not None
+            and tabbed_panel.default_tab in tabbed_panel._tab_panels
+        ):
             return tabbed_panel.default_tab
 
     @classmethod
@@ -92,17 +102,14 @@ class TabPanel:
     def register(cls):
         if not hasattr(cls, "parent_tab_panel"):
             raise NotImplementedError(
-                f"Panel tab '{cls.__name__}' has no ``parent_tab_panel`` defined!")
+                f"Panel tab '{cls.__name__}' has no ``parent_tab_panel`` defined!"
+            )
 
         tabbed_panel = cls.parent_tab_panel
         active_tab_prop_name = cls._get_active_tab_propname()
 
         if not hasattr(bpy.types.Scene, active_tab_prop_name):
-            setattr(
-                bpy.types.Scene,
-                active_tab_prop_name,
-                bpy.props.StringProperty()
-            )
+            setattr(bpy.types.Scene, active_tab_prop_name, bpy.props.StringProperty())
 
         toggle_op = cls._tab_toggle_op_factory(cls.bl_idname)
         tabbed_panel._panel_toggle_ops[cls.bl_idname] = toggle_op
@@ -120,6 +127,7 @@ class TabPanel:
     @classmethod
     def _tab_toggle_op_factory(cls, _tab_id: str):
         """Dynamically create a tab toggle operator class"""
+
         class SOLLUMZ_OT_toggle_tab(bpy.types.Operator):
             bl_idname = f"sollumz.toggletab_{_tab_id.lower()}"
             bl_description = f"Toggle the {cls.bl_label} tab"

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -7,7 +7,7 @@ SOLLUMZ_SHADERS = list(map(lambda s: s.value, shadermats))
 SOLLUMZ_COLLISION_MATERIALS = list(collisionmats)
 BLENDER_LANGUAGES = ("en_US", "es")  # bpy.app.translations.locales
 
+
 @pytest.fixture()
 def context():
     return bpy.context
-

--- a/tests/test_shader_creation.py
+++ b/tests/test_shader_creation.py
@@ -1,6 +1,10 @@
 import pytest
 import bpy
-from .test_fixtures import BLENDER_LANGUAGES, SOLLUMZ_SHADERS, SOLLUMZ_COLLISION_MATERIALS
+from .test_fixtures import (
+    BLENDER_LANGUAGES,
+    SOLLUMZ_SHADERS,
+    SOLLUMZ_COLLISION_MATERIALS,
+)
 from ..ydr.shader_materials import create_shader
 from ..ybn.collision_materials import create_collision_material_from_index
 from ..ynv.ynvimport import get_material as ynv_get_material
@@ -15,7 +19,9 @@ def use_every_language(request):
         bpy.data.materials.remove(mat)
 
     bpy.context.preferences.view.language = request.param
-    _ = bpy.context.preferences.view.language  # need to read it after changing otherwise Blender crashes (Windows fatal exception: access violation) wtf??
+    _ = (
+        bpy.context.preferences.view.language
+    )  # need to read it after changing otherwise Blender crashes (Windows fatal exception: access violation) wtf??
     return request.param
 
 
@@ -25,7 +31,9 @@ class TestAllLanguages:
         mat = create_shader(shader)
         assert mat is not None
 
-    @pytest.mark.parametrize("material_index", list(range(len(SOLLUMZ_COLLISION_MATERIALS))))
+    @pytest.mark.parametrize(
+        "material_index", list(range(len(SOLLUMZ_COLLISION_MATERIALS)))
+    )
     def test_create_collision_material(self, material_index, use_every_language):
         mat = create_collision_material_from_index(material_index)
         assert mat is not None
@@ -34,7 +42,9 @@ class TestAllLanguages:
         mat = ynv_get_material("0 204 0 255 161 107")
         assert mat is not None
 
-    @pytest.mark.parametrize("sollum_type", (SollumType.YMAP_MODEL_OCCLUDER, SollumType.YMAP_BOX_OCCLUDER))
+    @pytest.mark.parametrize(
+        "sollum_type", (SollumType.YMAP_MODEL_OCCLUDER, SollumType.YMAP_BOX_OCCLUDER)
+    )
     def test_create_occluder_material(self, sollum_type, use_every_language):
         mat = add_occluder_material(sollum_type)
         assert mat is not None
@@ -50,4 +60,3 @@ class TestAllLanguages:
         bsdf, mo = find_bsdf_and_material_output(mat)
         assert bsdf is not None
         assert mo is not None
-

--- a/tests/test_shader_manager.py
+++ b/tests/test_shader_manager.py
@@ -2,48 +2,60 @@ import pytest
 from ..cwxml.shader import ShaderManager
 
 
-@pytest.mark.parametrize("filename, expected", (
-    ("default.sps", "default.sps"),
-    ("hash_18ad1594", "default.sps"),
-    ("hash_18AD1594", "default.sps"),
-    ("terrain_cb_4lyr.sps", "terrain_cb_4lyr.sps"),
-    ("hash_C8D15397", "terrain_cb_4lyr.sps"),
-))
+@pytest.mark.parametrize(
+    "filename, expected",
+    (
+        ("default.sps", "default.sps"),
+        ("hash_18ad1594", "default.sps"),
+        ("hash_18AD1594", "default.sps"),
+        ("terrain_cb_4lyr.sps", "terrain_cb_4lyr.sps"),
+        ("hash_C8D15397", "terrain_cb_4lyr.sps"),
+    ),
+)
 def test_find_shader(filename: str, expected: str):
     shader = ShaderManager.find_shader(filename)
     assert shader is not None
     assert shader.filename == expected
 
 
-@pytest.mark.parametrize("filename", (
-    "unknown.sps",
-    "hash_1234ABCD",
-    "",
-))
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "unknown.sps",
+        "hash_1234ABCD",
+        "",
+    ),
+)
 def test_find_shader_unknown_returns_none(filename: str):
     shader = ShaderManager.find_shader(filename)
     assert shader is None
 
 
-@pytest.mark.parametrize("filename, expected", (
-    ("default.sps", "default"),
-    ("hash_18ad1594", "default"),
-    ("hash_18AD1594", "default"),
-    ("cutout.sps", "default"),
-    ("terrain_cb_4lyr.sps", "terrain_cb_4lyr"),
-    ("hash_C8D15397", "terrain_cb_4lyr"),
-))
+@pytest.mark.parametrize(
+    "filename, expected",
+    (
+        ("default.sps", "default"),
+        ("hash_18ad1594", "default"),
+        ("hash_18AD1594", "default"),
+        ("cutout.sps", "default"),
+        ("terrain_cb_4lyr.sps", "terrain_cb_4lyr"),
+        ("hash_C8D15397", "terrain_cb_4lyr"),
+    ),
+)
 def test_find_shader_base_name(filename: str, expected: str):
     base_shader = ShaderManager.find_shader_base_name(filename)
     assert base_shader is not None
     assert base_shader == expected
 
 
-@pytest.mark.parametrize("filename", (
-    "unknown.sps",
-    "hash_1234ABCD",
-    "",
-))
+@pytest.mark.parametrize(
+    "filename",
+    (
+        "unknown.sps",
+        "hash_1234ABCD",
+        "",
+    ),
+)
 def test_find_shader_base_name_unknown_returns_none(filename: str):
     shader = ShaderManager.find_shader_base_name(filename)
     assert shader is None

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -2,22 +2,28 @@ import pytest
 from ..cwxml.element import get_str_type, ElementTree, ValueProperty
 
 
-@pytest.mark.parametrize("string, expected", (
-    ("true", True),
-    ("True", True),
-    ("TrUE", True),
-    ("false", False),
-    ("False", False),
-    ("FALsE", False),
-))
+@pytest.mark.parametrize(
+    "string, expected",
+    (
+        ("true", True),
+        ("True", True),
+        ("TrUE", True),
+        ("false", False),
+        ("False", False),
+        ("FALsE", False),
+    ),
+)
 def test_xml_bool(string, expected):
     assert get_str_type(string) == expected
 
 
-@pytest.mark.parametrize("bool_value, expected", (
-    (True, "true"),
-    (False, "false"),
-))
+@pytest.mark.parametrize(
+    "bool_value, expected",
+    (
+        (True, "true"),
+        (False, "false"),
+    ),
+)
 def test_xml_bool_output(bool_value: bool, expected: str):
     class Data(ElementTree):
         tag_name = "Data"

--- a/tools/animationhelper.py
+++ b/tools/animationhelper.py
@@ -13,6 +13,7 @@ from ..cwxml.shader import ShaderManager
 
 from .. import logger
 
+
 class AnimationFlag(IntFlag):
     Default = 0
     RootMotion = 16
@@ -20,6 +21,7 @@ class AnimationFlag(IntFlag):
 
 class Track(IntEnum):
     """An enumeration of Animation Tracks supported by GTA."""
+
     BonePosition = 0
     BoneRotation = 1
     BoneScale = 2
@@ -194,7 +196,7 @@ def get_quantum_and_min_val(nums):
 
 
 def decompose_uv_affine_matrix(
-        uv0: Vector, uv1: Vector
+    uv0: Vector, uv1: Vector
 ) -> Tuple[Tuple[float, float], float, Tuple[float, float], float]:
     """
     Decompose the UV affine matrix into translation, rotation in radians, scale, and shear along X axis.
@@ -242,6 +244,7 @@ def decompose_uv_affine_matrix(
 #     self.uv0[2] = translation[0]
 #     self.uv1[2] = translation[1]
 
+
 def calculate_bone_space_transform_matrix(old_pose_bone, new_pose_bone):
     if old_pose_bone is None:
         old_mat = Matrix.Identity(4)
@@ -274,13 +277,21 @@ def transform_bone_location_space(fcurves, old_pose_bone, new_pose_bone):
     if x is None:
         return
 
-    assert len(x.keyframe_points) == len(y.keyframe_points) and len(x.keyframe_points) == len(z.keyframe_points), "TODO: Handle different number of keyframes for each axis"
+    assert len(x.keyframe_points) == len(y.keyframe_points) and len(
+        x.keyframe_points
+    ) == len(
+        z.keyframe_points
+    ), "TODO: Handle different number of keyframes for each axis"
 
     transform_mat = calculate_bone_space_transform_matrix(old_pose_bone, new_pose_bone)
 
-    for x_kfp, y_kfp, z_kfp in zip(x.keyframe_points, y.keyframe_points, z.keyframe_points):
+    for x_kfp, y_kfp, z_kfp in zip(
+        x.keyframe_points, y.keyframe_points, z.keyframe_points
+    ):
         x_co, y_co, z_co = x_kfp.co, y_kfp.co, z_kfp.co
-        assert x_co[0] == y_co[0] and x_co[0] == z_co[0], "TODO: Handle different keyframe times"
+        assert (
+            x_co[0] == y_co[0] and x_co[0] == z_co[0]
+        ), "TODO: Handle different keyframe times"
 
         old_vec = Vector((x_co[1], y_co[1], z_co[1]))
         new_vec = transform_mat @ old_vec
@@ -306,14 +317,22 @@ def transform_bone_rotation_quaternion_space(fcurves, old_pose_bone, new_pose_bo
     if w is None:
         return
 
-    assert len(x.keyframe_points) == len(y.keyframe_points) and len(x.keyframe_points) == len(z.keyframe_points) and len(x.keyframe_points) == len(w.keyframe_points), "TODO: Handle different number of keyframes for each axis"
+    assert (
+        len(x.keyframe_points) == len(y.keyframe_points)
+        and len(x.keyframe_points) == len(z.keyframe_points)
+        and len(x.keyframe_points) == len(w.keyframe_points)
+    ), "TODO: Handle different number of keyframes for each axis"
 
     transform_mat = calculate_bone_space_transform_matrix(old_pose_bone, new_pose_bone)
 
     prev_quat = None
-    for w_kfp, x_kfp, y_kfp, z_kfp in zip(w.keyframe_points, x.keyframe_points, y.keyframe_points, z.keyframe_points):
+    for w_kfp, x_kfp, y_kfp, z_kfp in zip(
+        w.keyframe_points, x.keyframe_points, y.keyframe_points, z.keyframe_points
+    ):
         w_co, x_co, y_co, z_co = w_kfp.co, x_kfp.co, y_kfp.co, z_kfp.co
-        assert x_co[0] == y_co[0] and x_co[0] == z_co[0] and x_co[0] == w_co[0], "TODO: Handle different keyframe times"
+        assert (
+            x_co[0] == y_co[0] and x_co[0] == z_co[0] and x_co[0] == w_co[0]
+        ), "TODO: Handle different keyframe times"
 
         quat = Quaternion((w_co[1], x_co[1], y_co[1], z_co[1]))
         quat.rotate(transform_mat)
@@ -348,19 +367,29 @@ def transform_camera_rotation_quaternion(fcurves, old_camera, new_camera):
         return
 
     # changing between blender cameras or non-camera targets, doesn't need to be converted
-    if (old_camera is not None and new_camera is not None) or (old_camera is None and new_camera is None):
+    if (old_camera is not None and new_camera is not None) or (
+        old_camera is None and new_camera is None
+    ):
         return
 
-    assert len(x.keyframe_points) == len(y.keyframe_points) and len(x.keyframe_points) == len(z.keyframe_points) and len(x.keyframe_points) == len(w.keyframe_points), "TODO: Handle different number of keyframes for each axis"
+    assert (
+        len(x.keyframe_points) == len(y.keyframe_points)
+        and len(x.keyframe_points) == len(z.keyframe_points)
+        and len(x.keyframe_points) == len(w.keyframe_points)
+    ), "TODO: Handle different number of keyframes for each axis"
 
     # if new camera is None, we convert from Blender to RAGE; otherwise from RAGE to Blender
     angle_delta = math.radians(-90.0 if new_camera is None else 90.0)
     x_axis = Vector((1.0, 0.0, 0.0))
 
     prev_quat = None
-    for w_kfp, x_kfp, y_kfp, z_kfp in zip(w.keyframe_points, x.keyframe_points, y.keyframe_points, z.keyframe_points):
+    for w_kfp, x_kfp, y_kfp, z_kfp in zip(
+        w.keyframe_points, x.keyframe_points, y.keyframe_points, z.keyframe_points
+    ):
         w_co, x_co, y_co, z_co = w_kfp.co, x_kfp.co, y_kfp.co, z_kfp.co
-        assert x_co[0] == y_co[0] and x_co[0] == z_co[0] and x_co[0] == w_co[0], "TODO: Handle different keyframe times"
+        assert (
+            x_co[0] == y_co[0] and x_co[0] == z_co[0] and x_co[0] == w_co[0]
+        ), "TODO: Handle different keyframe times"
 
         quat = Quaternion((w_co[1], x_co[1], y_co[1], z_co[1]))
         x_axis_local = quat @ x_axis
@@ -395,14 +424,20 @@ def add_driver_variable_obj_prop(fcurve, name, obj, obj_type, prop_data_path):
 
 def setup_camera_for_animation(camera: bpy.types.Camera):
     camera_obj = get_data_obj(camera)
-    camera_obj.rotation_mode = "QUATERNION"  # camera rotation track uses rotation_quaternion
+    camera_obj.rotation_mode = (
+        "QUATERNION"  # camera rotation track uses rotation_quaternion
+    )
 
     # connect camera_fov track to blender camera
     # NOTE: seems to report a dependency cycle, but works fine, blender bug?
     camera.driver_remove("lens")
     fcurve_lens = camera.driver_add("lens")
-    add_driver_variable_obj_prop(fcurve_lens, "fov", camera_obj, "OBJECT", "animation_tracks.camera_fov")
-    add_driver_variable_obj_prop(fcurve_lens, "sensor", camera, "CAMERA", "sensor_width")
+    add_driver_variable_obj_prop(
+        fcurve_lens, "fov", camera_obj, "OBJECT", "animation_tracks.camera_fov"
+    )
+    add_driver_variable_obj_prop(
+        fcurve_lens, "sensor", camera, "CAMERA", "sensor_width"
+    )
     fcurve_lens.driver.expression = "(sensor * 0.5) / tan(radians(fov) * 0.5)"
     fcurve_lens.update()
 
@@ -416,7 +451,9 @@ def add_global_anim_uv_drivers(material, x_dot_node, y_dot_node):
         for i in range(3):
             fcurve = fcurves[i]
             comp = components[i]
-            add_driver_variable_obj_prop(fcurve, comp, material, "MATERIAL", f"animation_tracks.{track}.{comp}")
+            add_driver_variable_obj_prop(
+                fcurve, comp, material, "MATERIAL", f"animation_tracks.{track}.{comp}"
+            )
             fcurve.driver.expression = comp
             fcurve.update()
 
@@ -494,7 +531,9 @@ def setup_material_for_animation(material: bpy.types.Material):
 
 def setup_armature_for_animation(armature: bpy.types.Armature):
     armature_obj = get_data_obj(armature)
-    armature_obj.rotation_mode = "QUATERNION"  # root rotation track uses rotation_quaternion
+    armature_obj.rotation_mode = (
+        "QUATERNION"  # root rotation track uses rotation_quaternion
+    )
 
 
 def get_canonical_track_data_path(track: Track, bone_id: int):
@@ -505,16 +544,18 @@ def get_canonical_track_data_path(track: Track, bone_id: int):
     base = f'pose.bones["#{bone_id}"].'
 
     if track == Track.BonePosition:
-        return f'{base}location'
+        return f"{base}location"
     elif track == Track.BoneRotation:
-        return f'{base}rotation_quaternion'
+        return f"{base}rotation_quaternion"
     elif track == Track.BoneScale:
-        return f'{base}scale'
+        return f"{base}scale"
     else:
-        return f'{base}animation_tracks_{TrackToPropertyNameMap[track]}'
+        return f"{base}animation_tracks_{TrackToPropertyNameMap[track]}"
 
 
-def track_data_path_to_canonical_form(data_path: str, target_id: bpy.types.ID, target_bone_name_map):
+def track_data_path_to_canonical_form(
+    data_path: str, target_id: bpy.types.ID, target_bone_name_map
+):
     is_armature = isinstance(target_id, bpy.types.Armature) or target_id is None
     is_camera = isinstance(target_id, bpy.types.Camera) or target_id is None
     is_material = isinstance(target_id, bpy.types.Material) or target_id is None
@@ -528,16 +569,22 @@ def track_data_path_to_canonical_form(data_path: str, target_id: bpy.types.ID, t
     elif is_camera and data_path == "rotation_quaternion":
         data_path = 'pose.bones["#0"].animation_tracks_camera_rotation'
     elif is_camera and data_path.startswith("animation_tracks.camera_"):
-        data_path = data_path.replace("animation_tracks.", 'pose.bones["#0"].animation_tracks_')
+        data_path = data_path.replace(
+            "animation_tracks.", 'pose.bones["#0"].animation_tracks_'
+        )
     elif is_material and data_path.startswith("animation_tracks.uv"):
-        data_path = data_path.replace("animation_tracks.", 'pose.bones["#0"].animation_tracks_')
+        data_path = data_path.replace(
+            "animation_tracks.", 'pose.bones["#0"].animation_tracks_'
+        )
     elif is_armature and data_path.startswith('pose.bones["'):  # bone properties
         data_path_parts = data_path.split('"')
         bone_name = data_path_parts[1]
         if bone_name.startswith("#"):
             pass  # already a bone ID (canonical form)
         else:
-            assert target_bone_name_map is not None, "The armature bone-map is required at this point"
+            assert (
+                target_bone_name_map is not None
+            ), "The armature bone-map is required at this point"
             bone_id = target_bone_name_map[bone_name]
             data_path_parts[1] = f"#{bone_id}"
             data_path = '"'.join(data_path_parts)
@@ -545,7 +592,9 @@ def track_data_path_to_canonical_form(data_path: str, target_id: bpy.types.ID, t
     return data_path
 
 
-def track_data_path_to_target_form(data_path: str, target_id: bpy.types.ID, target_bone_map):
+def track_data_path_to_target_form(
+    data_path: str, target_id: bpy.types.ID, target_bone_map
+):
     """
     Converts a data path from the canonical form to the target form, data path specific to the target.
     For example, inserting the bone name into the data path with armature targets.
@@ -562,16 +611,24 @@ def track_data_path_to_target_form(data_path: str, target_id: bpy.types.ID, targ
         data_path = "delta_location"
     elif data_path == 'pose.bones["#0"].animation_tracks_mover_rotation':
         data_path = "delta_rotation_quaternion"
-    elif is_camera and data_path.startswith('pose.bones["#0"].animation_tracks_camera_'):  # camera properties
+    elif is_camera and data_path.startswith(
+        'pose.bones["#0"].animation_tracks_camera_'
+    ):  # camera properties
         # modify the actual camera object instead of a pose bone
-        data_path = data_path.replace('pose.bones["#0"].animation_tracks_', "animation_tracks.")
+        data_path = data_path.replace(
+            'pose.bones["#0"].animation_tracks_', "animation_tracks."
+        )
         if data_path == "animation_tracks.camera_location":
             data_path = "location"  # use the object location property
         elif data_path == "animation_tracks.camera_rotation":
             data_path = "rotation_quaternion"  # use the object rotation property
-    elif is_material and data_path.startswith('pose.bones["#0"].animation_tracks_uv'):  # uv properties
+    elif is_material and data_path.startswith(
+        'pose.bones["#0"].animation_tracks_uv'
+    ):  # uv properties
         # modify the actual drawable geometry object instead of a pose bone
-        data_path = data_path.replace('pose.bones["#0"].animation_tracks_', "animation_tracks.")
+        data_path = data_path.replace(
+            'pose.bones["#0"].animation_tracks_', "animation_tracks."
+        )
     elif is_armature and data_path.startswith('pose.bones["'):  # bone properties
         # insert bone names in data paths
         data_path_parts = data_path.split('"')
@@ -588,10 +645,12 @@ def track_data_path_to_target_form(data_path: str, target_id: bpy.types.ID, targ
 
 
 def get_id_and_track_from_track_data_path(
-        data_path: str, target_id: bpy.types.ID, target_bone_name_map
+    data_path: str, target_id: bpy.types.ID, target_bone_name_map
 ) -> Tuple[int, Track] | None:
     """Gets the bone ID and track from a data path."""
-    canon_data_path = track_data_path_to_canonical_form(data_path, target_id, target_bone_name_map)
+    canon_data_path = track_data_path_to_canonical_form(
+        data_path, target_id, target_bone_name_map
+    )
     canon_data_path_parts = canon_data_path.split('"')
     if len(canon_data_path_parts) != 3:
         return None
@@ -605,7 +664,9 @@ def get_id_and_track_from_track_data_path(
         track = Track.BoneRotation
     elif track_str == "scale":
         track = Track.BoneScale
-    elif track_str.startswith("animation_tracks_uv_transforms["):  # special case for UV transforms collection
+    elif track_str.startswith(
+        "animation_tracks_uv_transforms["
+    ):  # special case for UV transforms collection
         track = Track.UVTransforms
     else:
         prop_name = track_str.removeprefix("animation_tracks_")
@@ -616,7 +677,11 @@ def get_id_and_track_from_track_data_path(
     return id, track
 
 
-def retarget_animation(animation_obj: bpy.types.Object, old_target_id: bpy.types.ID, new_target_id: bpy.types.ID):
+def retarget_animation(
+    animation_obj: bpy.types.Object,
+    old_target_id: bpy.types.ID,
+    new_target_id: bpy.types.ID,
+):
     if isinstance(old_target_id, bpy.types.Armature):
         old_bone_map = build_bone_map(get_data_obj(old_target_id))
         old_bone_name_map = build_name_bone_map(get_data_obj(old_target_id))
@@ -643,9 +708,13 @@ def retarget_animation(animation_obj: bpy.types.Object, old_target_id: bpy.types
         # TODO: can we somehow store the track ID in the F-Curve to avoid parsing the data paths?
         data_path = fcurve.data_path
 
-        canon_data_path = track_data_path_to_canonical_form(data_path, old_target_id, old_bone_name_map)
+        canon_data_path = track_data_path_to_canonical_form(
+            data_path, old_target_id, old_bone_name_map
+        )
 
-        data_path = track_data_path_to_target_form(canon_data_path, new_target_id, new_bone_map)
+        data_path = track_data_path_to_target_form(
+            canon_data_path, new_target_id, new_bone_map
+        )
 
         # check if track needs to be transformed
         data_path_parts = canon_data_path.split('"')
@@ -681,8 +750,12 @@ def retarget_animation(animation_obj: bpy.types.Object, old_target_id: bpy.types
         transform_bone_rotation_quaternion_space(fcurves, old_bone, new_bone)
 
     for bone_id, fcurves in camera_rotations_to_transform.items():
-        old_camera = old_target_id if isinstance(old_target_id, bpy.types.Camera) else None
-        new_camera = new_target_id if isinstance(new_target_id, bpy.types.Camera) else None
+        old_camera = (
+            old_target_id if isinstance(old_target_id, bpy.types.Camera) else None
+        )
+        new_camera = (
+            new_target_id if isinstance(new_target_id, bpy.types.Camera) else None
+        )
         transform_camera_rotation_quaternion(fcurves, old_camera, new_camera)
 
     if new_is_armature:
@@ -718,11 +791,13 @@ def get_target_from_id(target_id: bpy.types.ID) -> bpy.types.ID:
 
 
 def is_any_sollumz_animation_obj(obj: bpy.types.Object) -> bool:
-    return obj.sollum_type in {SollumType.CLIP_DICTIONARY,
-                               SollumType.ANIMATION,
-                               SollumType.ANIMATIONS,
-                               SollumType.CLIP,
-                               SollumType.CLIPS}
+    return obj.sollum_type in {
+        SollumType.CLIP_DICTIONARY,
+        SollumType.ANIMATION,
+        SollumType.ANIMATIONS,
+        SollumType.CLIP,
+        SollumType.CLIPS,
+    }
 
 
 def update_uv_clip_hash(clip_obj) -> bool:
@@ -741,15 +816,23 @@ def update_uv_clip_hash(clip_obj) -> bool:
         logger.error(f"Material '{target.name}' is not used by any mesh.")
         return False
     elif len(meshes) > 1:
-        logger.warning(f"Material is used by more than one mesh. '{meshes[0].name}' will be used.")
+        logger.warning(
+            f"Material is used by more than one mesh. '{meshes[0].name}' will be used."
+        )
 
     mesh = meshes[0]
-    drawable_models = [o for o in bpy.data.objects if o.sollum_type == SollumType.DRAWABLE_MODEL and o.data == mesh]
+    drawable_models = [
+        o
+        for o in bpy.data.objects
+        if o.sollum_type == SollumType.DRAWABLE_MODEL and o.data == mesh
+    ]
     if len(drawable_models) == 0:
         logger.error(f"Material '{target.name}' is not used by any drawable model.")
         return False
     elif len(drawable_models) > 1:
-        logger.warning(f"Material is used by more than one drawable model. '{drawable_models[0].name}' will be used.")
+        logger.warning(
+            f"Material is used by more than one drawable model. '{drawable_models[0].name}' will be used."
+        )
 
     drawable_model = drawable_models[0]
     if drawable_model.parent is None:
@@ -760,7 +843,10 @@ def update_uv_clip_hash(clip_obj) -> bool:
     temp_parent_obj = drawable_model
     while temp_parent_obj.parent:
         temp_parent_obj = temp_parent_obj.parent
-        if temp_parent_obj.sollum_type == SollumType.DRAWABLE or temp_parent_obj.sollum_type == SollumType.FRAGMENT :
+        if (
+            temp_parent_obj.sollum_type == SollumType.DRAWABLE
+            or temp_parent_obj.sollum_type == SollumType.FRAGMENT
+        ):
             parent = temp_parent_obj
         else:
             break

--- a/tools/blenderhelper.py
+++ b/tools/blenderhelper.py
@@ -20,7 +20,7 @@ def remove_number_suffix(string: str):
     if match is None:
         return string
 
-    return string[:match.start()]
+    return string[: match.start()]
 
 
 def create_brush(name):
@@ -130,6 +130,7 @@ def remove_unused_materials(obj):
     obj.select_set(True)
     bpy.ops.object.material_slot_remove_unused()
 
+
 # MIT License
 
 # Copyright (c) 2017 GiveMeAllYourCats
@@ -180,8 +181,11 @@ def get_selected_vertices(obj):
     if obj.mode != "OBJECT":
         bpy.ops.object.mode_set(mode="OBJECT")
     # We need to switch from Edit mode to Object mode so the vertex selection gets updated (disgusting!)
-    verts = [obj.matrix_world @ Vector((v.co.x, v.co.y, v.co.z))
-             for v in obj.data.vertices if v.select]
+    verts = [
+        obj.matrix_world @ Vector((v.co.x, v.co.y, v.co.z))
+        for v in obj.data.vertices
+        if v.select
+    ]
     bpy.ops.object.mode_set(mode=mode)
     return verts
 
@@ -290,7 +294,11 @@ def get_object_with_children(obj):
     return objs
 
 
-def create_blender_object(sollum_type: SollumType, name: Optional[str] = None, object_data: Optional[bpy.types.Mesh] = None) -> bpy.types.Object:
+def create_blender_object(
+    sollum_type: SollumType,
+    name: Optional[str] = None,
+    object_data: Optional[bpy.types.Mesh] = None,
+) -> bpy.types.Object:
     """Create a bpy object of the given sollum type and link it to the scene."""
     name = name or SOLLUMZ_UI_NAMES[sollum_type]
     object_data = object_data or bpy.data.meshes.new(name)
@@ -301,7 +309,9 @@ def create_blender_object(sollum_type: SollumType, name: Optional[str] = None, o
     return obj
 
 
-def create_empty_object(sollum_type: SollumType, name: Optional[str] = None) -> bpy.types.Object:
+def create_empty_object(
+    sollum_type: SollumType, name: Optional[str] = None
+) -> bpy.types.Object:
     """Create a bpy empty object of the given sollum type and link it to the scene."""
     name = name or SOLLUMZ_UI_NAMES[sollum_type]
     obj = bpy.data.objects.new(name, None)
@@ -326,7 +336,11 @@ def add_armature_modifier(obj: bpy.types.Object, armature_obj: bpy.types.Object)
     return mod
 
 
-def add_child_of_bone_constraint(obj: bpy.types.Object, armature_obj: bpy.types.Object, target_bone: Optional[str] = None):
+def add_child_of_bone_constraint(
+    obj: bpy.types.Object,
+    armature_obj: bpy.types.Object,
+    target_bone: Optional[str] = None,
+):
     """Add Child Of constraint and set bone. Also sets bone target space and owner space so that parenting evaluated properly."""
     constraint: bpy.types.ChildOfConstraint = obj.constraints.new("CHILD_OF")
     constraint.target = armature_obj
@@ -393,13 +407,19 @@ def get_child_of_pose_bone(obj: bpy.types.Object) -> Optional[bpy.types.PoseBone
     return armature.pose.bones.get(constraint.subtarget)
 
 
-def get_child_of_constraint(obj: bpy.types.Object) -> Optional[bpy.types.ChildOfConstraint]:
+def get_child_of_constraint(
+    obj: bpy.types.Object,
+) -> Optional[bpy.types.ChildOfConstraint]:
     """Get first child of constraint with armature target and bone subtarget set. Returns None if not found."""
     for constraint in obj.constraints:
         if constraint.type != "CHILD_OF":
             continue
 
-        if constraint.target and constraint.target.type == "ARMATURE" and constraint.subtarget:
+        if (
+            constraint.target
+            and constraint.target.type == "ARMATURE"
+            and constraint.subtarget
+        ):
             return constraint
 
 
@@ -418,24 +438,50 @@ def parent_objs(objs: list[bpy.types.Object], parent_obj: bpy.types.Object):
 
 def lod_level_enum_flag_prop_factory(default: set[LODLevel] = None):
     """Returns an EnumProperty as a flag with all LOD levels"""
-    default = default or {LODLevel.HIGH,
-                          LODLevel.MEDIUM, LODLevel.LOW, LODLevel.VERYLOW}
+    default = default or {
+        LODLevel.HIGH,
+        LODLevel.MEDIUM,
+        LODLevel.LOW,
+        LODLevel.VERYLOW,
+    }
     return bpy.props.EnumProperty(
         items=(
-            (LODLevel.VERYHIGH.value,
-             SOLLUMZ_UI_NAMES[LODLevel.VERYHIGH], SOLLUMZ_UI_NAMES[LODLevel.VERYHIGH]),
-            (LODLevel.HIGH.value,
-             SOLLUMZ_UI_NAMES[LODLevel.HIGH], SOLLUMZ_UI_NAMES[LODLevel.HIGH]),
-            (LODLevel.MEDIUM.value,
-             SOLLUMZ_UI_NAMES[LODLevel.MEDIUM], SOLLUMZ_UI_NAMES[LODLevel.MEDIUM]),
-            (LODLevel.LOW.value,
-             SOLLUMZ_UI_NAMES[LODLevel.LOW], SOLLUMZ_UI_NAMES[LODLevel.LOW]),
-            (LODLevel.VERYLOW.value,
-             SOLLUMZ_UI_NAMES[LODLevel.VERYLOW], SOLLUMZ_UI_NAMES[LODLevel.VERYLOW]),
-        ), options={"ENUM_FLAG"}, default=default)
+            (
+                LODLevel.VERYHIGH.value,
+                SOLLUMZ_UI_NAMES[LODLevel.VERYHIGH],
+                SOLLUMZ_UI_NAMES[LODLevel.VERYHIGH],
+            ),
+            (
+                LODLevel.HIGH.value,
+                SOLLUMZ_UI_NAMES[LODLevel.HIGH],
+                SOLLUMZ_UI_NAMES[LODLevel.HIGH],
+            ),
+            (
+                LODLevel.MEDIUM.value,
+                SOLLUMZ_UI_NAMES[LODLevel.MEDIUM],
+                SOLLUMZ_UI_NAMES[LODLevel.MEDIUM],
+            ),
+            (
+                LODLevel.LOW.value,
+                SOLLUMZ_UI_NAMES[LODLevel.LOW],
+                SOLLUMZ_UI_NAMES[LODLevel.LOW],
+            ),
+            (
+                LODLevel.VERYLOW.value,
+                SOLLUMZ_UI_NAMES[LODLevel.VERYLOW],
+                SOLLUMZ_UI_NAMES[LODLevel.VERYLOW],
+            ),
+        ),
+        options={"ENUM_FLAG"},
+        default=default,
+    )
 
 
-def tag_redraw(context: bpy.types.Context, space_type: str = "PROPERTIES", region_type: str = "WINDOW"):
+def tag_redraw(
+    context: bpy.types.Context,
+    space_type: str = "PROPERTIES",
+    region_type: str = "WINDOW",
+):
     """Redraw all panels in the given space_type and region_type"""
     for window in context.window_manager.windows:
         for area in window.screen.areas:
@@ -445,7 +491,9 @@ def tag_redraw(context: bpy.types.Context, space_type: str = "PROPERTIES", regio
                         region.tag_redraw()
 
 
-def find_bsdf_and_material_output(material: bpy.types.Material) -> Tuple[bpy.types.ShaderNodeBsdfPrincipled, bpy.types.ShaderNodeOutputMaterial]:
+def find_bsdf_and_material_output(
+    material: bpy.types.Material,
+) -> Tuple[bpy.types.ShaderNodeBsdfPrincipled, bpy.types.ShaderNodeOutputMaterial]:
     material_output = None
     bsdf = None
     for node in material.node_tree.nodes:
@@ -455,4 +503,3 @@ def find_bsdf_and_material_output(material: bpy.types.Material) -> Tuple[bpy.typ
             bsdf = node
 
     return bsdf, material_output
-

--- a/tools/boundhelper.py
+++ b/tools/boundhelper.py
@@ -3,7 +3,11 @@ import bpy
 from ..sollumz_properties import SollumType, BOUND_TYPES
 from ..tools.meshhelper import create_box
 from ..ybn.properties import load_flag_presets, flag_presets, BoundFlags
-from .blenderhelper import create_blender_object, create_empty_object, remove_number_suffix
+from .blenderhelper import (
+    create_blender_object,
+    create_empty_object,
+    remove_number_suffix,
+)
 from mathutils import Vector
 
 
@@ -116,13 +120,21 @@ def constrain_bound(obj: bpy.types.Object):
     constraint.max_z = 1
 
 
-def convert_objs_to_composites(objs: list[bpy.types.Object], bound_child_type: SollumType, apply_default_flags: bool = False):
+def convert_objs_to_composites(
+    objs: list[bpy.types.Object],
+    bound_child_type: SollumType,
+    apply_default_flags: bool = False,
+):
     """Convert each object in ``objs`` to a Bound Composite."""
     for obj in objs:
         convert_obj_to_composite(obj, bound_child_type, apply_default_flags)
 
 
-def convert_objs_to_single_composite(objs: list[bpy.types.Object], bound_child_type: SollumType, apply_default_flags: bool = False):
+def convert_objs_to_single_composite(
+    objs: list[bpy.types.Object],
+    bound_child_type: SollumType,
+    apply_default_flags: bool = False,
+):
     """Create a single composite from all ``objs``."""
     composite_obj = create_empty_object(SollumType.BOUND_COMPOSITE)
 
@@ -142,7 +154,8 @@ def convert_objs_to_single_composite(objs: list[bpy.types.Object], bound_child_t
 
 def center_composite_to_children(composite_obj: bpy.types.Object):
     child_objs = [
-        child for child in composite_obj.children if child.sollum_type in BOUND_TYPES]
+        child for child in composite_obj.children if child.sollum_type in BOUND_TYPES
+    ]
 
     center = Vector()
 
@@ -157,7 +170,9 @@ def center_composite_to_children(composite_obj: bpy.types.Object):
         obj.location -= center
 
 
-def convert_obj_to_composite(obj: bpy.types.Object, bound_child_type: SollumType, apply_default_flags: bool):
+def convert_obj_to_composite(
+    obj: bpy.types.Object, bound_child_type: SollumType, apply_default_flags: bool
+):
     composite_obj = create_empty_object(SollumType.BOUND_COMPOSITE)
     composite_obj.location = obj.location
     composite_obj.parent = obj.parent

--- a/tools/drawablehelper.py
+++ b/tools/drawablehelper.py
@@ -1,9 +1,21 @@
 import bpy
 from mathutils import Vector
-from ..ydr.shader_materials import create_shader, create_tinted_shader_graph, obj_has_tint_mats, try_get_node, ShaderManager
+from ..ydr.shader_materials import (
+    create_shader,
+    create_tinted_shader_graph,
+    obj_has_tint_mats,
+    try_get_node,
+    ShaderManager,
+)
 from ..sollumz_properties import SollumType, MaterialType, LODLevel
 from ..tools.blenderhelper import create_empty_object, find_bsdf_and_material_output
-from ..cwxml.drawable import BonePropertiesManager, Drawable, DrawableModel, TextureShaderParameter, VectorShaderParameter
+from ..cwxml.drawable import (
+    BonePropertiesManager,
+    Drawable,
+    DrawableModel,
+    TextureShaderParameter,
+    VectorShaderParameter,
+)
 from typing import Union
 
 
@@ -19,9 +31,11 @@ class MaterialConverter:
 
     def _convert_texture_node(self, param: TextureShaderParameter):
         node: bpy.types.ShaderNodeTexImage = try_get_node(
-            self.material.node_tree, param.name)
+            self.material.node_tree, param.name
+        )
         tonode: bpy.types.ShaderNodeTexImage = try_get_node(
-            self.new_material.node_tree, param.name)
+            self.new_material.node_tree, param.name
+        )
 
         if not node or not tonode:
             return
@@ -90,17 +104,20 @@ class MaterialConverter:
 
         if self.bsdf is None:
             raise Exception(
-                "Failed to convert material: Node tree must contain a Princpled BSDF node.")
+                "Failed to convert material: Node tree must contain a Princpled BSDF node."
+            )
 
         self.diffuse_node = self._get_diffuse_node()
 
         if self.diffuse_node is None:
             raise Exception(
-                "Failed to convert material: Material must have an image node linked to the base color.")
+                "Failed to convert material: Material must have an image node linked to the base color."
+            )
 
         if not isinstance(self.diffuse_node, bpy.types.ShaderNodeTexImage):
             raise Exception(
-                "Failed to convert material: Base color node is not an image node.")
+                "Failed to convert material: Base color node is not an image node."
+            )
 
         self.specular_node = self._get_specular_node()
         self.normal_node = self._get_normal_node()
@@ -111,11 +128,17 @@ class MaterialConverter:
     def _set_new_node_images(self):
         if self.new_material is None:
             raise Exception(
-                "Failed to set images: Sollumz material has not been created yet!")
+                "Failed to set images: Sollumz material has not been created yet!"
+            )
 
-        for node, name in {self.diffuse_node: "DiffuseSampler", self.specular_node: "SpecSampler", self.normal_node: "BumpSampler"}.items():
+        for node, name in {
+            self.diffuse_node: "DiffuseSampler",
+            self.specular_node: "SpecSampler",
+            self.normal_node: "BumpSampler",
+        }.items():
             new_node: bpy.types.ShaderNodeTexImage = try_get_node(
-                self.new_material.node_tree, name)
+                self.new_material.node_tree, name
+            )
 
             if node is None or new_node is None:
                 continue
@@ -130,7 +153,8 @@ class MaterialConverter:
     def _replace_material(self):
         if self.new_material is None:
             raise Exception(
-                "Failed to replace material: Sollumz material has not been created yet!")
+                "Failed to replace material: Sollumz material has not been created yet!"
+            )
 
         mat_name = f"{self.material.name}_{self.new_material.name}"
 
@@ -145,13 +169,19 @@ class MaterialConverter:
         has_specular_node = self.specular_node is not None
         has_normal_node = self.normal_node is not None
 
-        if has_specular_node and not isinstance(self.specular_node, bpy.types.ShaderNodeTexImage):
+        if has_specular_node and not isinstance(
+            self.specular_node, bpy.types.ShaderNodeTexImage
+        ):
             raise Exception(
-                "Failed to convert material: Specular node is not an image node.")
+                "Failed to convert material: Specular node is not an image node."
+            )
 
-        if has_normal_node and not isinstance(self.normal_node, bpy.types.ShaderNodeTexImage):
+        if has_normal_node and not isinstance(
+            self.normal_node, bpy.types.ShaderNodeTexImage
+        ):
             raise Exception(
-                "Failed to convert material: Normal map color input is not an image node.")
+                "Failed to convert material: Normal map color input is not an image node."
+            )
         if has_normal_node and has_specular_node:
             return "normal_spec.sps"
         elif has_normal_node:
@@ -238,7 +268,10 @@ def convert_obj_to_model(obj: bpy.types.Object):
 
 def center_drawable_to_models(drawable_obj: bpy.types.Object):
     model_objs = [
-        child for child in drawable_obj.children if child.sollum_type == SollumType.DRAWABLE_MODEL]
+        child
+        for child in drawable_obj.children
+        if child.sollum_type == SollumType.DRAWABLE_MODEL
+    ]
 
     center = Vector()
 

--- a/tools/fragmenthelper.py
+++ b/tools/fragmenthelper.py
@@ -2,8 +2,7 @@ from itertools import groupby
 
 
 def longest(lst, string):
-    lst = [[*g]
-           for k, g in groupby(enumerate(lst), key=lambda x: x[1]) if k == string]
+    lst = [[*g] for k, g in groupby(enumerate(lst), key=lambda x: x[1]) if k == string]
     if len(lst) > 0:
         group = max(lst, key=len)
         return group[0][0], 1 + group[-1][0]

--- a/tools/jenkhash.py
+++ b/tools/jenkhash.py
@@ -1,4 +1,3 @@
-
 def GenerateData(bts: bytes, seed=0):
     h = seed
 

--- a/tools/obb.py
+++ b/tools/obb.py
@@ -40,7 +40,6 @@ def bbox_orient(bme_verts, mx):
 
 
 def bbox_vol(box):
-
     V = (box[1] - box[0]) * (box[3] - box[2]) * (box[5] - box[4])
 
     return V
@@ -51,15 +50,16 @@ def box_coords(box):
     returns vertices in same configuration as default cube in blender
     easy to asign v.co of a cube primitive
     """
-    coords = [Vector((box[0], box[2], box[4])),
-              Vector((box[0], box[2], box[5])),
-              Vector((box[0], box[3], box[4])),
-              Vector((box[0], box[3], box[5])),
-              Vector((box[1], box[2], box[4])),
-              Vector((box[1], box[2], box[5])),
-              Vector((box[1], box[3], box[4])),
-              Vector((box[1], box[3], box[5])),
-              ]
+    coords = [
+        Vector((box[0], box[2], box[4])),
+        Vector((box[0], box[2], box[5])),
+        Vector((box[0], box[3], box[4])),
+        Vector((box[0], box[3], box[5])),
+        Vector((box[1], box[2], box[4])),
+        Vector((box[1], box[2], box[5])),
+        Vector((box[1], box[3], box[4])),
+        Vector((box[1], box[3], box[5])),
+    ]
 
     return coords
 
@@ -88,8 +88,7 @@ def get_obb(verts):
     for vert in verts:
         bme.verts.new(vert)
 
-    convex_hull = bmesh.ops.convex_hull(
-        bme, input=bme.verts, use_existing_faces=True)
+    convex_hull = bmesh.ops.convex_hull(bme, input=bme.verts, use_existing_faces=True)
     total_hull = convex_hull["geom"]
 
     hull_verts = [item for item in total_hull if hasattr(item, "co")]
@@ -101,7 +100,7 @@ def get_obb(verts):
     # Iterate through all degrees to obtain a more predictable result
     for i in range(0, 360):
         theta = math.radians(i)
-        phi = (1 + 5 ** 0.5) / 2
+        phi = (1 + 5**0.5) / 2
 
         x = math.cos(theta) * math.sin(phi)
         y = math.sin(theta) * math.sin(phi)

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -18,7 +18,7 @@ def flag_list_to_int(flag_list):
     flags = 0
     for i, enabled in enumerate(flag_list):
         if enabled == True:
-            flags += (1 << i)
+            flags += 1 << i
     return flags
 
 
@@ -163,7 +163,8 @@ def get_direction_of_vectors(a, b):
 
 def multiply_homogeneous(m: Matrix, v: Vector):
     """Multiply a 4x4 matrix by a 3d vector and get a 3d vector out. Takes the
-    resulting 4d vector and divides by the homogeneous coordinate 'w' to get a 3d vector."""
+    resulting 4d vector and divides by the homogeneous coordinate 'w' to get a 3d vector.
+    """
     x = (((m[0][0] * v.x) + (m[1][0] * v.y)) + (m[2][0] * v.z)) + m[3][0]
     y = (((m[0][1] * v.x) + (m[1][1] * v.y)) + (m[2][1] * v.z)) + m[3][1]
     z = (((m[0][2] * v.x) + (m[1][2] * v.y)) + (m[2][2] * v.z)) + m[3][2]
@@ -189,15 +190,15 @@ def get_filename(filepath: str):
 
 def np_arr_to_str(arr: NDArray, fmt: str):
     """Convert numpy array to formatted string (faster than np.savetxt)"""
-    n_fmt_chars = fmt.count('%')
+    n_fmt_chars = fmt.count("%")
 
     if arr.ndim == 1 and n_fmt_chars == 1:
-        fmt = ' '.join([fmt] * arr.size)
+        fmt = " ".join([fmt] * arr.size)
     else:
         if n_fmt_chars == 1:
-            fmt = ' '.join([fmt] * arr.shape[1])
+            fmt = " ".join([fmt] * arr.shape[1])
 
-        fmt = '\n'.join([fmt] * arr.shape[0])
+        fmt = "\n".join([fmt] * arr.shape[0])
 
     return fmt % tuple(arr.ravel())
 
@@ -209,20 +210,24 @@ def get_matrix_without_scale(matrix: Matrix) -> Matrix:
 
 
 def reshape_mat_3x4(mat_4x4: Matrix):
-    return Matrix((
-        mat_4x4[0],
-        mat_4x4[1],
-        mat_4x4[2],
-    ))
+    return Matrix(
+        (
+            mat_4x4[0],
+            mat_4x4[1],
+            mat_4x4[2],
+        )
+    )
 
 
 def reshape_mat_4x3(mat_4x4: Matrix):
-    return Matrix((
-        mat_4x4[0][:3],
-        mat_4x4[1][:3],
-        mat_4x4[2][:3],
-        mat_4x4[3][:3],
-    ))
+    return Matrix(
+        (
+            mat_4x4[0][:3],
+            mat_4x4[1][:3],
+            mat_4x4[2][:3],
+            mat_4x4[3][:3],
+        )
+    )
 
 
 def color_hash(data: str) -> Tuple[float, float, float, float]:

--- a/tools/ymaphelper.py
+++ b/tools/ymaphelper.py
@@ -12,7 +12,10 @@ def calculate_ymap_content_flags(selected_ymap=None, sollum_type=None):
         selected_ymap.ymap_properties.content_flags_toggle.has_hd = True
         selected_ymap.ymap_properties.content_flags_toggle.has_physics = True
         selected_ymap.ymap_properties.content_flags_toggle.has_occl = False
-    elif sollum_type == SollumType.YMAP_MODEL_OCCLUDER_GROUP or sollum_type == SollumType.YMAP_BOX_OCCLUDER_GROUP:
+    elif (
+        sollum_type == SollumType.YMAP_MODEL_OCCLUDER_GROUP
+        or sollum_type == SollumType.YMAP_BOX_OCCLUDER_GROUP
+    ):
         selected_ymap.ymap_properties.content_flags_toggle.has_hd = False
         selected_ymap.ymap_properties.content_flags_toggle.has_physics = False
         selected_ymap.ymap_properties.content_flags_toggle.has_occl = True
@@ -39,7 +42,10 @@ def create_ymap_group(sollum_type=None, selected_ymap=None, empty_name=None):
     if sollum_type == SollumType.YMAP_ENTITY_GROUP:
         selected_ymap.ymap_properties.content_flags_toggle.has_hd = True
         selected_ymap.ymap_properties.content_flags_toggle.has_physics = True
-    elif sollum_type == SollumType.YMAP_BOX_OCCLUDER_GROUP or sollum_type == SollumType.YMAP_MODEL_OCCLUDER_GROUP:
+    elif (
+        sollum_type == SollumType.YMAP_BOX_OCCLUDER_GROUP
+        or sollum_type == SollumType.YMAP_MODEL_OCCLUDER_GROUP
+    ):
         selected_ymap.ymap_properties.content_flags_toggle.has_occl = True
     empty.parent = selected_ymap
     calculate_ymap_content_flags(selected_ymap, sollum_type)

--- a/tools/ytyphelper.py
+++ b/tools/ytyphelper.py
@@ -38,8 +38,11 @@ def base_archetype_from_object(obj):
 
 def ytyp_from_objects(objs):
     ytyp = CMapTypes()
-    ytyp.name = os.path.basename(
-        bpy.data.filepath).replace(".blend", "") if bpy.data.filepath is not "" else "untitled"
+    ytyp.name = (
+        os.path.basename(bpy.data.filepath).replace(".blend", "")
+        if bpy.data.filepath is not ""
+        else "untitled"
+    )
     for obj in objs:
         ytyp.archetypes.append(base_archetype_from_object(obj))
     return ytyp

--- a/ybn/collision_materials.py
+++ b/ybn/collision_materials.py
@@ -4,71 +4,57 @@ from collections import namedtuple
 from .. import logger
 from ..tools.blenderhelper import find_bsdf_and_material_output
 
-CollisionMaterial = namedtuple(
-    "CollisionMaterial", "name, ui_name, color, density")
+CollisionMaterial = namedtuple("CollisionMaterial", "name, ui_name, color, density")
 
 collisionmats = [
     CollisionMaterial("DEFAULT", "Default", (255, 0, 255, 255), 1750),
     CollisionMaterial("CONCRETE", "Concrete", (145, 145, 145, 255), 7850.5),
-    CollisionMaterial("CONCRETE_POTHOLE", "Concrete Pothole",
-                      (145, 145, 145, 255), 4900),
-    CollisionMaterial("CONCRETE_DUSTY", "Concrete Dusty",
-                      (145, 140, 130, 255), 7850.5),
+    CollisionMaterial(
+        "CONCRETE_POTHOLE", "Concrete Pothole", (145, 145, 145, 255), 4900
+    ),
+    CollisionMaterial("CONCRETE_DUSTY", "Concrete Dusty", (145, 140, 130, 255), 7850.5),
     CollisionMaterial("TARMAC", "Tarmac", (90, 90, 90, 255), 6300),
-    CollisionMaterial("TARMAC_PAINTED", "Tarmac Painted",
-                      (90, 90, 90, 255), 6300),
-    CollisionMaterial("TARMAC_POTHOLE", "Tarmac Pothole",
-                      (70, 70, 70, 255), 4900),
+    CollisionMaterial("TARMAC_PAINTED", "Tarmac Painted", (90, 90, 90, 255), 6300),
+    CollisionMaterial("TARMAC_POTHOLE", "Tarmac Pothole", (70, 70, 70, 255), 4900),
     CollisionMaterial("RUMBLE_STRIP", "Rumble Strip", (90, 90, 90, 255), 6300),
-    CollisionMaterial("BREEZE_BLOCK", "Breeze Block",
-                      (145, 145, 145, 255), 7000),
+    CollisionMaterial("BREEZE_BLOCK", "Breeze Block", (145, 145, 145, 255), 7000),
     CollisionMaterial("ROCK", "Rock", (185, 185, 185, 255), 7000),
     CollisionMaterial("ROCK_MOSSY", "Rock Mossy", (185, 185, 185, 255), 7000),
     CollisionMaterial("STONE", "Stone", (185, 185, 185, 255), 7000),
-    CollisionMaterial("COBBLESTONE", "Cobblestone",
-                      (185, 185, 185, 255), 7000),
+    CollisionMaterial("COBBLESTONE", "Cobblestone", (185, 185, 185, 255), 7000),
     CollisionMaterial("BRICK", "Brick", (195, 95, 30, 255), 7000),
     CollisionMaterial("MARBLE", "Marble", (195, 155, 145, 255), 8970.5),
-    CollisionMaterial("PAVING_SLAB", "Paving Slab",
-                      (200, 165, 130, 255), 7000),
-    CollisionMaterial("SANDSTONE_SOLID", "Sandstone Solid",
-                      (215, 195, 150, 255), 8130.5),
-    CollisionMaterial("SANDSTONE_BRITTLE", "Sandstone Brittle",
-                      (205, 180, 120, 255), 5075),
+    CollisionMaterial("PAVING_SLAB", "Paving Slab", (200, 165, 130, 255), 7000),
+    CollisionMaterial(
+        "SANDSTONE_SOLID", "Sandstone Solid", (215, 195, 150, 255), 8130.5
+    ),
+    CollisionMaterial(
+        "SANDSTONE_BRITTLE", "Sandstone Brittle", (205, 180, 120, 255), 5075
+    ),
     CollisionMaterial("SAND_LOOSE", "Sand Loose", (235, 220, 190, 255), 5047),
-    CollisionMaterial("SAND_COMPACT", "Sand Compact",
-                      (250, 240, 220, 255), 5950),
+    CollisionMaterial("SAND_COMPACT", "Sand Compact", (250, 240, 220, 255), 5950),
     CollisionMaterial("SAND_WET", "Sand Wet", (190, 185, 165, 255), 6727),
     CollisionMaterial("SAND_TRACK", "Sand Track", (250, 240, 220, 255), 5775),
-    CollisionMaterial("SAND_UNDERWATER", "Sand Underwater",
-                      (135, 130, 120, 255), 5775),
-    CollisionMaterial("SAND_DRY_DEEP", "Sand Dry Deep",
-                      (110, 100, 85, 255), 5047),
-    CollisionMaterial("SAND_WET_DEEP", "Sand Wet Deep",
-                      (110, 100, 85, 255), 6727),
+    CollisionMaterial("SAND_UNDERWATER", "Sand Underwater", (135, 130, 120, 255), 5775),
+    CollisionMaterial("SAND_DRY_DEEP", "Sand Dry Deep", (110, 100, 85, 255), 5047),
+    CollisionMaterial("SAND_WET_DEEP", "Sand Wet Deep", (110, 100, 85, 255), 6727),
     CollisionMaterial("ICE", "Ice", (200, 250, 255, 255), 3216.5),
-    CollisionMaterial("ICE_TARMAC", "Ice Tarmac",
-                      (200, 250, 255, 255), 3216.5),
+    CollisionMaterial("ICE_TARMAC", "Ice Tarmac", (200, 250, 255, 255), 3216.5),
     CollisionMaterial("SNOW_LOOSE", "Snow Loose", (255, 255, 255, 255), 560),
-    CollisionMaterial("SNOW_COMPACT", "Snow Compact",
-                      (255, 255, 255, 255), 1683.5),
+    CollisionMaterial("SNOW_COMPACT", "Snow Compact", (255, 255, 255, 255), 1683.5),
     CollisionMaterial("SNOW_DEEP", "Snow Deep", (255, 255, 255, 255), 560),
-    CollisionMaterial("SNOW_TARMAC", "Snow Tarmac",
-                      (255, 255, 255, 255), 6300),
-    CollisionMaterial("GRAVEL_SMALL", "Gravel Small",
-                      (255, 255, 255, 255), 6727),
-    CollisionMaterial("GRAVEL_LARGE", "Gravel Large",
-                      (255, 255, 255, 255), 5887),
-    CollisionMaterial("GRAVEL_DEEP", "Gravel Deep",
-                      (255, 255, 255, 255), 6727),
-    CollisionMaterial("GRAVEL_TRAIN_TRACK",
-                      "Gravel Train Track", (145, 140, 130, 255), 6727),
+    CollisionMaterial("SNOW_TARMAC", "Snow Tarmac", (255, 255, 255, 255), 6300),
+    CollisionMaterial("GRAVEL_SMALL", "Gravel Small", (255, 255, 255, 255), 6727),
+    CollisionMaterial("GRAVEL_LARGE", "Gravel Large", (255, 255, 255, 255), 5887),
+    CollisionMaterial("GRAVEL_DEEP", "Gravel Deep", (255, 255, 255, 255), 6727),
+    CollisionMaterial(
+        "GRAVEL_TRAIN_TRACK", "Gravel Train Track", (145, 140, 130, 255), 6727
+    ),
     CollisionMaterial("DIRT_TRACK", "Dirt Track", (175, 160, 140, 255), 4550),
     CollisionMaterial("MUD_HARD", "Mud Hard", (175, 160, 140, 255), 5327),
     CollisionMaterial("MUD_POTHOLE", "Mud Pothole", (105, 95, 75, 255), 4200),
     CollisionMaterial("MUD_SOFT", "Mud Soft", (105, 95, 75, 255), 6055),
-    CollisionMaterial("MUD_UNDERWATER", "Mud Underwater",
-                      (75, 65, 50, 255), 6055),
+    CollisionMaterial("MUD_UNDERWATER", "Mud Underwater", (75, 65, 50, 255), 6055),
     CollisionMaterial("MUD_DEEP", "Mud Deep", (105, 95, 75, 255), 6055),
     CollisionMaterial("MARSH", "Marsh", (105, 95, 75, 255), 6055),
     CollisionMaterial("MARSH_DEEP", "Marsh Deep", (105, 95, 75, 255), 6055),
@@ -84,171 +70,186 @@ collisionmats = [
     CollisionMaterial("LEAVES", "Leaves", (70, 100, 50, 255), 350),
     CollisionMaterial("WOODCHIPS", "Woodchips", (115, 100, 70, 255), 1820),
     CollisionMaterial("TREE_BARK", "Tree Bark", (115, 100, 70, 255), 840),
-    CollisionMaterial("METAL_SOLID_SMALL", "Metal Solid Small",
-                      (155, 180, 190, 255), 24500),
-    CollisionMaterial("METAL_SOLID_MEDIUM",
-                      "Metal Solid Medium", (155, 180, 190, 255), 28000),
-    CollisionMaterial("METAL_SOLID_LARGE", "Metal Solid Large",
-                      (155, 180, 190, 255), 31500),
-    CollisionMaterial("METAL_HOLLOW_SMALL",
-                      "Metal Hollow Small", (155, 180, 190, 255), 1750),
-    CollisionMaterial("METAL_HOLLOW_MEDIUM",
-                      "Metal Hollow Medium", (155, 180, 190, 255), 2100),
-    CollisionMaterial("METAL_HOLLOW_LARGE",
-                      "Metal Hollow Large", (155, 180, 190, 255), 2450),
-    CollisionMaterial("METAL_CHAINLINK_SMALL",
-                      "Metal Chainlink Small", (155, 180, 190, 255), 3500),
-    CollisionMaterial("METAL_CHAINLINK_LARGE",
-                      "Metal Chainlink Large", (155, 180, 190, 255), 3850),
-    CollisionMaterial("METAL_CORRUGATED_IRON",
-                      "Metal Corrugated Iron", (155, 180, 190, 255), 21000),
-    CollisionMaterial("METAL_GRILLE", "Metal Grille",
-                      (155, 180, 190, 255), 3500),
-    CollisionMaterial("METAL_RAILING", "Metal Railing",
-                      (155, 180, 190, 255), 4200),
+    CollisionMaterial(
+        "METAL_SOLID_SMALL", "Metal Solid Small", (155, 180, 190, 255), 24500
+    ),
+    CollisionMaterial(
+        "METAL_SOLID_MEDIUM", "Metal Solid Medium", (155, 180, 190, 255), 28000
+    ),
+    CollisionMaterial(
+        "METAL_SOLID_LARGE", "Metal Solid Large", (155, 180, 190, 255), 31500
+    ),
+    CollisionMaterial(
+        "METAL_HOLLOW_SMALL", "Metal Hollow Small", (155, 180, 190, 255), 1750
+    ),
+    CollisionMaterial(
+        "METAL_HOLLOW_MEDIUM", "Metal Hollow Medium", (155, 180, 190, 255), 2100
+    ),
+    CollisionMaterial(
+        "METAL_HOLLOW_LARGE", "Metal Hollow Large", (155, 180, 190, 255), 2450
+    ),
+    CollisionMaterial(
+        "METAL_CHAINLINK_SMALL", "Metal Chainlink Small", (155, 180, 190, 255), 3500
+    ),
+    CollisionMaterial(
+        "METAL_CHAINLINK_LARGE", "Metal Chainlink Large", (155, 180, 190, 255), 3850
+    ),
+    CollisionMaterial(
+        "METAL_CORRUGATED_IRON", "Metal Corrugated Iron", (155, 180, 190, 255), 21000
+    ),
+    CollisionMaterial("METAL_GRILLE", "Metal Grille", (155, 180, 190, 255), 3500),
+    CollisionMaterial("METAL_RAILING", "Metal Railing", (155, 180, 190, 255), 4200),
     CollisionMaterial("METAL_DUCT", "Metal Duct", (155, 180, 190, 255), 1750),
-    CollisionMaterial("METAL_GARAGE_DOOR", "Metal Garage Door",
-                      (155, 180, 190, 255), 31500),
-    CollisionMaterial("METAL_MANHOLE", "Metal Manhole",
-                      (155, 180, 190, 255), 31500),
-    CollisionMaterial("WOOD_SOLID_SMALL", "Wood Solid Small",
-                      (155, 130, 95, 255), 1400),
-    CollisionMaterial("WOOD_SOLID_MEDIUM", "Wood Solid Medium",
-                      (155, 130, 95, 255), 2100),
-    CollisionMaterial("WOOD_SOLID_LARGE", "Wood Solid Large",
-                      (155, 130, 95, 255), 2852.5),
-    CollisionMaterial("WOOD_SOLID_POLISHED",
-                      "Wood Solid Polished", (155, 130, 95, 255), 2800),
-    CollisionMaterial("WOOD_FLOOR_DUSTY", "Wood Floor Dusty",
-                      (165, 145, 110, 255), 2100),
-    CollisionMaterial("WOOD_HOLLOW_SMALL", "Wood Hollow Small",
-                      (170, 150, 125, 255), 350),
-    CollisionMaterial("WOOD_HOLLOW_MEDIUM",
-                      "Wood Hollow Medium", (170, 150, 125, 255), 700),
-    CollisionMaterial("WOOD_HOLLOW_LARGE", "Wood Hollow Large",
-                      (170, 150, 125, 255), 1050),
-    CollisionMaterial("WOOD_CHIPBOARD", "Wood Chipboard",
-                      (170, 150, 125, 255), 595),
-    CollisionMaterial("WOOD_OLD_CREAKY", "Wood Old Creaky",
-                      (155, 130, 95, 255), 2100),
-    CollisionMaterial("WOOD_HIGH_DENSITY", "Wood High Density",
-                      (155, 130, 95, 255), 21000),
-    CollisionMaterial("WOOD_LATTICE", "Wood Lattice",
-                      (155, 130, 95, 255), 1400),
+    CollisionMaterial(
+        "METAL_GARAGE_DOOR", "Metal Garage Door", (155, 180, 190, 255), 31500
+    ),
+    CollisionMaterial("METAL_MANHOLE", "Metal Manhole", (155, 180, 190, 255), 31500),
+    CollisionMaterial(
+        "WOOD_SOLID_SMALL", "Wood Solid Small", (155, 130, 95, 255), 1400
+    ),
+    CollisionMaterial(
+        "WOOD_SOLID_MEDIUM", "Wood Solid Medium", (155, 130, 95, 255), 2100
+    ),
+    CollisionMaterial(
+        "WOOD_SOLID_LARGE", "Wood Solid Large", (155, 130, 95, 255), 2852.5
+    ),
+    CollisionMaterial(
+        "WOOD_SOLID_POLISHED", "Wood Solid Polished", (155, 130, 95, 255), 2800
+    ),
+    CollisionMaterial(
+        "WOOD_FLOOR_DUSTY", "Wood Floor Dusty", (165, 145, 110, 255), 2100
+    ),
+    CollisionMaterial(
+        "WOOD_HOLLOW_SMALL", "Wood Hollow Small", (170, 150, 125, 255), 350
+    ),
+    CollisionMaterial(
+        "WOOD_HOLLOW_MEDIUM", "Wood Hollow Medium", (170, 150, 125, 255), 700
+    ),
+    CollisionMaterial(
+        "WOOD_HOLLOW_LARGE", "Wood Hollow Large", (170, 150, 125, 255), 1050
+    ),
+    CollisionMaterial("WOOD_CHIPBOARD", "Wood Chipboard", (170, 150, 125, 255), 595),
+    CollisionMaterial("WOOD_OLD_CREAKY", "Wood Old Creaky", (155, 130, 95, 255), 2100),
+    CollisionMaterial(
+        "WOOD_HIGH_DENSITY", "Wood High Density", (155, 130, 95, 255), 21000
+    ),
+    CollisionMaterial("WOOD_LATTICE", "Wood Lattice", (155, 130, 95, 255), 1400),
     CollisionMaterial("CERAMIC", "Ceramic", (220, 210, 195, 255), 9695),
     CollisionMaterial("ROOF_TILE", "Roof Tile", (220, 210, 195, 255), 7000),
     CollisionMaterial("ROOF_FELT", "Roof Felt", (165, 145, 110, 255), 5250),
     CollisionMaterial("FIBREGLASS", "Fibreglass", (255, 250, 210, 255), 1750),
     CollisionMaterial("TARPAULIN", "Tarpaulin", (255, 250, 210, 255), 2800),
     CollisionMaterial("PLASTIC", "Plastic", (255, 250, 210, 255), 3500),
-    CollisionMaterial("PLASTIC_HOLLOW", "Plastic Hollow",
-                      (240, 230, 185, 255), 875),
-    CollisionMaterial("PLASTIC_HIGH_DENSITY",
-                      "Plastic High Density", (255, 250, 210, 255), 21000),
-    CollisionMaterial("PLASTIC_CLEAR", "Plastic Clear",
-                      (255, 250, 210, 255), 3500),
-    CollisionMaterial("PLASTIC_HOLLOW_CLEAR",
-                      "Plastic Hollow Clear", (240, 230, 185, 255), 875),
-    CollisionMaterial("PLASTIC_HIGH_DENSITY_CLEAR",
-                      "Plastic High Density Clear", (255, 250, 210, 255), 21000),
-    CollisionMaterial("FIBREGLASS_HOLLOW", "Fibreglass Hollow",
-                      (240, 230, 185, 255), 126),
+    CollisionMaterial("PLASTIC_HOLLOW", "Plastic Hollow", (240, 230, 185, 255), 875),
+    CollisionMaterial(
+        "PLASTIC_HIGH_DENSITY", "Plastic High Density", (255, 250, 210, 255), 21000
+    ),
+    CollisionMaterial("PLASTIC_CLEAR", "Plastic Clear", (255, 250, 210, 255), 3500),
+    CollisionMaterial(
+        "PLASTIC_HOLLOW_CLEAR", "Plastic Hollow Clear", (240, 230, 185, 255), 875
+    ),
+    CollisionMaterial(
+        "PLASTIC_HIGH_DENSITY_CLEAR",
+        "Plastic High Density Clear",
+        (255, 250, 210, 255),
+        21000,
+    ),
+    CollisionMaterial(
+        "FIBREGLASS_HOLLOW", "Fibreglass Hollow", (240, 230, 185, 255), 126
+    ),
     CollisionMaterial("RUBBER", "Rubber", (70, 70, 70, 255), 4200),
-    CollisionMaterial("RUBBER_HOLLOW", "Rubber Hollow",
-                      (70, 70, 70, 255), 875),
+    CollisionMaterial("RUBBER_HOLLOW", "Rubber Hollow", (70, 70, 70, 255), 875),
     CollisionMaterial("LINOLEUM", "Linoleum", (205, 150, 80, 255), 1925),
     CollisionMaterial("LAMINATE", "Laminate", (170, 150, 125, 255), 2800),
-    CollisionMaterial("CARPET_SOLID", "Carpet Solid",
-                      (250, 100, 100, 255), 1050),
-    CollisionMaterial("CARPET_SOLID_DUSTY",
-                      "Carpet Solid Dusty", (255, 135, 135, 255), 1050),
-    CollisionMaterial("CARPET_FLOORBOARD", "Carpet Floorboard",
-                      (250, 100, 100, 255), 1750),
+    CollisionMaterial("CARPET_SOLID", "Carpet Solid", (250, 100, 100, 255), 1050),
+    CollisionMaterial(
+        "CARPET_SOLID_DUSTY", "Carpet Solid Dusty", (255, 135, 135, 255), 1050
+    ),
+    CollisionMaterial(
+        "CARPET_FLOORBOARD", "Carpet Floorboard", (250, 100, 100, 255), 1750
+    ),
     CollisionMaterial("CLOTH", "Cloth", (250, 100, 100, 255), 875),
-    CollisionMaterial("PLASTER_SOLID", "Plaster Solid",
-                      (145, 145, 145, 255), 2971.5),
-    CollisionMaterial("PLASTER_BRITTLE", "Plaster Brittle",
-                      (225, 225, 225, 255), 2971.5),
-    CollisionMaterial("CARDBOARD_SHEET", "Cardboard Sheet",
-                      (120, 115, 95, 255), 400),
-    CollisionMaterial("CARDBOARD_BOX", "Cardboard Box",
-                      (120, 115, 95, 255), 200),
+    CollisionMaterial("PLASTER_SOLID", "Plaster Solid", (145, 145, 145, 255), 2971.5),
+    CollisionMaterial(
+        "PLASTER_BRITTLE", "Plaster Brittle", (225, 225, 225, 255), 2971.5
+    ),
+    CollisionMaterial("CARDBOARD_SHEET", "Cardboard Sheet", (120, 115, 95, 255), 400),
+    CollisionMaterial("CARDBOARD_BOX", "Cardboard Box", (120, 115, 95, 255), 200),
     CollisionMaterial("PAPER", "Paper", (230, 225, 220, 255), 4203.5),
     CollisionMaterial("FOAM", "Foam", (230, 235, 240, 255), 175),
-    CollisionMaterial("FEATHER_PILLOW", "Feather Pillow",
-                      (230, 230, 230, 255), 192.5),
-    CollisionMaterial("POLYSTYRENE", "Polystyrene",
-                      (255, 250, 210, 255), 157.5),
+    CollisionMaterial("FEATHER_PILLOW", "Feather Pillow", (230, 230, 230, 255), 192.5),
+    CollisionMaterial("POLYSTYRENE", "Polystyrene", (255, 250, 210, 255), 157.5),
     CollisionMaterial("LEATHER", "Leather", (250, 100, 100, 255), 3307.5),
     CollisionMaterial("TVSCREEN", "Tvscreen", (115, 125, 125, 255), 9026.5),
-    CollisionMaterial("SLATTED_BLINDS", "Slatted Blinds",
-                      (255, 250, 210, 255), 8750),
-    CollisionMaterial("GLASS_SHOOT_THROUGH",
-                      "Glass Shoot Through", (205, 240, 255, 255), 8750),
-    CollisionMaterial("GLASS_BULLETPROOF", "Glass Bulletproof",
-                      (115, 125, 125, 255), 8750),
-    CollisionMaterial("GLASS_OPAQUE", "Glass Opaque",
-                      (205, 240, 255, 255), 8750),
+    CollisionMaterial("SLATTED_BLINDS", "Slatted Blinds", (255, 250, 210, 255), 8750),
+    CollisionMaterial(
+        "GLASS_SHOOT_THROUGH", "Glass Shoot Through", (205, 240, 255, 255), 8750
+    ),
+    CollisionMaterial(
+        "GLASS_BULLETPROOF", "Glass Bulletproof", (115, 125, 125, 255), 8750
+    ),
+    CollisionMaterial("GLASS_OPAQUE", "Glass Opaque", (205, 240, 255, 255), 8750),
     CollisionMaterial("PERSPEX", "Perspex", (205, 240, 255, 255), 4130),
     CollisionMaterial("CAR_METAL", "Car Metal", (255, 255, 255, 255), 3363.5),
-    CollisionMaterial("CAR_PLASTIC", "Car Plastic",
-                      (255, 255, 255, 255), 1750),
-    CollisionMaterial("CAR_SOFTTOP", "Car Softtop",
-                      (250, 100, 100, 255), 1750),
-    CollisionMaterial("CAR_SOFTTOP_CLEAR", "Car Softtop Clear",
-                      (250, 100, 100, 255), 1750),
-    CollisionMaterial("CAR_GLASS_WEAK", "Car Glass Weak",
-                      (210, 245, 245, 255), 8750),
-    CollisionMaterial("CAR_GLASS_MEDIUM", "Car Glass Medium",
-                      (210, 245, 245, 255), 8750),
-    CollisionMaterial("CAR_GLASS_STRONG", "Car Glass Strong",
-                      (210, 245, 245, 255), 8750),
-    CollisionMaterial("CAR_GLASS_BULLETPROOF",
-                      "Car Glass Bulletproof", (210, 245, 245, 255), 8750),
-    CollisionMaterial("CAR_GLASS_OPAQUE", "Car Glass Opaque",
-                      (210, 245, 245, 255), 8750),
+    CollisionMaterial("CAR_PLASTIC", "Car Plastic", (255, 255, 255, 255), 1750),
+    CollisionMaterial("CAR_SOFTTOP", "Car Softtop", (250, 100, 100, 255), 1750),
+    CollisionMaterial(
+        "CAR_SOFTTOP_CLEAR", "Car Softtop Clear", (250, 100, 100, 255), 1750
+    ),
+    CollisionMaterial("CAR_GLASS_WEAK", "Car Glass Weak", (210, 245, 245, 255), 8750),
+    CollisionMaterial(
+        "CAR_GLASS_MEDIUM", "Car Glass Medium", (210, 245, 245, 255), 8750
+    ),
+    CollisionMaterial(
+        "CAR_GLASS_STRONG", "Car Glass Strong", (210, 245, 245, 255), 8750
+    ),
+    CollisionMaterial(
+        "CAR_GLASS_BULLETPROOF", "Car Glass Bulletproof", (210, 245, 245, 255), 8750
+    ),
+    CollisionMaterial(
+        "CAR_GLASS_OPAQUE", "Car Glass Opaque", (210, 245, 245, 255), 8750
+    ),
     CollisionMaterial("WATER", "Water", (55, 145, 230, 255), 3573.5),
     CollisionMaterial("BLOOD", "Blood", (205, 5, 5, 255), 3573.5),
     CollisionMaterial("OIL", "Oil", (80, 65, 65, 255), 3573.5),
     CollisionMaterial("PETROL", "Petrol", (70, 100, 120, 255), 3573.5),
     CollisionMaterial("FRESH_MEAT", "Fresh Meat", (255, 55, 20, 255), 4200),
     CollisionMaterial("DRIED_MEAT", "Dried Meat", (185, 100, 85, 255), 4200),
-    CollisionMaterial("EMISSIVE_GLASS", "Emissive Glass",
-                      (205, 240, 255, 255), 8750),
-    CollisionMaterial("EMISSIVE_PLASTIC", "Emissive Plastic",
-                      (255, 250, 210, 255), 3500),
-    CollisionMaterial("VFX_METAL_ELECTRIFIED",
-                      "Vfx Metal Electrified", (155, 180, 190, 255), 2100),
-    CollisionMaterial("VFX_METAL_WATER_TOWER",
-                      "Vfx Metal Water Tower", (155, 180, 190, 255), 2100),
-    CollisionMaterial("VFX_METAL_STEAM", "Vfx Metal Steam",
-                      (155, 180, 190, 255), 2100),
-    CollisionMaterial("VFX_METAL_FLAME", "Vfx Metal Flame",
-                      (155, 180, 190, 255), 2100),
-    CollisionMaterial("PHYS_NO_FRICTION", "Phys No Friction",
-                      (0, 0, 0, 255), 1750),
-    CollisionMaterial("PHYS_GOLF_BALL", "Phys Golf Ball",
-                      (0, 0, 0, 255), 577.5),
-    CollisionMaterial("PHYS_TENNIS_BALL", "Phys Tennis Ball",
-                      (0, 0, 0, 255), 350),
+    CollisionMaterial("EMISSIVE_GLASS", "Emissive Glass", (205, 240, 255, 255), 8750),
+    CollisionMaterial(
+        "EMISSIVE_PLASTIC", "Emissive Plastic", (255, 250, 210, 255), 3500
+    ),
+    CollisionMaterial(
+        "VFX_METAL_ELECTRIFIED", "Vfx Metal Electrified", (155, 180, 190, 255), 2100
+    ),
+    CollisionMaterial(
+        "VFX_METAL_WATER_TOWER", "Vfx Metal Water Tower", (155, 180, 190, 255), 2100
+    ),
+    CollisionMaterial("VFX_METAL_STEAM", "Vfx Metal Steam", (155, 180, 190, 255), 2100),
+    CollisionMaterial("VFX_METAL_FLAME", "Vfx Metal Flame", (155, 180, 190, 255), 2100),
+    CollisionMaterial("PHYS_NO_FRICTION", "Phys No Friction", (0, 0, 0, 255), 1750),
+    CollisionMaterial("PHYS_GOLF_BALL", "Phys Golf Ball", (0, 0, 0, 255), 577.5),
+    CollisionMaterial("PHYS_TENNIS_BALL", "Phys Tennis Ball", (0, 0, 0, 255), 350),
     CollisionMaterial("PHYS_CASTER", "Phys Caster", (0, 0, 0, 255), 1750),
-    CollisionMaterial("PHYS_CASTER_RUSTY",
-                      "Phys Caster Rusty", (0, 0, 0, 255), 1750),
+    CollisionMaterial("PHYS_CASTER_RUSTY", "Phys Caster Rusty", (0, 0, 0, 255), 1750),
     CollisionMaterial("PHYS_CAR_VOID", "Phys Car Void", (0, 0, 0, 255), 1750),
-    CollisionMaterial("PHYS_PED_CAPSULE", "Phys Ped Capsule",
-                      (0, 0, 0, 255), 1750),
-    CollisionMaterial("PHYS_ELECTRIC_FENCE",
-                      "Phys Electric Fence", (0, 0, 0, 255), 1750),
-    CollisionMaterial("PHYS_ELECTRIC_METAL",
-                      "Phys Electric Metal", (0, 0, 0, 255), 1750),
-    CollisionMaterial("PHYS_BARBED_WIRE", "Phys Barbed Wire",
-                      (0, 0, 0, 255), 1750),
-    CollisionMaterial("PHYS_POOLTABLE_SURFACE",
-                      "Phys Pooltable Surface", (155, 130, 95, 255), 8750),
-    CollisionMaterial("PHYS_POOLTABLE_CUSHION",
-                      "Phys Pooltable Cushion", (155, 130, 95, 255), 8750),
-    CollisionMaterial("PHYS_POOLTABLE_BALL",
-                      "Phys Pooltable Ball", (255, 250, 210, 255), 8750),
+    CollisionMaterial("PHYS_PED_CAPSULE", "Phys Ped Capsule", (0, 0, 0, 255), 1750),
+    CollisionMaterial(
+        "PHYS_ELECTRIC_FENCE", "Phys Electric Fence", (0, 0, 0, 255), 1750
+    ),
+    CollisionMaterial(
+        "PHYS_ELECTRIC_METAL", "Phys Electric Metal", (0, 0, 0, 255), 1750
+    ),
+    CollisionMaterial("PHYS_BARBED_WIRE", "Phys Barbed Wire", (0, 0, 0, 255), 1750),
+    CollisionMaterial(
+        "PHYS_POOLTABLE_SURFACE", "Phys Pooltable Surface", (155, 130, 95, 255), 8750
+    ),
+    CollisionMaterial(
+        "PHYS_POOLTABLE_CUSHION", "Phys Pooltable Cushion", (155, 130, 95, 255), 8750
+    ),
+    CollisionMaterial(
+        "PHYS_POOLTABLE_BALL", "Phys Pooltable Ball", (255, 250, 210, 255), 8750
+    ),
     CollisionMaterial("BUTTOCKS", "Buttocks", (0, 0, 0, 255), 350),
     CollisionMaterial("THIGH_LEFT", "Thigh Left", (0, 0, 0, 255), 350),
     CollisionMaterial("SHIN_LEFT", "Shin Left", (0, 0, 0, 255), 350),
@@ -265,35 +266,38 @@ collisionmats = [
     CollisionMaterial("LOWER_ARM_LEFT", "Lower Arm Left", (0, 0, 0, 255), 350),
     CollisionMaterial("HAND_LEFT", "Hand Left", (0, 0, 0, 255), 350),
     CollisionMaterial("CLAVICLE_RIGHT", "Clavicle Right", (0, 0, 0, 255), 350),
-    CollisionMaterial("UPPER_ARM_RIGHT", "Upper Arm Right",
-                      (0, 0, 0, 255), 350),
-    CollisionMaterial("LOWER_ARM_RIGHT", "Lower Arm Right",
-                      (0, 0, 0, 255), 350),
+    CollisionMaterial("UPPER_ARM_RIGHT", "Upper Arm Right", (0, 0, 0, 255), 350),
+    CollisionMaterial("LOWER_ARM_RIGHT", "Lower Arm Right", (0, 0, 0, 255), 350),
     CollisionMaterial("HAND_RIGHT", "Hand Right", (0, 0, 0, 255), 350),
     CollisionMaterial("NECK", "Neck", (0, 0, 0, 255), 350),
     CollisionMaterial("HEAD", "Head", (0, 0, 0, 255), 350),
     CollisionMaterial("ANIMAL_DEFAULT", "Animal Default", (0, 0, 0, 255), 350),
-    CollisionMaterial("CAR_ENGINE", "Car Engine",
-                      (255, 255, 255, 255), 3363.5),
+    CollisionMaterial("CAR_ENGINE", "Car Engine", (255, 255, 255, 255), 3363.5),
     CollisionMaterial("PUDDLE", "Puddle", (55, 145, 230, 255), 3573.5),
-    CollisionMaterial("CONCRETE_PAVEMENT", "Concrete Pavement",
-                      (145, 145, 145, 255), 7850.5),
-    CollisionMaterial("BRICK_PAVEMENT", "Brick Pavement",
-                      (195, 95, 30, 255), 7000),
-    CollisionMaterial("PHYS_DYNAMIC_COVER_BOUND",
-                      "Phys Dynamic Cover Bound", (0, 0, 0, 255), 1750),
-    CollisionMaterial("VFX_WOOD_BEER_BARREL",
-                      "Vfx Wood Beer Barrel", (155, 130, 95, 255), 1400),
-    CollisionMaterial("WOOD_HIGH_FRICTION",
-                      "Wood High Friction", (155, 130, 95, 255), 1400),
-    CollisionMaterial("ROCK_NOINST", "Rock Noinst",
-                      (185, 185, 185, 255), 7000),
-    CollisionMaterial("BUSHES_NOINST", "Bushes Noinst",
-                      (85, 160, 30, 255), 525),
-    CollisionMaterial("METAL_SOLID_ROAD_SURFACE",
-                      "Metal Solid Road Surface", (155, 180, 190, 255), 28000),
-    CollisionMaterial("STUNT_RAMP_SURFACE",
-                      "Stunt Ramp Surface", (155, 180, 190, 255), 28000),
+    CollisionMaterial(
+        "CONCRETE_PAVEMENT", "Concrete Pavement", (145, 145, 145, 255), 7850.5
+    ),
+    CollisionMaterial("BRICK_PAVEMENT", "Brick Pavement", (195, 95, 30, 255), 7000),
+    CollisionMaterial(
+        "PHYS_DYNAMIC_COVER_BOUND", "Phys Dynamic Cover Bound", (0, 0, 0, 255), 1750
+    ),
+    CollisionMaterial(
+        "VFX_WOOD_BEER_BARREL", "Vfx Wood Beer Barrel", (155, 130, 95, 255), 1400
+    ),
+    CollisionMaterial(
+        "WOOD_HIGH_FRICTION", "Wood High Friction", (155, 130, 95, 255), 1400
+    ),
+    CollisionMaterial("ROCK_NOINST", "Rock Noinst", (185, 185, 185, 255), 7000),
+    CollisionMaterial("BUSHES_NOINST", "Bushes Noinst", (85, 160, 30, 255), 525),
+    CollisionMaterial(
+        "METAL_SOLID_ROAD_SURFACE",
+        "Metal Solid Road Surface",
+        (155, 180, 190, 255),
+        28000,
+    ),
+    CollisionMaterial(
+        "STUNT_RAMP_SURFACE", "Stunt Ramp Surface", (155, 180, 190, 255), 28000
+    ),
     CollisionMaterial("TEMP_01", "Temp 01", (255, 0, 255, 255), 5950),
     CollisionMaterial("TEMP_02", "Temp 02", (255, 0, 255, 255), 5950),
 ]
@@ -305,8 +309,7 @@ def create_collision_material_from_index(index: int):
     try:
         matinfo = collisionmats[index]
     except IndexError:
-        logger.warning(
-            f"Invalid material index '{index}'! Setting to default...")
+        logger.warning(f"Invalid material index '{index}'! Setting to default...")
 
     mat = bpy.data.materials.new(matinfo.name)
     mat.sollum_type = MaterialType.COLLISION

--- a/ybn/operators.py
+++ b/ybn/operators.py
@@ -2,19 +2,41 @@ from math import ceil
 from ..tools.obb import get_obb, get_obb_extents
 import traceback
 from ..cwxml.flag_preset import FlagPreset
-from ..ybn.properties import BoundFlags, load_flag_presets, flag_presets, get_flag_presets_path
+from ..ybn.properties import (
+    BoundFlags,
+    load_flag_presets,
+    flag_presets,
+    get_flag_presets_path,
+)
 from ..ybn.collision_materials import create_collision_material_from_index
-from ..tools.boundhelper import create_bound_shape, convert_objs_to_composites, convert_objs_to_single_composite, center_composite_to_children
+from ..tools.boundhelper import (
+    create_bound_shape,
+    convert_objs_to_composites,
+    convert_objs_to_single_composite,
+    center_composite_to_children,
+)
 from ..tools.meshhelper import create_box_from_extents
-from ..sollumz_properties import SollumType, SOLLUMZ_UI_NAMES, BOUND_TYPES, MaterialType, BOUND_POLYGON_TYPES
+from ..sollumz_properties import (
+    SollumType,
+    SOLLUMZ_UI_NAMES,
+    BOUND_TYPES,
+    MaterialType,
+    BOUND_POLYGON_TYPES,
+)
 from ..sollumz_helper import SOLLUMZ_OT_base
-from ..tools.blenderhelper import get_selected_vertices, get_children_recursive, create_blender_object, create_empty_object
+from ..tools.blenderhelper import (
+    get_selected_vertices,
+    get_children_recursive,
+    create_blender_object,
+    create_empty_object,
+)
 import bpy
 from mathutils import Vector
 
 
 class SOLLUMZ_OT_create_polygon_bound(bpy.types.Operator):
     """Create a BVH bound child"""
+
     bl_idname = "sollumz.createpolygonbound"
     bl_label = "Create BVH Child"
 
@@ -36,13 +58,16 @@ class SOLLUMZ_OT_create_polygon_bound(bpy.types.Operator):
 
 class SOLLUMZ_OT_create_polygon_box_from_verts(bpy.types.Operator):
     """Create a Bound Polygon Box from the selected vertices (must be in edit mode)"""
+
     bl_idname = "sollumz.createpolyboxfromverts"
     bl_label = "Create Box From Selection"
     bl_options = {"UNDO"}
 
     @classmethod
     def poll(self, context):
-        return context.active_object is not None and context.active_object.mode == "EDIT"
+        return (
+            context.active_object is not None and context.active_object.mode == "EDIT"
+        )
 
     def execute(self, context):
         sollum_type = context.scene.poly_bound_type_verts
@@ -73,8 +98,7 @@ class SOLLUMZ_OT_create_polygon_box_from_verts(bpy.types.Operator):
         center = world_matrix @ (bbmin + bbmax) / 2
         local_center = (bbmin + bbmax) / 2
 
-        create_box_from_extents(
-            pobj.data, bbmin - local_center, bbmax - local_center)
+        create_box_from_extents(pobj.data, bbmin - local_center, bbmax - local_center)
 
         pobj.matrix_world = world_matrix
         pobj.location = center
@@ -86,13 +110,15 @@ class SOLLUMZ_OT_create_polygon_box_from_verts(bpy.types.Operator):
 
 class SOLLUMZ_OT_convert_to_composite(bpy.types.Operator):
     """Convert the selected object to a Bound Composite"""
+
     bl_idname = "sollumz.converttocomposite"
     bl_label = "Convert to Composite"
     bl_options = {"UNDO"}
 
     def execute(self, context):
         selected_meshes = [
-            obj for obj in context.selected_objects if obj.type == "MESH"]
+            obj for obj in context.selected_objects if obj.type == "MESH"
+        ]
 
         if not selected_meshes:
             self.report({"INFO"}, f"No mesh objects selected!")
@@ -104,22 +130,26 @@ class SOLLUMZ_OT_convert_to_composite(bpy.types.Operator):
 
         if context.scene.create_seperate_composites or len(selected_meshes) == 1:
             convert_objs_to_composites(
-                selected_meshes, bound_child_type, apply_default_flags)
+                selected_meshes, bound_child_type, apply_default_flags
+            )
         else:
             composite_obj = convert_objs_to_single_composite(
-                selected_meshes, bound_child_type, apply_default_flags)
+                selected_meshes, bound_child_type, apply_default_flags
+            )
 
             if do_center:
                 center_composite_to_children(composite_obj)
 
         self.report(
-            {"INFO"}, f"Succesfully converted all selected objects to a Composite.")
+            {"INFO"}, f"Succesfully converted all selected objects to a Composite."
+        )
 
         return {"FINISHED"}
 
 
 class SOLLUMZ_OT_create_bound(bpy.types.Operator):
     """Create a sollumz bound of the selected type"""
+
     bl_idname = "sollumz.createbound"
     bl_label = "Create Bound"
 
@@ -153,8 +183,7 @@ class CreateCollisionMatHelper:
         mat = create_collision_material_from_index(mat_index)
         obj.data.materials.append(mat)
 
-        self.report(
-            {"INFO"}, f"Succesfully added {mat.name} material to {obj.name}")
+        self.report({"INFO"}, f"Succesfully added {mat.name} material to {obj.name}")
 
     def execute(self, context):
         selected = context.selected_objects
@@ -172,14 +201,20 @@ class CreateCollisionMatHelper:
         return {"FINISHED"}
 
 
-class SOLLUMZ_OT_create_collision_material(CreateCollisionMatHelper, bpy.types.Operator):
+class SOLLUMZ_OT_create_collision_material(
+    CreateCollisionMatHelper, bpy.types.Operator
+):
     """Create a sollumz collision material"""
+
     bl_idname = "sollumz.createcollisionmaterial"
     bl_label = "Create Collision Material"
 
 
-class SOLLUMZ_OT_clear_and_create_collision_material(CreateCollisionMatHelper, bpy.types.Operator):
+class SOLLUMZ_OT_clear_and_create_collision_material(
+    CreateCollisionMatHelper, bpy.types.Operator
+):
     """Delete all materials on selected object(s) and add selected collision material."""
+
     bl_idname = "sollumz.clearandcreatecollisionmaterial"
     bl_label = "Clear and Create Collision Material"
 
@@ -188,8 +223,11 @@ class SOLLUMZ_OT_clear_and_create_collision_material(CreateCollisionMatHelper, b
         super().create_material(mat_index, obj)
 
 
-class SOLLUMZ_OT_convert_non_collision_materials_to_selected(CreateCollisionMatHelper, bpy.types.Operator):
+class SOLLUMZ_OT_convert_non_collision_materials_to_selected(
+    CreateCollisionMatHelper, bpy.types.Operator
+):
     """Convert all non-collision materials to the selected collision material."""
+
     bl_idname = "sollumz.convertnoncollisionmaterialstoselected"
     bl_label = "Convert Non-Collision Materials To Selected"
 
@@ -205,6 +243,7 @@ class SOLLUMZ_OT_convert_non_collision_materials_to_selected(CreateCollisionMatH
 
 class SOLLUMZ_OT_convert_to_collision_material(SOLLUMZ_OT_base, bpy.types.Operator):
     """Convert material to a collision material"""
+
     bl_idname = "sollumz.converttocollisionmaterial"
     bl_label = "Convert To Selected"
     bl_action = f"{bl_label}"
@@ -221,13 +260,15 @@ class SOLLUMZ_OT_convert_to_collision_material(SOLLUMZ_OT_base, bpy.types.Operat
             return False
 
         mat = create_collision_material_from_index(
-            context.scene.collision_material_index)
+            context.scene.collision_material_index
+        )
         active_mat_index = aobj.active_material_index
         aobj.data.materials[active_mat_index] = mat
 
 
 class SOLLUMZ_OT_split_collision(SOLLUMZ_OT_base, bpy.types.Operator):
     """Split a collision into many parts. Sorted based on location"""
+
     bl_idname = "sollumz.splitcollision"
     bl_label = "Split Collision"
     bl_action = f"{bl_label}"
@@ -244,7 +285,8 @@ class SOLLUMZ_OT_split_collision(SOLLUMZ_OT_base, bpy.types.Operator):
         for composite in selected:
             if composite.sollum_type != SollumType.BOUND_COMPOSITE:
                 self.message(
-                    f"Selected object {composite.name} is not a {SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE]}, skipping...")
+                    f"Selected object {composite.name} is not a {SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE]}, skipping..."
+                )
                 continue
 
             # Create list for storing bound polys
@@ -254,8 +296,7 @@ class SOLLUMZ_OT_split_collision(SOLLUMZ_OT_base, bpy.types.Operator):
                 if bvh.sollum_type == SollumType.BOUND_GEOMETRYBVH:
                     for bound_poly in bvh.children:
                         if bound_poly.sollum_type in BOUND_POLYGON_TYPES:
-                            selected_composites[composite].append(
-                                bound_poly)
+                            selected_composites[composite].append(bound_poly)
                             num_bound_polys_selected += 1
 
         # Split objects
@@ -264,24 +305,24 @@ class SOLLUMZ_OT_split_collision(SOLLUMZ_OT_base, bpy.types.Operator):
             composite.name = ""
 
             parts_per_col = ceil(
-                num_bound_polys_selected / context.scene.split_collision_count)
+                num_bound_polys_selected / context.scene.split_collision_count
+            )
 
             if num_bound_polys_selected < parts_per_col:
                 self.message(
-                    f"Can't divide by a value less than the number of Bound Polygon(s) ({num_bound_polys_selected} selected).")
+                    f"Can't divide by a value less than the number of Bound Polygon(s) ({num_bound_polys_selected} selected)."
+                )
                 return False
 
             new_composite = None
 
             for i, bound_poly in enumerate(bound_polys):
                 if i % parts_per_col == 0:
-                    new_composite = create_empty_object(
-                        SollumType.BOUND_COMPOSITE)
+                    new_composite = create_empty_object(SollumType.BOUND_COMPOSITE)
                     # new_composite = create_bound(
                     #     SollumType.BOUND_COMPOSITE, do_link=False)
 
-                    bound_poly.users_collection[0].objects.link(
-                        new_composite)
+                    bound_poly.users_collection[0].objects.link(new_composite)
 
                     new_composite.name = composite_name
                     new_composite.matrix_world = composite.matrix_world
@@ -324,6 +365,7 @@ class SOLLUMZ_OT_split_collision(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_delete_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
     """Delete a flag preset"""
+
     bl_idname = "sollumz.delete_flag_preset"
     bl_label = "Delete Flag Preset"
     bl_action = f"{bl_label}"
@@ -358,17 +400,20 @@ class SOLLUMZ_OT_delete_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
                 return True
             except:
                 self.error(
-                    f"Error during deletion of flag preset: {traceback.format_exc()}")
+                    f"Error during deletion of flag preset: {traceback.format_exc()}"
+                )
                 return False
 
         except IndexError:
             self.message(
-                f"Flag preset does not exist! Ensure the preset file is present in the '{filepath}' directory.")
+                f"Flag preset does not exist! Ensure the preset file is present in the '{filepath}' directory."
+            )
             return False
 
 
 class SOLLUMZ_OT_save_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
     """Save a flag preset"""
+
     bl_idname = "sollumz.save_flag_preset"
     bl_label = "Save Flag Preset"
     bl_action = f"{bl_label}"
@@ -381,9 +426,13 @@ class SOLLUMZ_OT_save_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
             self.message("No object selected!")
             return False
 
-        if obj.sollum_type and not (obj.sollum_type == SollumType.BOUND_GEOMETRY or obj.sollum_type == SollumType.BOUND_GEOMETRYBVH):
+        if obj.sollum_type and not (
+            obj.sollum_type == SollumType.BOUND_GEOMETRY
+            or obj.sollum_type == SollumType.BOUND_GEOMETRYBVH
+        ):
             self.message(
-                f"Selected object must be either a {SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRY]} or {SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH]}!")
+                f"Selected object must be either a {SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRY]} or {SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH]}!"
+            )
             return False
 
         name = context.scene.new_flag_preset_name
@@ -409,7 +458,8 @@ class SOLLUMZ_OT_save_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
         for preset in flag_presets.presets:
             if preset.name == name:
                 self.message(
-                    "A preset with that name already exists! If you wish to overwrite this preset, delete the original.")
+                    "A preset with that name already exists! If you wish to overwrite this preset, delete the original."
+                )
                 return False
 
         flag_presets.presets.append(flag_preset)
@@ -421,6 +471,7 @@ class SOLLUMZ_OT_save_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_load_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
     """Load a flag preset to the selected Geometry bounds"""
+
     bl_idname = "sollumz.load_flag_preset"
     bl_label = "Apply Flags Preset"
     bl_context = "object"
@@ -453,12 +504,12 @@ class SOLLUMZ_OT_load_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
 
                 # Hacky way to force the UI to redraw. For some reason setting custom properties will not cause the object properties panel to redraw, so we have to do this.
                 obj.location = obj.location
-                self.message(
-                    f"Applied preset '{preset.name}' to: {obj.name}")
+                self.message(f"Applied preset '{preset.name}' to: {obj.name}")
             except IndexError:
                 filepath = get_flag_presets_path()
                 self.error(
-                    f"Flag preset does not exist! Ensure the preset file is present in the '{filepath}' directory.")
+                    f"Flag preset does not exist! Ensure the preset file is present in the '{filepath}' directory."
+                )
                 return False
 
         return True
@@ -466,12 +517,12 @@ class SOLLUMZ_OT_load_flag_preset(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_clear_col_flags(SOLLUMZ_OT_base, bpy.types.Operator):
     """Load commonly used collision flags"""
+
     bl_idname = "sollumz.clear_col_flags"
     bl_label = "Clear Collision Flags"
     bl_action = f"{bl_label}"
 
     def run(self, context):
-
         aobj = context.active_object
         if aobj is None:
             self.message("Please select an object.")

--- a/ybn/properties.py
+++ b/ybn/properties.py
@@ -3,7 +3,13 @@ from ..sollumz_properties import SOLLUMZ_UI_NAMES, SollumType
 from bpy.app.handlers import persistent
 from .collision_materials import collisionmats
 from ..cwxml.flag_preset import FlagPresetsFile
-from ..tools.meshhelper import create_disc, create_cylinder, create_sphere, create_capsule, create_box
+from ..tools.meshhelper import (
+    create_disc,
+    create_cylinder,
+    create_sphere,
+    create_capsule,
+    create_box,
+)
 from mathutils import Vector, Matrix
 import os
 
@@ -22,9 +28,13 @@ class CollisionMatFlags(bpy.types.PropertyGroup):
     no_ragdoll: bpy.props.BoolProperty(name="NO RAGDOLL", default=False)
     vehicle_wheel: bpy.props.BoolProperty(name="VEHICLE WHEEL", default=False)
     no_ptfx: bpy.props.BoolProperty(name="NO PTFX", default=False)
-    too_steep_for_player: bpy.props.BoolProperty(name="TOO STEEP FOR PLAYER", default=False)
+    too_steep_for_player: bpy.props.BoolProperty(
+        name="TOO STEEP FOR PLAYER", default=False
+    )
     no_network_spawn: bpy.props.BoolProperty(name="NO NETWORK SPAWN", default=False)
-    no_cam_collision_allow_clipping: bpy.props.BoolProperty(name="NO CAM COLLISION ALLOW CLIPPING", default=False)
+    no_cam_collision_allow_clipping: bpy.props.BoolProperty(
+        name="NO CAM COLLISION ALLOW CLIPPING", default=False
+    )
 
 
 def set_collision_mat_raw_flags(f: CollisionMatFlags, flags_lo: int, flags_hi: int):
@@ -79,8 +89,7 @@ class CollisionProperties(CollisionMatFlags, bpy.types.PropertyGroup):
     procedural_id: bpy.props.IntProperty(name="Procedural ID", default=0)
     room_id: bpy.props.IntProperty(name="Room ID", default=0)
     ped_density: bpy.props.IntProperty(name="Ped Density", default=0)
-    material_color_index: bpy.props.IntProperty(
-        name="Material Color Index", default=0)
+    material_color_index: bpy.props.IntProperty(name="Material Color Index", default=0)
 
 
 class BoundFlags(bpy.types.PropertyGroup):
@@ -90,37 +99,31 @@ class BoundFlags(bpy.types.PropertyGroup):
     map_animal: bpy.props.BoolProperty(name="MAP ANIMAL", default=False)
     map_cover: bpy.props.BoolProperty(name="MAP COVER", default=False)
     map_vehicle: bpy.props.BoolProperty(name="MAP VEHICLE", default=False)
-    vehicle_not_bvh: bpy.props.BoolProperty(
-        name="VEHICLE NOT BVH", default=False)
+    vehicle_not_bvh: bpy.props.BoolProperty(name="VEHICLE NOT BVH", default=False)
     vehicle_bvh: bpy.props.BoolProperty(name="VEHICLE BVH", default=False)
     ped: bpy.props.BoolProperty(name="PED", default=False)
     ragdoll: bpy.props.BoolProperty(name="RAGDOLL", default=False)
     animal: bpy.props.BoolProperty(name="ANIMAL", default=False)
-    animal_ragdoll: bpy.props.BoolProperty(
-        name="ANIMAL RAGDOLL", default=False)
+    animal_ragdoll: bpy.props.BoolProperty(name="ANIMAL RAGDOLL", default=False)
     object: bpy.props.BoolProperty(name="OBJECT", default=False)
-    object_env_cloth: bpy.props.BoolProperty(
-        name="OBJECT_ENV_CLOTH", default=False)
+    object_env_cloth: bpy.props.BoolProperty(name="OBJECT_ENV_CLOTH", default=False)
     plant: bpy.props.BoolProperty(name="PLANT", default=False)
     projectile: bpy.props.BoolProperty(name="PROJECTILE", default=False)
     explosion: bpy.props.BoolProperty(name="EXPLOSION", default=False)
     pickup: bpy.props.BoolProperty(name="PICKUP", default=False)
     foliage: bpy.props.BoolProperty(name="FOLIAGE", default=False)
-    forklift_forks: bpy.props.BoolProperty(
-        name="FORKLIFT FORKS", default=False)
+    forklift_forks: bpy.props.BoolProperty(name="FORKLIFT FORKS", default=False)
     test_weapon: bpy.props.BoolProperty(name="TEST WEAPON", default=False)
     test_camera: bpy.props.BoolProperty(name="TEST CAMERA", default=False)
     test_ai: bpy.props.BoolProperty(name="TEST AI", default=False)
     test_script: bpy.props.BoolProperty(name="TEST SCRIPT", default=False)
-    test_vehicle_wheel: bpy.props.BoolProperty(
-        name="TEST VEHICLE WHEEL", default=False)
+    test_vehicle_wheel: bpy.props.BoolProperty(name="TEST VEHICLE WHEEL", default=False)
     glass: bpy.props.BoolProperty(name="GLASS", default=False)
     map_river: bpy.props.BoolProperty(name="MAP RIVER", default=False)
     smoke: bpy.props.BoolProperty(name="SMOKE", default=False)
     unsmashed: bpy.props.BoolProperty(name="UNSMASHED", default=False)
     map_stairs: bpy.props.BoolProperty(name="MAP STAIRS", default=False)
-    map_deep_surface: bpy.props.BoolProperty(
-        name="MAP DEEP SURFACE", default=False)
+    map_deep_surface: bpy.props.BoolProperty(name="MAP DEEP SURFACE", default=False)
 
 
 class BoundProperties(bpy.types.PropertyGroup):
@@ -147,7 +150,8 @@ def get_flag_presets_path():
         return presets_path
     else:
         raise FileNotFoundError(
-            f"flag_presets.xml file not found! Please redownload this file from the github and place it in '{os.path.dirname(presets_path)}'")
+            f"flag_presets.xml file not found! Please redownload this file from the github and place it in '{os.path.dirname(presets_path)}'"
+        )
 
 
 flag_presets = FlagPresetsFile()
@@ -182,134 +186,213 @@ def on_file_loaded(_):
 
 def update_bounds(self, context):
     if self.sollum_type == SollumType.BOUND_BOX:
-        create_box(self.data, 1, Matrix.Diagonal(
-            Vector(self.bound_dimensions)))
-    elif self.sollum_type == SollumType.BOUND_SPHERE or self.sollum_type == SollumType.BOUND_POLY_SPHERE:
+        create_box(self.data, 1, Matrix.Diagonal(Vector(self.bound_dimensions)))
+    elif (
+        self.sollum_type == SollumType.BOUND_SPHERE
+        or self.sollum_type == SollumType.BOUND_POLY_SPHERE
+    ):
         create_sphere(mesh=self.data, radius=self.bound_radius)
 
     elif self.sollum_type == SollumType.BOUND_CYLINDER:
-        create_cylinder(mesh=self.data, radius=self.bound_radius,
-                        length=self.bound_length)
+        create_cylinder(
+            mesh=self.data, radius=self.bound_radius, length=self.bound_length
+        )
     elif self.sollum_type == SollumType.BOUND_POLY_CYLINDER:
-        create_cylinder(mesh=self.data, radius=self.bound_radius,
-                        length=self.bound_length, rot_mat=Matrix())
+        create_cylinder(
+            mesh=self.data,
+            radius=self.bound_radius,
+            length=self.bound_length,
+            rot_mat=Matrix(),
+        )
 
     elif self.sollum_type == SollumType.BOUND_DISC:
-        create_disc(mesh=self.data, radius=self.bound_radius,
-                    length=self.margin * 2)
+        create_disc(mesh=self.data, radius=self.bound_radius, length=self.margin * 2)
 
     elif self.sollum_type == SollumType.BOUND_CAPSULE:
-        create_capsule(mesh=self.data, diameter=self.margin,
-                       length=self.bound_radius, use_rot=True)
+        create_capsule(
+            mesh=self.data, diameter=self.margin, length=self.bound_radius, use_rot=True
+        )
     elif self.sollum_type == SollumType.BOUND_POLY_CAPSULE:
-        create_capsule(mesh=self.data, diameter=self.bound_radius / 2,
-                       length=self.bound_length)
+        create_capsule(
+            mesh=self.data, diameter=self.bound_radius / 2, length=self.bound_length
+        )
 
 
 def register():
-    bpy.types.Object.bound_properties = bpy.props.PointerProperty(
-        type=BoundProperties)
+    bpy.types.Object.bound_properties = bpy.props.PointerProperty(type=BoundProperties)
     bpy.types.Object.margin = bpy.props.FloatProperty(
-        name="Margin", precision=3, update=update_bounds, min=0, default=0.04)
+        name="Margin", precision=3, update=update_bounds, min=0, default=0.04
+    )
     bpy.types.Object.bound_radius = bpy.props.FloatProperty(
-        name="Radius", precision=3, update=update_bounds, min=0)
+        name="Radius", precision=3, update=update_bounds, min=0
+    )
     bpy.types.Object.bound_length = bpy.props.FloatProperty(
-        name="Length", precision=3, update=update_bounds, min=0)
+        name="Length", precision=3, update=update_bounds, min=0
+    )
     bpy.types.Object.bound_dimensions = bpy.props.FloatVectorProperty(
-        name="Extents", precision=3, min=0, update=update_bounds, subtype="XYZ")
+        name="Extents", precision=3, min=0, update=update_bounds, subtype="XYZ"
+    )
 
     # nest these in object.bound_properties ? is it possible#
-    bpy.types.Object.composite_flags1 = bpy.props.PointerProperty(
-        type=BoundFlags)
-    bpy.types.Object.composite_flags2 = bpy.props.PointerProperty(
-        type=BoundFlags)
+    bpy.types.Object.composite_flags1 = bpy.props.PointerProperty(type=BoundFlags)
+    bpy.types.Object.composite_flags2 = bpy.props.PointerProperty(type=BoundFlags)
 
     bpy.types.Scene.collision_material_index = bpy.props.IntProperty(
-        name="Material Index")
+        name="Material Index"
+    )
     bpy.types.Scene.collision_materials = bpy.props.CollectionProperty(
-        type=CollisionMaterial, name="Collision Materials")
+        type=CollisionMaterial, name="Collision Materials"
+    )
     bpy.app.handlers.load_post.append(on_file_loaded)
 
     bpy.types.Scene.new_flag_preset_name = bpy.props.StringProperty(
-        name="Flag Preset Name")
-    bpy.types.Scene.flag_preset_index = bpy.props.IntProperty(
-        name="Flag Preset Index")
+        name="Flag Preset Name"
+    )
+    bpy.types.Scene.flag_preset_index = bpy.props.IntProperty(name="Flag Preset Index")
     bpy.types.Scene.flag_presets = bpy.props.CollectionProperty(
-        type=FlagPresetProp, name="Flag Presets")
+        type=FlagPresetProp, name="Flag Presets"
+    )
 
     bpy.types.Material.collision_properties = bpy.props.PointerProperty(
-        type=CollisionProperties)
+        type=CollisionProperties
+    )
     bpy.types.Material.collision_flags = bpy.props.PointerProperty(
-        type=CollisionMatFlags)
+        type=CollisionMatFlags
+    )
 
     # COLLISION TOOLS UI PROPERTIES
     bpy.types.Scene.create_poly_bound_type = bpy.props.EnumProperty(
         items=[
-            (SollumType.BOUND_POLY_BOX.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_BOX], "Create a bound poly box object"),
-            (SollumType.BOUND_POLY_SPHERE.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_SPHERE], "Create a bound poly sphere object"),
-            (SollumType.BOUND_POLY_CAPSULE.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_CAPSULE], "Create a bound poly capsule object"),
-            (SollumType.BOUND_POLY_CYLINDER.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_CYLINDER], "Create a bound poly cylinder object"),
+            (
+                SollumType.BOUND_POLY_BOX.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_BOX],
+                "Create a bound poly box object",
+            ),
+            (
+                SollumType.BOUND_POLY_SPHERE.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_SPHERE],
+                "Create a bound poly sphere object",
+            ),
+            (
+                SollumType.BOUND_POLY_CAPSULE.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_CAPSULE],
+                "Create a bound poly capsule object",
+            ),
+            (
+                SollumType.BOUND_POLY_CYLINDER.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_CYLINDER],
+                "Create a bound poly cylinder object",
+            ),
         ],
         name="Type",
-        default=SollumType.BOUND_POLY_BOX.value
+        default=SollumType.BOUND_POLY_BOX.value,
     )
 
     bpy.types.Scene.create_bound_type = bpy.props.EnumProperty(
         items=[
-            (SollumType.BOUND_COMPOSITE.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE], "Create a bound composite object"),
-            (SollumType.BOUND_GEOMETRYBVH.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH], "Create a bound geometrybvh object"),
-            (SollumType.BOUND_BOX.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_BOX], "Create a bound box object"),
-            (SollumType.BOUND_SPHERE.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_SPHERE], "Create a bound sphere object"),
-            (SollumType.BOUND_CAPSULE.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_CAPSULE], "Create a bound capsule object"),
-            (SollumType.BOUND_CYLINDER.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_CYLINDER], "Create a bound cylinder object"),
-            (SollumType.BOUND_DISC.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_DISC], "Create a bound disc object"),
+            (
+                SollumType.BOUND_COMPOSITE.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE],
+                "Create a bound composite object",
+            ),
+            (
+                SollumType.BOUND_GEOMETRYBVH.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH],
+                "Create a bound geometrybvh object",
+            ),
+            (
+                SollumType.BOUND_BOX.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_BOX],
+                "Create a bound box object",
+            ),
+            (
+                SollumType.BOUND_SPHERE.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_SPHERE],
+                "Create a bound sphere object",
+            ),
+            (
+                SollumType.BOUND_CAPSULE.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_CAPSULE],
+                "Create a bound capsule object",
+            ),
+            (
+                SollumType.BOUND_CYLINDER.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_CYLINDER],
+                "Create a bound cylinder object",
+            ),
+            (
+                SollumType.BOUND_DISC.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_DISC],
+                "Create a bound disc object",
+            ),
         ],
         name="Type",
-        default=SollumType.BOUND_COMPOSITE.value
+        default=SollumType.BOUND_COMPOSITE.value,
     )
 
     bpy.types.Scene.poly_bound_type_verts = bpy.props.EnumProperty(
         items=[
-            (SollumType.BOUND_POLY_BOX.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_BOX], "Create a bound polygon box object"),
-            (SollumType.BOUND_BOX.value, SOLLUMZ_UI_NAMES[SollumType.BOUND_BOX], "Create a bound box object")],
+            (
+                SollumType.BOUND_POLY_BOX.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_POLY_BOX],
+                "Create a bound polygon box object",
+            ),
+            (
+                SollumType.BOUND_BOX.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_BOX],
+                "Create a bound box object",
+            ),
+        ],
         name="Type",
-        default=SollumType.BOUND_POLY_BOX.value
+        default=SollumType.BOUND_POLY_BOX.value,
     )
 
-    bpy.types.Scene.poly_edge = bpy.props.EnumProperty(name="Edge", items=[("long", "Long Edge", "Create along the long edge"),
-                                                                           ("short", "Short Edge", "Create along the short edge")])
+    bpy.types.Scene.poly_edge = bpy.props.EnumProperty(
+        name="Edge",
+        items=[
+            ("long", "Long Edge", "Create along the long edge"),
+            ("short", "Short Edge", "Create along the short edge"),
+        ],
+    )
     bpy.types.Scene.bound_child_type = bpy.props.EnumProperty(
         items=[
-            (SollumType.BOUND_GEOMETRY.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRY], "Create bound geometry children."),
-            (SollumType.BOUND_GEOMETRYBVH.value,
-             SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH], "Create bound geometrybvh children.")
+            (
+                SollumType.BOUND_GEOMETRY.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRY],
+                "Create bound geometry children.",
+            ),
+            (
+                SollumType.BOUND_GEOMETRYBVH.value,
+                SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH],
+                "Create bound geometrybvh children.",
+            ),
         ],
         name="Child Type",
         description="The bound type of the Composite Children",
-        default=SollumType.BOUND_GEOMETRYBVH.value)
+        default=SollumType.BOUND_GEOMETRYBVH.value,
+    )
     bpy.types.Scene.create_seperate_composites = bpy.props.BoolProperty(
-        name="Separate Objects", description="Create a separate Composite for each selected object")
+        name="Separate Objects",
+        description="Create a separate Composite for each selected object",
+    )
 
     bpy.types.Scene.split_collision_count = bpy.props.IntProperty(
-        name="Divide By", description=f"Amount to split {SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH]}s or {SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE]}s by", default=2, min=2)
+        name="Divide By",
+        description=f"Amount to split {SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRYBVH]}s or {SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE]}s by",
+        default=2,
+        min=2,
+    )
 
     bpy.types.Scene.composite_apply_default_flag_preset = bpy.props.BoolProperty(
-        name="Apply Default Flag", description=f"Apply the default flag preset to the bound children", default=True)
+        name="Apply Default Flag",
+        description=f"Apply the default flag preset to the bound children",
+        default=True,
+    )
     bpy.types.Scene.center_composite_to_selection = bpy.props.BoolProperty(
-        name="Center to Selection", description="Center the Bound Composite to all selected objects", default=True)
+        name="Center to Selection",
+        description="Center the Bound Composite to all selected objects",
+        default=True,
+    )
 
 
 def unregister():

--- a/ybn/ui.py
+++ b/ybn/ui.py
@@ -1,6 +1,16 @@
 import bpy
-from .properties import BoundFlags, CollisionProperties, CollisionMatFlags, BoundProperties
-from ..sollumz_properties import MaterialType, SollumType, BOUND_TYPES, BOUND_POLYGON_TYPES
+from .properties import (
+    BoundFlags,
+    CollisionProperties,
+    CollisionMatFlags,
+    BoundProperties,
+)
+from ..sollumz_properties import (
+    MaterialType,
+    SollumType,
+    BOUND_TYPES,
+    BOUND_POLYGON_TYPES,
+)
 from .collision_materials import collisionmats
 from ..sollumz_ui import SOLLUMZ_PT_OBJECT_PANEL, SOLLUMZ_PT_MAT_PANEL
 from . import operators as ybn_ops
@@ -30,7 +40,9 @@ class SOLLUMZ_PT_COL_MAT_PROPERTIES_PANEL(bpy.types.Panel):
             return False
 
         active_mat = aobj.active_material
-        return active_mat is not None and active_mat.sollum_type == MaterialType.COLLISION
+        return (
+            active_mat is not None and active_mat.sollum_type == MaterialType.COLLISION
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -58,7 +70,10 @@ class SOLLUMZ_PT_BOUND_PROPERTIES_PANEL(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.sollum_type in BOUND_TYPES
+        return (
+            context.active_object is not None
+            and context.active_object.sollum_type in BOUND_TYPES
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -90,7 +105,12 @@ class SOLLUMZ_PT_BOUND_SHAPE_PANEL(bpy.types.Panel):
     @classmethod
     def poll(self, context):
         obj = context.active_object
-        return obj and ((obj.sollum_type in BOUND_TYPES or obj.sollum_type in BOUND_POLYGON_TYPES) and obj.sollum_type != SollumType.BOUND_COMPOSITE and obj.sollum_type != SollumType.BOUND_POLY_BOX and obj.sollum_type != SollumType.BOUND_POLY_TRIANGLE)
+        return obj and (
+            (obj.sollum_type in BOUND_TYPES or obj.sollum_type in BOUND_POLYGON_TYPES)
+            and obj.sollum_type != SollumType.BOUND_COMPOSITE
+            and obj.sollum_type != SollumType.BOUND_POLY_BOX
+            and obj.sollum_type != SollumType.BOUND_POLY_TRIANGLE
+        )
 
     def draw(self, context):
         obj = context.active_object
@@ -100,9 +120,19 @@ class SOLLUMZ_PT_BOUND_SHAPE_PANEL(bpy.types.Panel):
 
         grid = self.layout.grid_flow(columns=2, row_major=True)
 
-        if not obj.sollum_type in [SollumType.BOUND_GEOMETRY, SollumType.BOUND_GEOMETRYBVH, SollumType.BOUND_BOX, SollumType.BOUND_POLY_BOX, SollumType.BOUND_POLY_TRIANGLE]:
+        if not obj.sollum_type in [
+            SollumType.BOUND_GEOMETRY,
+            SollumType.BOUND_GEOMETRYBVH,
+            SollumType.BOUND_BOX,
+            SollumType.BOUND_POLY_BOX,
+            SollumType.BOUND_POLY_TRIANGLE,
+        ]:
             grid.prop(obj, "bound_radius")
-        if obj.sollum_type == SollumType.BOUND_CYLINDER or obj.sollum_type == SollumType.BOUND_POLY_CYLINDER or obj.sollum_type == SollumType.BOUND_POLY_CAPSULE:
+        if (
+            obj.sollum_type == SollumType.BOUND_CYLINDER
+            or obj.sollum_type == SollumType.BOUND_POLY_CYLINDER
+            or obj.sollum_type == SollumType.BOUND_POLY_CAPSULE
+        ):
             grid.prop(obj, "bound_length")
         if obj.sollum_type == SollumType.BOUND_BOX:
             grid.prop(obj, "bound_dimensions")
@@ -124,7 +154,12 @@ class SOLLUMZ_PT_BOUND_FLAGS_PANEL(bpy.types.Panel):
     @classmethod
     def poll(self, context):
         obj = context.active_object
-        return obj is not None and obj.parent is not None and obj.parent.sollum_type == SollumType.BOUND_COMPOSITE and obj.sollum_type in BOUND_TYPES
+        return (
+            obj is not None
+            and obj.parent is not None
+            and obj.parent.sollum_type == SollumType.BOUND_COMPOSITE
+            and obj.sollum_type in BOUND_TYPES
+        )
 
     def draw(self, context):
         obj = context.active_object
@@ -174,8 +209,7 @@ class SOLLUMZ_UL_COLLISION_MATERIALS_LIST(bpy.types.UIList):
             row.label(text=name, icon="MATERIAL")
         elif self.layout_type in {"GRID"}:
             layout.alignment = "CENTER"
-            layout.prop(item, "name",
-                        text=name, emboss=False, icon="MATERIAL")
+            layout.prop(item, "name", text=name, emboss=False, icon="MATERIAL")
 
 
 class SOLLUMZ_UL_FLAG_PRESET_LIST(bpy.types.UIList):
@@ -189,8 +223,7 @@ class SOLLUMZ_UL_FLAG_PRESET_LIST(bpy.types.UIList):
             row.label(text=item.name, icon="BOOKMARKS")
         elif self.layout_type in {"GRID"}:
             layout.alignment = "CENTER"
-            layout.prop(item, "name",
-                        text=item.name, emboss=False, icon="BOOKMARKS")
+            layout.prop(item, "name", text=item.name, emboss=False, icon="BOOKMARKS")
 
 
 class SOLLUMZ_PT_COLLISION_TOOL_PANEL(bpy.types.Panel):
@@ -226,8 +259,9 @@ class SOLLUMZ_PT_COLLISION_SPLIT_TOOL_PANEL(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         row = layout.row()
-        row.operator(ybn_ops.SOLLUMZ_OT_split_collision.bl_idname,
-                     icon="SCULPTMODE_HLT")
+        row.operator(
+            ybn_ops.SOLLUMZ_OT_split_collision.bl_idname, icon="SCULPTMODE_HLT"
+        )
         row.prop(context.scene, "split_collision_count")
 
 
@@ -248,8 +282,9 @@ class SOLLUMZ_PT_CREATE_BOUND_PANEL(bpy.types.Panel):
         layout = self.layout
 
         row = layout.row()
-        row.operator(ybn_ops.SOLLUMZ_OT_convert_to_composite.bl_idname,
-                     icon="FILE_REFRESH")
+        row.operator(
+            ybn_ops.SOLLUMZ_OT_convert_to_composite.bl_idname, icon="FILE_REFRESH"
+        )
         row.prop(context.scene, "bound_child_type")
 
         row = layout.row()
@@ -265,14 +300,17 @@ class SOLLUMZ_PT_CREATE_BOUND_PANEL(bpy.types.Panel):
 
         row = layout.row()
         row.operator(
-            ybn_ops.SOLLUMZ_OT_create_polygon_bound.bl_idname, icon="MESH_CAPSULE")
+            ybn_ops.SOLLUMZ_OT_create_polygon_bound.bl_idname, icon="MESH_CAPSULE"
+        )
         row.prop(context.scene, "create_poly_bound_type", text="")
 
         layout.separator()
 
         row = layout.row()
         row.operator(
-            ybn_ops.SOLLUMZ_OT_create_polygon_box_from_verts.bl_idname, icon="GROUP_VERTEX")
+            ybn_ops.SOLLUMZ_OT_create_polygon_box_from_verts.bl_idname,
+            icon="GROUP_VERTEX",
+        )
         row.prop(context.scene, "poly_bound_type_verts", text="")
 
 
@@ -292,18 +330,22 @@ class SOLLUMZ_PT_CREATE_MATERIAL_PANEL(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.template_list(
-            SOLLUMZ_UL_COLLISION_MATERIALS_LIST.bl_idname, "", context.scene, "collision_materials", context.scene, "collision_material_index"
+            SOLLUMZ_UL_COLLISION_MATERIALS_LIST.bl_idname,
+            "",
+            context.scene,
+            "collision_materials",
+            context.scene,
+            "collision_material_index",
         )
         row = layout.row()
         row.operator(ybn_ops.SOLLUMZ_OT_create_collision_material.bl_idname)
         row = layout.row()
-        row.operator(
-            ybn_ops.SOLLUMZ_OT_convert_to_collision_material.bl_idname)
-        row.operator(
-            ybn_ops.SOLLUMZ_OT_clear_and_create_collision_material.bl_idname)
+        row.operator(ybn_ops.SOLLUMZ_OT_convert_to_collision_material.bl_idname)
+        row.operator(ybn_ops.SOLLUMZ_OT_clear_and_create_collision_material.bl_idname)
         row = layout.row()
         row.operator(
-            ybn_ops.SOLLUMZ_OT_convert_non_collision_materials_to_selected.bl_idname)
+            ybn_ops.SOLLUMZ_OT_convert_non_collision_materials_to_selected.bl_idname
+        )
 
 
 class SOLLUMZ_PT_FLAG_PRESETS_PANEL(bpy.types.Panel):
@@ -323,14 +365,21 @@ class SOLLUMZ_PT_FLAG_PRESETS_PANEL(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.template_list(
-            SOLLUMZ_UL_FLAG_PRESET_LIST.bl_idname, "", context.scene, "flag_presets", context.scene, "flag_preset_index"
+            SOLLUMZ_UL_FLAG_PRESET_LIST.bl_idname,
+            "",
+            context.scene,
+            "flag_presets",
+            context.scene,
+            "flag_preset_index",
         )
         row = layout.row()
-        row.operator(ybn_ops.SOLLUMZ_OT_save_flag_preset.bl_idname, icon='FOLDER_REDIRECT')
+        row.operator(
+            ybn_ops.SOLLUMZ_OT_save_flag_preset.bl_idname, icon="FOLDER_REDIRECT"
+        )
         row.prop(context.scene, "new_flag_preset_name", text="Name")
         row = layout.row()
-        row.operator(ybn_ops.SOLLUMZ_OT_load_flag_preset.bl_idname, icon='CHECKMARK')
+        row.operator(ybn_ops.SOLLUMZ_OT_load_flag_preset.bl_idname, icon="CHECKMARK")
         row = layout.row()
-        row.operator(ybn_ops.SOLLUMZ_OT_clear_col_flags.bl_idname, icon='SHADERFX')
+        row.operator(ybn_ops.SOLLUMZ_OT_clear_col_flags.bl_idname, icon="SHADERFX")
         row = layout.row()
-        row.operator(ybn_ops.SOLLUMZ_OT_delete_flag_preset.bl_idname, icon='TRASH')
+        row.operator(ybn_ops.SOLLUMZ_OT_delete_flag_preset.bl_idname, icon="TRASH")

--- a/ybn/ybnimport.py
+++ b/ybn/ybnimport.py
@@ -19,7 +19,7 @@ from ..cwxml.bound import (
     PolyTriangle,
     YBN,
     Polygon,
-    Material as ColMaterial
+    Material as ColMaterial,
 )
 from ..sollumz_properties import SollumType, SOLLUMZ_UI_NAMES
 from .collision_materials import create_collision_material_from_index
@@ -31,8 +31,9 @@ from mathutils import Matrix, Vector
 
 def import_ybn(filepath):
     ybn_xml: BoundFile = YBN.from_xml_file(filepath)
-    create_bound_composite(ybn_xml.composite, os.path.basename(
-        filepath.replace(YBN.file_extension, "")))
+    create_bound_composite(
+        ybn_xml.composite, os.path.basename(filepath.replace(YBN.file_extension, ""))
+    )
 
 
 def create_bound_composite(composite_xml: BoundComposite, name: Optional[str] = None):
@@ -74,7 +75,11 @@ def create_bound_object(bound_xml: BoundChild | Bound):
         return create_bvh_obj(bound_xml)
 
 
-def create_bound_child_mesh(bound_xml: BoundChild, sollum_type: SollumType, mesh: Optional[bpy.types.Mesh] = None):
+def create_bound_child_mesh(
+    bound_xml: BoundChild,
+    sollum_type: SollumType,
+    mesh: Optional[bpy.types.Mesh] = None,
+):
     """Create a bound mesh object with materials and composite properties set."""
     obj = create_blender_object(sollum_type, object_data=mesh)
 
@@ -154,7 +159,9 @@ def create_bound_geometry(geom_xml: BoundGeometry):
     materials = create_geometry_materials(geom_xml)
     triangles = get_poly_triangles(geom_xml.polygons)
 
-    mesh = create_bound_mesh_data(geom_xml.vertices, triangles, geom_xml.vertex_colors, materials)
+    mesh = create_bound_mesh_data(
+        geom_xml.vertices, triangles, geom_xml.vertex_colors, materials
+    )
     mesh.transform(Matrix.Translation(geom_xml.geometry_center))
 
     geom_obj = create_blender_object(SollumType.BOUND_GEOMETRY, object_data=mesh)
@@ -176,8 +183,12 @@ def create_bvh_obj(bvh_xml: BoundGeometryBVH):
     triangles = get_poly_triangles(bvh_xml.polygons)
 
     if triangles:
-        mesh = create_bound_mesh_data(bvh_xml.vertices, triangles, bvh_xml.vertex_colors, materials)
-        bound_geom_obj = create_blender_object(SollumType.BOUND_POLY_TRIANGLE, object_data=mesh)
+        mesh = create_bound_mesh_data(
+            bvh_xml.vertices, triangles, bvh_xml.vertex_colors, materials
+        )
+        bound_geom_obj = create_blender_object(
+            SollumType.BOUND_POLY_TRIANGLE, object_data=mesh
+        )
         bound_geom_obj.location = bvh_xml.geometry_center
         bound_geom_obj.parent = bvh_obj
 
@@ -214,10 +225,16 @@ def set_bound_col_material_properties(bound_xml: Bound, mat: bpy.types.Material)
     mat.collision_properties.room_id = bound_xml.room_id
     mat.collision_properties.ped_density = bound_xml.ped_density
     mat.collision_properties.material_color_index = bound_xml.material_color_index
-    set_collision_mat_raw_flags(mat.collision_flags, bound_xml.unk_flags, bound_xml.poly_flags)
+    set_collision_mat_raw_flags(
+        mat.collision_flags, bound_xml.unk_flags, bound_xml.poly_flags
+    )
 
 
-def create_bvh_polys(bvh: BoundGeometryBVH, materials: list[bpy.types.Material], bvh_obj: bpy.types.Object):
+def create_bvh_polys(
+    bvh: BoundGeometryBVH,
+    materials: list[bpy.types.Material],
+    bvh_obj: bpy.types.Object,
+):
     for poly in bvh.polygons:
         if type(poly) is PolyTriangle:
             continue
@@ -333,8 +350,7 @@ def poly_to_obj(poly, materials, vertices) -> bpy.types.Object:
 
         return capsule
     elif type(poly) == PolyCylinder:
-        cylinder = init_poly_obj(
-            poly, SollumType.BOUND_POLY_CYLINDER, materials)
+        cylinder = init_poly_obj(poly, SollumType.BOUND_POLY_CYLINDER, materials)
         v1 = vertices[poly.v1]
         v2 = vertices[poly.v2]
 
@@ -358,7 +374,7 @@ def create_bound_mesh_data(
     vertices: list[Vector],
     triangles: list[PolyTriangle],
     vertex_colors: Optional[list[tuple[int, int, int, int]]],
-    materials: list[bpy.types.Material]
+    materials: list[bpy.types.Material],
 ) -> bpy.types.Mesh:
     mesh = bpy.data.meshes.new(SOLLUMZ_UI_NAMES[SollumType.BOUND_GEOMETRY])
 
@@ -376,7 +392,11 @@ def create_bound_mesh_data(
     return mesh
 
 
-def apply_bound_geom_materials(mesh: bpy.types.Mesh, triangles: list[PolyTriangle], materials: list[bpy.types.Material]):
+def apply_bound_geom_materials(
+    mesh: bpy.types.Mesh,
+    triangles: list[PolyTriangle],
+    materials: list[bpy.types.Material],
+):
     for mat in materials:
         mesh.materials.append(mat)
 
@@ -387,10 +407,15 @@ def apply_bound_geom_materials(mesh: bpy.types.Mesh, triangles: list[PolyTriangl
 def get_bound_geom_mesh_data(
     vertices: list[Vector],
     triangles: list[PolyTriangle],
-    vertex_colors: Optional[list[tuple[int, int, int, int]]]
+    vertex_colors: Optional[list[tuple[int, int, int, int]]],
 ) -> tuple[list, list, Optional[NDArray]]:
     def _color_to_float(color_int: tuple[int, int, int, int]):
-        return (color_int[0] / 255, color_int[1] / 255, color_int[2] / 255, color_int[3] / 255)
+        return (
+            color_int[0] / 255,
+            color_int[1] / 255,
+            color_int[2] / 255,
+            color_int[3] / 255,
+        )
 
     verts = []
     faces = []
@@ -423,7 +448,11 @@ def get_bound_geom_mesh_data(
             colors.append(_color_to_float(vertex_colors[poly.v2]))
             colors.append(_color_to_float(vertex_colors[poly.v3]))
 
-    return verts, faces, np.array(colors, dtype=np.float64) if colors is not None else None
+    return (
+        verts,
+        faces,
+        np.array(colors, dtype=np.float64) if colors is not None else None,
+    )
 
 
 def set_bound_geometry_properties(geom_xml: BoundGeometry, geom_obj: bpy.types.Object):

--- a/ycd/operators.py
+++ b/ycd/operators.py
@@ -12,13 +12,19 @@ from .. import logger
 class SOLLUMZ_OT_animations_set_target(SOLLUMZ_OT_base, bpy.types.Operator):
     bl_idname = "sollumz.animations_set_target"
     bl_label = "Set Animations Target"
-    bl_description = "Set the same target for all animations in the selected clip dictionaries"
+    bl_description = (
+        "Set the same target for all animations in the selected clip dictionaries"
+    )
 
     @classmethod
     def poll(cls, context):
-        return (len(context.selected_objects) > 0 and
-                any(is_any_sollumz_animation_obj(obj) for obj in context.selected_objects) and
-                context.scene.sollumz_animations_target_id is not None)
+        return (
+            len(context.selected_objects) > 0
+            and any(
+                is_any_sollumz_animation_obj(obj) for obj in context.selected_objects
+            )
+            and context.scene.sollumz_animations_target_id is not None
+        )
 
     def run(self, context):
         scene = context.scene
@@ -46,7 +52,9 @@ class SOLLUMZ_OT_animations_set_target(SOLLUMZ_OT_base, bpy.types.Operator):
             elif obj.sollum_type == SollumType.ANIMATIONS:
                 animations_obj = obj
             elif obj.sollum_type == SollumType.CLIP:
-                animations_obj = find_child_by_type(obj.parent.parent, SollumType.ANIMATIONS)
+                animations_obj = find_child_by_type(
+                    obj.parent.parent, SollumType.ANIMATIONS
+                )
             elif obj.sollum_type == SollumType.CLIPS:
                 animations_obj = find_child_by_type(obj.parent, SollumType.ANIMATIONS)
             elif obj.sollum_type == SollumType.CLIP_DICTIONARY:
@@ -76,7 +84,9 @@ class SOLLUMZ_OT_clip_apply_nla(SOLLUMZ_OT_base, bpy.types.Operator):
             return {"FINISHED"}
 
         # TODO: animation may be None, or not all animations have the same target/are filled in
-        target = clip_properties.animations[0].animation.animation_properties.get_target()
+        target = clip_properties.animations[
+            0
+        ].animation.animation_properties.get_target()
         if target is None:
             return {"FINISHED"}
 
@@ -100,12 +110,14 @@ class SOLLUMZ_OT_clip_apply_nla(SOLLUMZ_OT_base, bpy.types.Operator):
 
             group = groups[action.name]
 
-            group.append({
-                "name": clip_properties.hash,
-                "start_frames": start_frames,
-                "end_frames": end_frames,
-                "action": action,
-            })
+            group.append(
+                {
+                    "name": clip_properties.hash,
+                    "start_frames": start_frames,
+                    "end_frames": end_frames,
+                    "action": action,
+                }
+            )
 
         if target.animation_data is None:
             target.animation_data_create()
@@ -145,7 +157,10 @@ class SOLLUMZ_OT_clip_recalculate_uv_hash(SOLLUMZ_OT_base, bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.sollum_type == SollumType.CLIP
+        return (
+            context.active_object is not None
+            and context.active_object.sollum_type == SollumType.CLIP
+        )
 
     def run(self, context):
         logger.set_logging_operator(self)
@@ -226,7 +241,9 @@ class SOLLUMZ_OT_clip_new_tag(SOLLUMZ_OT_base, bpy.types.Operator):
         if properties.ignore_template:
             return "Add a new empty tag to the clip"
 
-        return bpy.types.UILayout.enum_item_description(properties, "template", properties.template)
+        return bpy.types.UILayout.enum_item_description(
+            properties, "template", properties.template
+        )
 
     def run(self, context):
         if len(bpy.context.selected_objects) <= 0:
@@ -244,7 +261,11 @@ class SOLLUMZ_OT_clip_new_tag(SOLLUMZ_OT_base, bpy.types.Operator):
 
         if clip_properties.duration != 0.0:
             # place the tag at the current frame
-            phase = bpy.context.scene.frame_float / bpy.context.scene.render.fps / clip_properties.duration
+            phase = (
+                bpy.context.scene.frame_float
+                / bpy.context.scene.render.fps
+                / clip_properties.duration
+            )
             phase = min(max(phase, 0.0), 1.0)
             tag.start_phase = phase
             tag.end_phase = phase
@@ -564,20 +585,17 @@ class SOLLUMZ_OT_create_clip(SOLLUMZ_OT_base, bpy.types.Operator):
         elif active_object.sollum_type == SollumType.ANIMATION:
             clip_dictionary_obj = active_object.parent.parent
 
-            clips_obj = find_child_by_type(
-                clip_dictionary_obj, SollumType.CLIPS)
+            clips_obj = find_child_by_type(clip_dictionary_obj, SollumType.CLIPS)
         elif active_object.sollum_type == SollumType.CLIPS:
             clips_obj = active_object
         elif active_object.sollum_type == SollumType.ANIMATIONS:
             clip_dictionary_obj = active_object.parent
 
-            clips_obj = find_child_by_type(
-                clip_dictionary_obj, SollumType.CLIPS)
+            clips_obj = find_child_by_type(clip_dictionary_obj, SollumType.CLIPS)
         elif active_object.sollum_type == SollumType.CLIP_DICTIONARY:
             clip_dictionary_obj = active_object
 
-            clips_obj = find_child_by_type(
-                clip_dictionary_obj, SollumType.CLIPS)
+            clips_obj = find_child_by_type(clip_dictionary_obj, SollumType.CLIPS)
 
         if clips_obj is not None:
             animation_obj = create_anim_obj(SollumType.CLIP)
@@ -603,21 +621,24 @@ class SOLLUMZ_OT_create_animation(SOLLUMZ_OT_base, bpy.types.Operator):
             clip_dictionary_obj = active_object.parent.parent
 
             animations_obj = find_child_by_type(
-                clip_dictionary_obj, SollumType.ANIMATIONS)
+                clip_dictionary_obj, SollumType.ANIMATIONS
+            )
         elif active_object.sollum_type == SollumType.ANIMATION:
             animations_obj = active_object.parent
         elif active_object.sollum_type == SollumType.CLIPS:
             clip_dictionary_obj = active_object.parent
 
             animations_obj = find_child_by_type(
-                clip_dictionary_obj, SollumType.ANIMATIONS)
+                clip_dictionary_obj, SollumType.ANIMATIONS
+            )
         elif active_object.sollum_type == SollumType.ANIMATIONS:
             animations_obj = active_object
         elif active_object.sollum_type == SollumType.CLIP_DICTIONARY:
             clip_dictionary_obj = active_object
 
             animations_obj = find_child_by_type(
-                clip_dictionary_obj, SollumType.ANIMATIONS)
+                clip_dictionary_obj, SollumType.ANIMATIONS
+            )
 
         if animations_obj is not None:
             animation_obj = create_anim_obj(SollumType.ANIMATION)
@@ -643,7 +664,9 @@ class SOLLUMZ_OT_uv_transform_add(SOLLUMZ_OT_base, bpy.types.Operator):
         obj = context.active_object
         animation_tracks = obj.active_material.animation_tracks
         animation_tracks.uv_transforms.add()
-        animation_tracks.uv_transforms_active_index = len(animation_tracks.uv_transforms) - 1
+        animation_tracks.uv_transforms_active_index = (
+            len(animation_tracks.uv_transforms) - 1
+        )
         animation_tracks.update_uv_transform_matrix()
         return {"FINISHED"}
 
@@ -663,7 +686,9 @@ class SOLLUMZ_OT_uv_transform_remove(SOLLUMZ_OT_base, bpy.types.Operator):
 
         obj = context.active_object
         animation_tracks = obj.active_material.animation_tracks
-        animation_tracks.uv_transforms.remove(animation_tracks.uv_transforms_active_index)
+        animation_tracks.uv_transforms.remove(
+            animation_tracks.uv_transforms_active_index
+        )
         length = len(animation_tracks.uv_transforms)
         if length > 0 and animation_tracks.uv_transforms_active_index >= length:
             animation_tracks.uv_transforms_active_index = length - 1
@@ -674,12 +699,16 @@ class SOLLUMZ_OT_uv_transform_remove(SOLLUMZ_OT_base, bpy.types.Operator):
 class SOLLUMZ_OT_uv_transform_move(SOLLUMZ_OT_base, bpy.types.Operator):
     bl_idname = "sollumz.uv_transform_move"
     bl_label = "Move UV transformation"
-    bl_description = "Move the active UV transformation up/down the transformation stack"
+    bl_description = (
+        "Move the active UV transformation up/down the transformation stack"
+    )
 
-    direction: bpy.props.EnumProperty(items=[
-        ("UP", "Up", "Move up", 0),
-        ("DOWN", "Down", "Move down", 1),
-    ])
+    direction: bpy.props.EnumProperty(
+        items=[
+            ("UP", "Up", "Move up", 0),
+            ("DOWN", "Down", "Move down", 1),
+        ]
+    )
 
     @classmethod
     def poll(cls, context):
@@ -724,12 +753,19 @@ class UVSpriteSheetFrame(bpy.types.PropertyGroup):
                     frame.order -= 1
         self.prev_use = self.use
 
-    use: bpy.props.BoolProperty(name="Use", description="Use frame in animation", default=False, update=on_use_changed)
+    use: bpy.props.BoolProperty(
+        name="Use",
+        description="Use frame in animation",
+        default=False,
+        update=on_use_changed,
+    )
     prev_use: bpy.props.BoolProperty(name="Prev Use", default=False)
     order: bpy.props.IntProperty(name="Order", default=0, min=0)
 
 
-class SOLLUMZ_OT_uv_sprite_sheet_anim_select_all_frames(SOLLUMZ_OT_base, bpy.types.Operator):
+class SOLLUMZ_OT_uv_sprite_sheet_anim_select_all_frames(
+    SOLLUMZ_OT_base, bpy.types.Operator
+):
     bl_idname = "sollumz.uv_sprite_sheet_anim_select_all_frames"
     bl_label = "Select All"
     bl_description = "Use all the frames in the sprite sheet texture"
@@ -759,7 +795,9 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim_clear_frames(SOLLUMZ_OT_base, bpy.types.Op
 class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
     bl_idname = "sollumz.uv_sprite_sheet_anim"
     bl_label = "Create Sprite Sheet UV Animation"
-    bl_description = "Create a UV animation based on the frames of a sprite sheet texture"
+    bl_description = (
+        "Create a UV animation based on the frames of a sprite sheet texture"
+    )
 
     def on_num_frames_changed(self, context):
         total_frames = self.frames_horizontal * self.frames_vertical
@@ -780,8 +818,16 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
         # cannot use self._image in callbacks, use context pointer instead
         image = context.operator_uv_sprite_sheet_anim_image
         img_w, img_h = image.size
-        max_w = img_w - self.offset_x - self.separation_horizontal * (self.frames_horizontal - 1)
-        max_h = img_h - self.offset_y - self.separation_vertical * (self.frames_vertical - 1)
+        max_w = (
+            img_w
+            - self.offset_x
+            - self.separation_horizontal * (self.frames_horizontal - 1)
+        )
+        max_h = (
+            img_h
+            - self.offset_y
+            - self.separation_vertical * (self.frames_vertical - 1)
+        )
         self.frame_width = max_w / self.frames_horizontal
         self.frame_height = max_h / self.frames_vertical
 
@@ -807,64 +853,120 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
     frames_horizontal: bpy.props.IntProperty(
         name="Frames Horizontal",
         description="Number of horizontal frames in the sprite sheet texture",
-        min=1, default=1, update=on_num_frames_changed)
+        min=1,
+        default=1,
+        update=on_num_frames_changed,
+    )
     frames_vertical: bpy.props.IntProperty(
         name="Frames Vertical",
         description="Number of vertical frames in the sprite sheet texture",
-        min=1, default=1, update=on_num_frames_changed)
+        min=1,
+        default=1,
+        update=on_num_frames_changed,
+    )
     frame_width: bpy.props.FloatProperty(
         name="Frame Width",
         description="Width of a frame in the sprite sheet texture, in pixels",
-        min=1, default=1, subtype="PIXEL", step=100)
+        min=1,
+        default=1,
+        subtype="PIXEL",
+        step=100,
+    )
     frame_height: bpy.props.FloatProperty(
         name="Frame Height",
         description="Height of a frame in the sprite sheet texture, in pixels",
-        min=1, default=1, subtype="PIXEL", step=100)
+        min=1,
+        default=1,
+        subtype="PIXEL",
+        step=100,
+    )
     offset_x: bpy.props.FloatProperty(
         name="Offset X",
         description="Offset along X-axis of the first frame in the sprite sheet texture, in pixels",
-        min=0, default=0, subtype="PIXEL", step=100)
+        min=0,
+        default=0,
+        subtype="PIXEL",
+        step=100,
+    )
     offset_y: bpy.props.FloatProperty(
         name="Offset Y",
         description="Offset along Y-axis of the first frame in the sprite sheet texture, in pixels",
-        min=0, default=0, subtype="PIXEL", step=100)
+        min=0,
+        default=0,
+        subtype="PIXEL",
+        step=100,
+    )
     separation_horizontal: bpy.props.FloatProperty(
         name="Separation Horizontal",
         description="Horizontal separation between frames in the sprite sheet texture, in pixels",
-        min=0, default=0, subtype="PIXEL", step=100)
+        min=0,
+        default=0,
+        subtype="PIXEL",
+        step=100,
+    )
     separation_vertical: bpy.props.FloatProperty(
         name="Separation Vertical",
         description="Vertical separation between frames in the sprite sheet texture, in pixels",
-        min=0, default=0, subtype="PIXEL", step=100)
+        min=0,
+        default=0,
+        subtype="PIXEL",
+        step=100,
+    )
     keyframe_interval: bpy.props.IntProperty(
         name="Keyframe Interval",
         description="Interval at which keyframes are inserted. It is recommended to use a multiple of 30 to prevent flickering in-game",
-        min=1, default=30)
+        min=1,
+        default=30,
+    )
     use_dst_frame: bpy.props.BoolProperty(
         name="Use Destination Frame",
         description="Specify the destination frame bounds manually instead of auto-calculating them. "
-                    "Useful when the UV mapped area is not rectangular",
-        default=False, update=on_use_dst_frame_changed)
+        "Useful when the UV mapped area is not rectangular",
+        default=False,
+        update=on_use_dst_frame_changed,
+    )
     dst_frame_offset_x: bpy.props.FloatProperty(
         name="Destination Frame Offset X",
         description="Offset along X-axis of the area UV mapped in the sprite sheet texture, in pixels",
-        default=0, subtype="PIXEL", step=100)
+        default=0,
+        subtype="PIXEL",
+        step=100,
+    )
     dst_frame_offset_y: bpy.props.FloatProperty(
         name="Destination Frame Offset Y",
         description="Offset along Y-axis of the area UV mapped in the sprite sheet texture, in pixels",
-        default=0, subtype="PIXEL", step=100)
+        default=0,
+        subtype="PIXEL",
+        step=100,
+    )
     dst_frame_width: bpy.props.FloatProperty(
         name="Destination Frame Width",
         description="Width of the area UV mapped in the sprite sheet texture, in pixels",
-        min=1, default=1, subtype="PIXEL", step=100)
+        min=1,
+        default=1,
+        subtype="PIXEL",
+        step=100,
+    )
     dst_frame_height: bpy.props.FloatProperty(
         name="Destination Frame Height",
         description="Height of the area UV mapped in the sprite sheet texture, in pixels",
-        min=1, default=1, subtype="PIXEL", step=100)
-    auto_dst_frame_offset_x: bpy.props.FloatProperty(default=0, subtype="PIXEL", step=100)
-    auto_dst_frame_offset_y: bpy.props.FloatProperty(default=0, subtype="PIXEL", step=100)
-    auto_dst_frame_width: bpy.props.FloatProperty(min=1, default=1, subtype="PIXEL", step=100)
-    auto_dst_frame_height: bpy.props.FloatProperty(min=1, default=1, subtype="PIXEL", step=100)
+        min=1,
+        default=1,
+        subtype="PIXEL",
+        step=100,
+    )
+    auto_dst_frame_offset_x: bpy.props.FloatProperty(
+        default=0, subtype="PIXEL", step=100
+    )
+    auto_dst_frame_offset_y: bpy.props.FloatProperty(
+        default=0, subtype="PIXEL", step=100
+    )
+    auto_dst_frame_width: bpy.props.FloatProperty(
+        min=1, default=1, subtype="PIXEL", step=100
+    )
+    auto_dst_frame_height: bpy.props.FloatProperty(
+        min=1, default=1, subtype="PIXEL", step=100
+    )
 
     def run(self, context):
         self.render_shutdown(context)
@@ -891,8 +993,12 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
         frame_h = self.frame_height / img_h
         scale_x = frame_w * img_w / self.dst_frame_width
         scale_y = frame_h * img_h / self.dst_frame_height
-        frame_offset_x = self.offset_x / img_w - (self.dst_frame_offset_x / img_w) * scale_x
-        frame_offset_y = self.offset_y / img_h - (self.dst_frame_offset_y / img_h) * scale_y
+        frame_offset_x = (
+            self.offset_x / img_w - (self.dst_frame_offset_x / img_w) * scale_x
+        )
+        frame_offset_y = (
+            self.offset_y / img_h - (self.dst_frame_offset_y / img_h) * scale_y
+        )
         frame_sep_x = self.separation_horizontal / img_w
         frame_sep_y = self.separation_vertical / img_h
 
@@ -911,7 +1017,9 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
 
                     frame_idx = frame.order * self.keyframe_interval
                     translate_transform.translation = (frame_x, frame_y)
-                    translate_transform.keyframe_insert(data_path="translation", frame=frame_idx)
+                    translate_transform.keyframe_insert(
+                        data_path="translation", frame=frame_idx
+                    )
 
                     next_frame_idx = (frame.order + 1) * self.keyframe_interval
                     if next_frame_idx > frame_end:
@@ -921,7 +1029,9 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
         if frame_end != 0:
             # insert one last keyframe to keep the last frame visible for the specified duration before it loops
             translate_transform.translation = frame_end_translation
-            translate_transform.keyframe_insert(data_path="translation", frame=frame_end)
+            translate_transform.keyframe_insert(
+                data_path="translation", frame=frame_end
+            )
 
         # make all keyframes constant
         action = mat.animation_data.action
@@ -933,7 +1043,7 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
         bpy.context.scene.frame_start = 0
         bpy.context.scene.frame_end = frame_end
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     def cancel(self, context):
         self.render_shutdown(context)
@@ -996,7 +1106,12 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
             for x in range(self.frames_horizontal):
                 i = y * self.frames_horizontal + x
                 frame = self.frames[i]
-                row.prop(frame, "use", text=f"{frame.order}" if frame.use else " ", toggle=True)
+                row.prop(
+                    frame,
+                    "use",
+                    text=f"{frame.order}" if frame.use else " ",
+                    toggle=True,
+                )
             row = col.row(align=True)
             row.scale_y = FRAME_BUTTOM_SCALE_Y
         right_col.separator()
@@ -1017,21 +1132,29 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
         empty_area_overlay_color = (0.05, 0.05, 0.05, 0.9)
         dst_frame_overlay_color = (0.9, 0.9, 0.9, 0.35)
         frame_bounds_color = theme.user_interface.wcol_toggle.outline
-        frame_bounds_color = (frame_bounds_color[0],
-                              frame_bounds_color[1],
-                              frame_bounds_color[2],
-                              1.0)
+        frame_bounds_color = (
+            frame_bounds_color[0],
+            frame_bounds_color[1],
+            frame_bounds_color[2],
+            1.0,
+        )
         selected_frame_bounds_color = theme.user_interface.wcol_toggle.inner_sel
-        selected_frame_overlay_color = (selected_frame_bounds_color[0],
-                                        selected_frame_bounds_color[1],
-                                        selected_frame_bounds_color[2],
-                                        0.325)
+        selected_frame_overlay_color = (
+            selected_frame_bounds_color[0],
+            selected_frame_bounds_color[1],
+            selected_frame_bounds_color[2],
+            0.325,
+        )
         selected_frame_order_number_color = theme.user_interface.wcol_toggle.text_sel
-        selected_frame_order_number_color = (selected_frame_order_number_color[0],
-                                             selected_frame_order_number_color[1],
-                                             selected_frame_order_number_color[2],
-                                             1.0)
-        selected_frame_order_number_font_size = 18 * (bpy.context.preferences.system.dpi / 72)
+        selected_frame_order_number_color = (
+            selected_frame_order_number_color[0],
+            selected_frame_order_number_color[1],
+            selected_frame_order_number_color[2],
+            1.0,
+        )
+        selected_frame_order_number_font_size = 18 * (
+            bpy.context.preferences.system.dpi / 72
+        )
         selected_frame_order_number_font_id = 0
 
         # vertex buffers
@@ -1069,15 +1192,19 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
                 pos = rects_pos[i]
                 color = rects_color[i]
                 if len(pos) > 0:
-                    batch = gpu_extras.batch.batch_for_shader(self._render_color_shader, "LINES",
-                                                              {"pos": pos, "color": color})
+                    batch = gpu_extras.batch.batch_for_shader(
+                        self._render_color_shader, "LINES", {"pos": pos, "color": color}
+                    )
                     batch.draw(self._render_color_shader)
                     pos.clear()
                     color.clear()
 
             if len(filled_rects_pos) > 0:
-                batch = gpu_extras.batch.batch_for_shader(self._render_color_shader, "TRIS",
-                                                          {"pos": filled_rects_pos, "color": filled_rects_color})
+                batch = gpu_extras.batch.batch_for_shader(
+                    self._render_color_shader,
+                    "TRIS",
+                    {"pos": filled_rects_pos, "color": filled_rects_color},
+                )
                 batch.draw(self._render_color_shader)
                 filled_rects_pos.clear()
                 filled_rects_color.clear()
@@ -1097,11 +1224,13 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
 
         # destination frame bounds
         if self.use_dst_frame:
-            _fill_rect(dst_x + self.dst_frame_offset_x / img_h * dst_h,
-                       dst_y - self.dst_frame_offset_y / img_h * dst_h,
-                       self.dst_frame_width / img_w * dst_w,
-                       self.dst_frame_height / img_h * dst_h,
-                       dst_frame_overlay_color)
+            _fill_rect(
+                dst_x + self.dst_frame_offset_x / img_h * dst_h,
+                dst_y - self.dst_frame_offset_y / img_h * dst_h,
+                self.dst_frame_width / img_w * dst_w,
+                self.dst_frame_height / img_h * dst_h,
+                dst_frame_overlay_color,
+            )
 
         # calculate frame bounds rectangles
         order_numbers = []
@@ -1123,18 +1252,43 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
                 rect_w = frame_w - line_width / 2
                 rect_h = frame_h - line_width / 2
                 if frame.use:
-                    _draw_rect(rect_x, rect_y, rect_w, rect_h, selected_frame_bounds_color, layer=1)
-                    _fill_rect(rect_x, rect_y, rect_w, rect_h, selected_frame_overlay_color)
+                    _draw_rect(
+                        rect_x,
+                        rect_y,
+                        rect_w,
+                        rect_h,
+                        selected_frame_bounds_color,
+                        layer=1,
+                    )
+                    _fill_rect(
+                        rect_x, rect_y, rect_w, rect_h, selected_frame_overlay_color
+                    )
 
-                    order_numbers.append(((frame_x, frame_y, frame_w, frame_h), frame.order))
+                    order_numbers.append(
+                        ((frame_x, frame_y, frame_w, frame_h), frame.order)
+                    )
                 else:
-                    _draw_rect(rect_x, rect_y, rect_w, rect_h, frame_bounds_color, layer=0)
+                    _draw_rect(
+                        rect_x, rect_y, rect_w, rect_h, frame_bounds_color, layer=0
+                    )
 
                 if frame_sep_x > 0 and x != self.frames_horizontal - 1:
-                    _fill_rect(frame_x + frame_w, frame_y, frame_sep_x, frame_h, empty_area_overlay_color)
+                    _fill_rect(
+                        frame_x + frame_w,
+                        frame_y,
+                        frame_sep_x,
+                        frame_h,
+                        empty_area_overlay_color,
+                    )
 
             if frame_sep_y > 0 and y != self.frames_vertical - 1:
-                _fill_rect(dst_x, frame_y - frame_h, dst_w, frame_sep_y, empty_area_overlay_color)
+                _fill_rect(
+                    dst_x,
+                    frame_y - frame_h,
+                    dst_w,
+                    frame_sep_y,
+                    empty_area_overlay_color,
+                )
                 # TODO: same dark overlay for offset_x/y
 
         # render frame bounds rectangles
@@ -1147,8 +1301,13 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
             x, y, w, h = bounds
             blf.position(selected_frame_order_number_font_id, x + 5, y - 25, 0)
             blf.clipping(selected_frame_order_number_font_id, x, y - h, x + w, y)
-            blf.color(selected_frame_order_number_font_id, *selected_frame_order_number_color)
-            blf.size(selected_frame_order_number_font_id, selected_frame_order_number_font_size)
+            blf.color(
+                selected_frame_order_number_font_id, *selected_frame_order_number_color
+            )
+            blf.size(
+                selected_frame_order_number_font_id,
+                selected_frame_order_number_font_size,
+            )
             blf.draw(selected_frame_order_number_font_id, f"{number}")
             k += 1
 
@@ -1169,15 +1328,19 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
 
         self._render_image_bounds = (x, y + h, w, h)
         self._render_image_batch = gpu_extras.batch.batch_for_shader(
-            self._render_image_shader, "TRI_FAN",
+            self._render_image_shader,
+            "TRI_FAN",
             {
                 "pos": ((x, y), (x + w, y), (x + w, y + h), (x, y + h)),
                 "texCoord": ((0, 0), (1, 0), (1, 1), (0, 1)),
-            })
-        self._render_handler = self._space.draw_handler_add(self.render_callback, (context,), 'WINDOW', 'POST_PIXEL')
+            },
+        )
+        self._render_handler = self._space.draw_handler_add(
+            self.render_callback, (context,), "WINDOW", "POST_PIXEL"
+        )
 
     def render_shutdown(self, context):
-        self._space.draw_handler_remove(self._render_handler, 'WINDOW')
+        self._space.draw_handler_remove(self._render_handler, "WINDOW")
 
     def search_image(self, context):
         self._image = None
@@ -1208,6 +1371,7 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
 
         # calculate the UV bounds
         import sys
+
         uvs = mesh.uv_layers.active.uv
         min_u = sys.float_info.max
         min_v = sys.float_info.max
@@ -1228,8 +1392,12 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
                 max_u = max(max_u, u)
                 max_v = max(max_v, v)
 
-        if (min_u == sys.float_info.max or min_v == sys.float_info.max or
-                max_u == sys.float_info.min or max_v == sys.float_info.min):
+        if (
+            min_u == sys.float_info.max
+            or min_v == sys.float_info.max
+            or max_u == sys.float_info.min
+            or max_v == sys.float_info.min
+        ):
             return
 
         # calculate the UV bounds in pixels
@@ -1253,8 +1421,10 @@ class SOLLUMZ_OT_uv_sprite_sheet_anim(SOLLUMZ_OT_base, bpy.types.Operator):
             return {"CANCELLED"}
 
         if self.first_run:
-            with context.temp_override(operator_uv_sprite_sheet_anim=self,
-                                       operator_uv_sprite_sheet_anim_image=self._image):  # see draw()
+            with context.temp_override(
+                operator_uv_sprite_sheet_anim=self,
+                operator_uv_sprite_sheet_anim_image=self._image,
+            ):  # see draw()
                 self.frames_horizontal = 4
                 self.frames_vertical = 4
                 self.calc_destination_frame_size(context)
@@ -1270,9 +1440,11 @@ class SOLLUMZ_OT_timeline_clip_tags_drag(SOLLUMZ_OT_base, bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return (context.region is not None and
-                context.active_object is not None and
-                context.active_object.sollum_type == SollumType.CLIP)
+        return (
+            context.region is not None
+            and context.active_object is not None
+            and context.active_object.sollum_type == SollumType.CLIP
+        )
 
     def run(self, context):
         return {"FINISHED"}
@@ -1294,7 +1466,9 @@ class SOLLUMZ_OT_timeline_clip_tags_drag(SOLLUMZ_OT_base, bpy.types.Operator):
         mouse_x = event.mouse_region_x
         mouse_y = event.mouse_region_y
 
-        if mouse_y >= region.height - 23.5:  # ignore if mouse is on the timeline scrubber
+        if (
+            mouse_y >= region.height - 23.5
+        ):  # ignore if mouse is on the timeline scrubber
             self.clear_hovered_state(region, clip_obj)
             return {"PASS_THROUGH"}
 
@@ -1358,12 +1532,20 @@ class SOLLUMZ_OT_timeline_clip_tags_drag(SOLLUMZ_OT_base, bpy.types.Operator):
 
             old_hovered_start = clip_tag.ui_timeline_hovered_start
             old_hovered_end = clip_tag.ui_timeline_hovered_end
-            new_hovered_start = start_x - hover_threshold <= mouse_x <= start_x + hover_threshold
-            new_hovered_end = end_x - hover_threshold <= mouse_x <= end_x + hover_threshold
+            new_hovered_start = (
+                start_x - hover_threshold <= mouse_x <= start_x + hover_threshold
+            )
+            new_hovered_end = (
+                end_x - hover_threshold <= mouse_x <= end_x + hover_threshold
+            )
             clip_tag.ui_timeline_hovered_start = new_hovered_start
             clip_tag.ui_timeline_hovered_end = new_hovered_end
 
-            any_change = any_change or old_hovered_start != new_hovered_start or old_hovered_end != new_hovered_end
+            any_change = (
+                any_change
+                or old_hovered_start != new_hovered_start
+                or old_hovered_end != new_hovered_end
+            )
 
         if any_change:
             region.tag_redraw()
@@ -1383,7 +1565,11 @@ class SOLLUMZ_OT_timeline_clip_tags_drag(SOLLUMZ_OT_base, bpy.types.Operator):
             clip_tag.ui_timeline_hovered_start = new_hovered_start
             clip_tag.ui_timeline_hovered_end = new_hovered_end
 
-            any_change = any_change or old_hovered_start != new_hovered_start or old_hovered_end != new_hovered_end
+            any_change = (
+                any_change
+                or old_hovered_start != new_hovered_start
+                or old_hovered_end != new_hovered_end
+            )
 
         if any_change:
             region.tag_redraw()
@@ -1391,7 +1577,9 @@ class SOLLUMZ_OT_timeline_clip_tags_drag(SOLLUMZ_OT_base, bpy.types.Operator):
     def update_drag_state(self, clip_obj):
         any_dragging = False
         clip_properties = clip_obj.clip_properties
-        for clip_tag in reversed(clip_properties.tags):  # reversed so the tag drawn on top is always picked first
+        for clip_tag in reversed(
+            clip_properties.tags
+        ):  # reversed so the tag drawn on top is always picked first
             if not clip_tag.ui_view_on_timeline:
                 continue
 
@@ -1401,7 +1589,11 @@ class SOLLUMZ_OT_timeline_clip_tags_drag(SOLLUMZ_OT_base, bpy.types.Operator):
             else:
                 clip_tag.ui_timeline_drag_start = clip_tag.ui_timeline_hovered_start
                 clip_tag.ui_timeline_drag_end = clip_tag.ui_timeline_hovered_end
-                any_dragging = any_dragging or clip_tag.ui_timeline_drag_start or clip_tag.ui_timeline_drag_end
+                any_dragging = (
+                    any_dragging
+                    or clip_tag.ui_timeline_drag_start
+                    or clip_tag.ui_timeline_drag_end
+                )
         return any_dragging
 
     def clear_drag_state(self, clip_obj):
@@ -1421,7 +1613,10 @@ class SOLLUMZ_OT_timeline_clip_tags_drag(SOLLUMZ_OT_base, bpy.types.Operator):
         any_dragging = False
         clip_properties = clip_obj.clip_properties
         for clip_tag in clip_properties.tags:
-            if not clip_tag.ui_timeline_drag_start and not clip_tag.ui_timeline_drag_end:
+            if (
+                not clip_tag.ui_timeline_drag_start
+                and not clip_tag.ui_timeline_drag_end
+            ):
                 continue
 
             any_dragging = True
@@ -1441,11 +1636,20 @@ def register():
     wm = bpy.context.window_manager
     kc = wm.keyconfigs.addon
     if kc:
-        for name, space_type in (("Dopesheet", "DOPESHEET_EDITOR"), ("NLA Editor", "NLA_EDITOR")):
-            km = wm.keyconfigs.addon.keymaps.new(name=name, space_type=space_type, region_type="WINDOW")
-            kmi = km.keymap_items.new(SOLLUMZ_OT_timeline_clip_tags_drag.bl_idname, "MOUSEMOVE", "ANY")
+        for name, space_type in (
+            ("Dopesheet", "DOPESHEET_EDITOR"),
+            ("NLA Editor", "NLA_EDITOR"),
+        ):
+            km = wm.keyconfigs.addon.keymaps.new(
+                name=name, space_type=space_type, region_type="WINDOW"
+            )
+            kmi = km.keymap_items.new(
+                SOLLUMZ_OT_timeline_clip_tags_drag.bl_idname, "MOUSEMOVE", "ANY"
+            )
             addon_keymaps.append((km, kmi))
-            kmi = km.keymap_items.new(SOLLUMZ_OT_timeline_clip_tags_drag.bl_idname, "LEFTMOUSE", "ANY")
+            kmi = km.keymap_items.new(
+                SOLLUMZ_OT_timeline_clip_tags_drag.bl_idname, "LEFTMOUSE", "ANY"
+            )
             addon_keymaps.append((km, kmi))
 
 

--- a/ycd/properties.py
+++ b/ycd/properties.py
@@ -4,7 +4,12 @@ import bpy
 import math
 from mathutils import Matrix, Vector
 from ..sollumz_properties import SollumType
-from ..tools.animationhelper import retarget_animation, get_target_from_id, get_frame_range_and_count, update_uv_clip_hash
+from ..tools.animationhelper import (
+    retarget_animation,
+    get_target_from_id,
+    get_frame_range_and_count,
+    update_uv_clip_hash,
+)
 
 
 def animations_filter(self, object):
@@ -16,7 +21,10 @@ def animations_filter(self, object):
     if active_object.sollum_type != SollumType.CLIP:
         return False
 
-    return object.sollum_type == SollumType.ANIMATION and active_object.parent.parent == object.parent.parent
+    return (
+        object.sollum_type == SollumType.ANIMATION
+        and active_object.parent.parent == object.parent.parent
+    )
 
 
 ClipAttributeTypes = [
@@ -36,9 +44,15 @@ class ClipAttribute(bpy.types.PropertyGroup):
     value_float: bpy.props.FloatProperty(name="Value", default=0.0)
     value_int: bpy.props.IntProperty(name="Value", default=0)
     value_bool: bpy.props.BoolProperty(name="Value", default=False)
-    value_vec3: bpy.props.FloatVectorProperty(name="Value", default=(0.0, 0.0, 0.0), size=3)
-    value_vec4: bpy.props.FloatVectorProperty(name="Value", default=(0.0, 0.0, 0.0, 0.0), size=4)
-    value_string: bpy.props.StringProperty(name="Value", default="")  # used with String and HashString
+    value_vec3: bpy.props.FloatVectorProperty(
+        name="Value", default=(0.0, 0.0, 0.0), size=3
+    )
+    value_vec4: bpy.props.FloatVectorProperty(
+        name="Value", default=(0.0, 0.0, 0.0, 0.0), size=4
+    )
+    value_string: bpy.props.StringProperty(
+        name="Value", default=""
+    )  # used with String and HashString
 
 
 class ClipTag(bpy.types.PropertyGroup):
@@ -53,36 +67,66 @@ class ClipTag(bpy.types.PropertyGroup):
     name: bpy.props.StringProperty(name="Name", default="")
 
     start_phase: bpy.props.FloatProperty(
-        name="Start Phase", description="Start phase of the tag",
-        default=0, min=0, max=1, step=1, update=on_start_phase_changed)
+        name="Start Phase",
+        description="Start phase of the tag",
+        default=0,
+        min=0,
+        max=1,
+        step=1,
+        update=on_start_phase_changed,
+    )
     end_phase: bpy.props.FloatProperty(
-        name="End Phase", description="End phase of the tag",
-        default=0, min=0, max=1, step=1, update=on_end_phase_changed)
+        name="End Phase",
+        description="End phase of the tag",
+        default=0,
+        min=0,
+        max=1,
+        step=1,
+        update=on_end_phase_changed,
+    )
 
     attributes: bpy.props.CollectionProperty(name="Attributes", type=ClipAttribute)
 
     ui_active_attribute_index: bpy.props.IntProperty()
     ui_show_expanded: bpy.props.BoolProperty(
-        name="Show Expanded", description="Show details of the tag",
-        default=True)
+        name="Show Expanded", description="Show details of the tag", default=True
+    )
     ui_view_on_timeline: bpy.props.BoolProperty(
-        name="View on Timeline", description="Show tag on the timeline",
-        default=True)
+        name="View on Timeline", description="Show tag on the timeline", default=True
+    )
     ui_timeline_color: bpy.props.FloatVectorProperty(
-        name="Timeline Color", description="Color of the tag on the timeline",
-        default=(1.0, 0.0, 0.0, 1.0), size=4, subtype="COLOR", min=0.0, max=1.0)
+        name="Timeline Color",
+        description="Color of the tag on the timeline",
+        default=(1.0, 0.0, 0.0, 1.0),
+        size=4,
+        subtype="COLOR",
+        min=0.0,
+        max=1.0,
+    )
     ui_timeline_hovered_start: bpy.props.BoolProperty(
-        name="Timeline Hovered Start", description="Is the tag start marker hovered on the timeline?",
-        default=False, options={"HIDDEN", "SKIP_SAVE"})
+        name="Timeline Hovered Start",
+        description="Is the tag start marker hovered on the timeline?",
+        default=False,
+        options={"HIDDEN", "SKIP_SAVE"},
+    )
     ui_timeline_hovered_end: bpy.props.BoolProperty(
-        name="Timeline Hovered End", description="Is the tag end marker hovered on the timeline?",
-        default=False, options={"HIDDEN", "SKIP_SAVE"})
+        name="Timeline Hovered End",
+        description="Is the tag end marker hovered on the timeline?",
+        default=False,
+        options={"HIDDEN", "SKIP_SAVE"},
+    )
     ui_timeline_drag_start: bpy.props.BoolProperty(
-        name="Timeline Drag Start", description="Is the tag start marker being dragged on the timeline?",
-        default=False, options={"HIDDEN", "SKIP_SAVE"})
+        name="Timeline Drag Start",
+        description="Is the tag start marker being dragged on the timeline?",
+        default=False,
+        options={"HIDDEN", "SKIP_SAVE"},
+    )
     ui_timeline_drag_end: bpy.props.BoolProperty(
-        name="Timeline Drag End", description="Is the tag end marker being dragged on the timeline?",
-        default=False, options={"HIDDEN", "SKIP_SAVE"})
+        name="Timeline Drag End",
+        description="Is the tag end marker being dragged on the timeline?",
+        default=False,
+        options={"HIDDEN", "SKIP_SAVE"},
+    )
 
 
 class ClipProperty(bpy.types.PropertyGroup):
@@ -90,7 +134,8 @@ class ClipProperty(bpy.types.PropertyGroup):
     attributes: bpy.props.CollectionProperty(name="Attributes", type=ClipAttribute)
 
     ui_show_expanded: bpy.props.BoolProperty(
-        name="Show Expanded", default=True, description="Show details of the property")
+        name="Show Expanded", default=True, description="Show details of the property"
+    )
 
 
 class ClipAnimation(bpy.types.PropertyGroup):
@@ -112,15 +157,30 @@ class ClipAnimation(bpy.types.PropertyGroup):
             update_uv_clip_hash(clip_obj)
 
     start_frame: bpy.props.IntProperty(
-        name="Start Frame", default=0, min=0, description="First frame of the playback area")
+        name="Start Frame",
+        default=0,
+        min=0,
+        description="First frame of the playback area",
+    )
     end_frame: bpy.props.IntProperty(
-        name="End Frame", default=0, min=0, description="Last frame (inclusive) of the playback area")
+        name="End Frame",
+        default=0,
+        min=0,
+        description="Last frame (inclusive) of the playback area",
+    )
 
     animation: bpy.props.PointerProperty(
-        name="Animation", type=bpy.types.Object, poll=animations_filter, update=on_animation_changed)
+        name="Animation",
+        type=bpy.types.Object,
+        poll=animations_filter,
+        update=on_animation_changed,
+    )
 
     ui_show_expanded: bpy.props.BoolProperty(
-        name="Show Expanded", default=True, description="Show details of the linked animation")
+        name="Show Expanded",
+        default=True,
+        description="Show details of the linked animation",
+    )
 
 
 class ClipProperties(bpy.types.PropertyGroup):
@@ -128,8 +188,12 @@ class ClipProperties(bpy.types.PropertyGroup):
     name: bpy.props.StringProperty(name="Name", default="")
 
     duration: bpy.props.FloatProperty(
-        name="Duration", description="Duration of the clip in seconds",
-        default=0, min=0, subtype="TIME_ABSOLUTE")
+        name="Duration",
+        description="Duration of the clip in seconds",
+        default=0,
+        min=0,
+        subtype="TIME_ABSOLUTE",
+    )
 
     animations: bpy.props.CollectionProperty(name="Animations", type=ClipAnimation)
 
@@ -160,9 +224,13 @@ class AnimationProperties(bpy.types.PropertyGroup):
     hash: bpy.props.StringProperty(name="Hash", default="")
     action: bpy.props.PointerProperty(name="Action", type=bpy.types.Action)
 
-    target_id: bpy.props.PointerProperty(name="Target", type=bpy.types.ID, update=on_target_update)
+    target_id: bpy.props.PointerProperty(
+        name="Target", type=bpy.types.ID, update=on_target_update
+    )
     target_id_prev: bpy.props.PointerProperty(name="Target (Prev)", type=bpy.types.ID)
-    target_id_type: bpy.props.EnumProperty(name="Target Type", items=AnimationTargetIDTypes, default="ARMATURE")
+    target_id_type: bpy.props.EnumProperty(
+        name="Target Type", items=AnimationTargetIDTypes, default="ARMATURE"
+    )
 
     def get_target(self) -> bpy.types.ID:
         """Returns the ID instance where the animation data should be created to play the animation."""
@@ -190,13 +258,16 @@ class UVTransform(bpy.types.PropertyGroup):
         if not values:
             # tx, ty, rotation, scale_x, scale_y, shear_x, shear_y, reflect_x, reflect_y
             self["values"] = [0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0]
-            values = self["values"]  # lookup again to get array converted to a IDPropertyArray instance
+            values = self[
+                "values"
+            ]  # lookup again to get array converted to a IDPropertyArray instance
         return values
 
     @staticmethod
     def _float_getter(index):
         def getter(self):
             return self.values_array()[index]
+
         return getter
 
     @staticmethod
@@ -204,6 +275,7 @@ class UVTransform(bpy.types.PropertyGroup):
         def setter(self, value):
             self.values_array()[index] = value
             self.on_update(None)
+
         return setter
 
     @staticmethod
@@ -211,6 +283,7 @@ class UVTransform(bpy.types.PropertyGroup):
         def getter(self):
             values = self.values_array()
             return (values[index_x], values[index_y])
+
         return getter
 
     @staticmethod
@@ -220,66 +293,89 @@ class UVTransform(bpy.types.PropertyGroup):
             values[index_x] = value[0]
             values[index_y] = value[1]
             self.on_update(None)
+
         return setter
 
-    update_uv_transform_matrix_on_change: bpy.props.BoolProperty(default=True, options={"HIDDEN", "SKIP_SAVE"})
+    update_uv_transform_matrix_on_change: bpy.props.BoolProperty(
+        default=True, options={"HIDDEN", "SKIP_SAVE"}
+    )
     mode: bpy.props.EnumProperty(
-        name="Transformation Mode", items=UVTransformModes, default="TRANSLATE", update=on_update, options=set())
+        name="Transformation Mode",
+        items=UVTransformModes,
+        default="TRANSLATE",
+        update=on_update,
+        options=set(),
+    )
     translation: bpy.props.FloatVectorProperty(
-        name="Translation", size=2, subtype="XYZ", get=_vec2_getter(0, 1), set=_vec2_setter(0, 1))
+        name="Translation",
+        size=2,
+        subtype="XYZ",
+        get=_vec2_getter(0, 1),
+        set=_vec2_setter(0, 1),
+    )
     rotation: bpy.props.FloatProperty(
-        name="Rotation", subtype="ANGLE", unit="ROTATION", get=_float_getter(2), set=_float_setter(2))
+        name="Rotation",
+        subtype="ANGLE",
+        unit="ROTATION",
+        get=_float_getter(2),
+        set=_float_setter(2),
+    )
     scale: bpy.props.FloatVectorProperty(
-        name="Scale", size=2, subtype="XYZ", get=_vec2_getter(3, 4), set=_vec2_setter(3, 4))
+        name="Scale",
+        size=2,
+        subtype="XYZ",
+        get=_vec2_getter(3, 4),
+        set=_vec2_setter(3, 4),
+    )
     shear: bpy.props.FloatVectorProperty(
-        name="Shear", size=2, subtype="XYZ", get=_vec2_getter(5, 6), set=_vec2_setter(5, 6))
+        name="Shear",
+        size=2,
+        subtype="XYZ",
+        get=_vec2_getter(5, 6),
+        set=_vec2_setter(5, 6),
+    )
     reflect: bpy.props.FloatVectorProperty(
-        name="Reflection Axis", size=2, subtype="XYZ", get=_vec2_getter(7, 8), set=_vec2_setter(7, 8))
+        name="Reflection Axis",
+        size=2,
+        subtype="XYZ",
+        get=_vec2_getter(7, 8),
+        set=_vec2_setter(7, 8),
+    )
 
     def get_matrix(self) -> Matrix:
         """
         Returns the affine matrix for this transform.
         """
         if self.mode == "TRANSLATE":
-            return Matrix((
-                (1.0, 0.0, self.translation[0]),
-                (0.0, 1.0, self.translation[1]),
-                (0.0, 0.0, 1.0)
-            ))
+            return Matrix(
+                (
+                    (1.0, 0.0, self.translation[0]),
+                    (0.0, 1.0, self.translation[1]),
+                    (0.0, 0.0, 1.0),
+                )
+            )
         elif self.mode == "ROTATE":
             cos = math.cos(self.rotation)
             sin = math.sin(self.rotation)
-            return Matrix((
-                (cos, -sin, 0.0),
-                (sin, cos, 0.0),
-                (0.0, 0.0, 1.0)
-            ))
+            return Matrix(((cos, -sin, 0.0), (sin, cos, 0.0), (0.0, 0.0, 1.0)))
         elif self.mode == "SCALE":
-            return Matrix((
-                (self.scale[0], 0.0, 0.0),
-                (0.0, self.scale[1], 0.0),
-                (0.0, 0.0, 1.0)
-            ))
+            return Matrix(
+                ((self.scale[0], 0.0, 0.0), (0.0, self.scale[1], 0.0), (0.0, 0.0, 1.0))
+            )
         elif self.mode == "SHEAR":
-            return Matrix((
-                (1.0, self.shear[0], 0.0),
-                (self.shear[1], 1.0, 0.0),
-                (0.0, 0.0, 1.0)
-            ))
+            return Matrix(
+                ((1.0, self.shear[0], 0.0), (self.shear[1], 1.0, 0.0), (0.0, 0.0, 1.0))
+            )
         elif self.mode == "REFLECT":
             v = Vector(self.reflect)
             if v.length_squared == 0.0:
                 return Matrix.Identity(3)
             v.normalize()
-            a = v.x ** 2 - v.y ** 2
+            a = v.x**2 - v.y**2
             b = 2 * v.x * v.y
             c = b
-            d = v.y ** 2 - v.x ** 2
-            return Matrix((
-                (a, b, 0.0),
-                (c, d, 0.0),
-                (0.0, 0.0, 1.0)
-            ))
+            d = v.y**2 - v.x**2
+            return Matrix(((a, b, 0.0), (c, d, 0.0), (0.0, 0.0, 1.0)))
         else:
             return Matrix.Identity(3)
 
@@ -294,15 +390,21 @@ class UVTransform(bpy.types.PropertyGroup):
 class AnimationTracks(bpy.types.PropertyGroup):
     @staticmethod
     def Vec3Prop(name, subtype="TRANSLATION", default=(0.0, 0.0, 0.0)):
-        return bpy.props.FloatVectorProperty(name=name, size=3, subtype=subtype, default=default)
+        return bpy.props.FloatVectorProperty(
+            name=name, size=3, subtype=subtype, default=default
+        )
 
     @staticmethod
     def QuatProp(name, default=(1.0, 0.0, 0.0, 0.0)):
-        return bpy.props.FloatVectorProperty(name=name, size=4, subtype="QUATERNION", default=default)
+        return bpy.props.FloatVectorProperty(
+            name=name, size=4, subtype="QUATERNION", default=default
+        )
 
     @staticmethod
-    def FloatProp(name, subtype="NONE", default=0.0, min=-3.402823e+38, max=3.402823e+38):
-        return bpy.props.FloatProperty(name=name, subtype=subtype, default=default, min=min, max=max)
+    def FloatProp(name, subtype="NONE", default=0.0, min=-3.402823e38, max=3.402823e38):
+        return bpy.props.FloatProperty(
+            name=name, subtype=subtype, default=default, min=min, max=max
+        )
 
     mover_location: Vec3Prop("Mover Location")  # aka root motion
     mover_rotation: QuatProp("Mover Rotation")
@@ -314,16 +416,22 @@ class AnimationTracks(bpy.types.PropertyGroup):
     unk_24: FloatProp("Unk 24")
     unk_25: Vec3Prop("Unk 25", subtype="XYZ")
     unk_26: QuatProp("Unk 26")
-    camera_fov: FloatProp("Camera FOV", default=39.6, min=1.0, max=130.0)  # in degrees, 1.0-130.0
+    camera_fov: FloatProp(
+        "Camera FOV", default=39.6, min=1.0, max=130.0
+    )  # in degrees, 1.0-130.0
     camera_dof: Vec3Prop("Camera DOF", subtype="XYZ")  # x=near, y=far, z=unused
     unk_29: Vec3Prop("Unk 29", subtype="XYZ")
     unk_30: FloatProp("Unk 30")
     unk_31: FloatProp("Unk 31")
     unk_32: FloatProp("Unk 32")
-    unk_33: FloatProp("Unk 33") # high heels related (used on BONETAG_HIGH_HEELS, which doesn't seem to be a real bone)
+    unk_33: FloatProp(
+        "Unk 33"
+    )  # high heels related (used on BONETAG_HIGH_HEELS, which doesn't seem to be a real bone)
     unk_34: Vec3Prop("Unk 34", subtype="XYZ")
     camera_dof_strength: FloatProp("Camera DOF Strength", min=0.0, max=1.0)  # 0.0-1.0
-    camera_unk_39: FloatProp("Camera Unk 39", min=0.0, max=1.0)  # boolean flag, true= >0.5, false= <=0.5
+    camera_unk_39: FloatProp(
+        "Camera Unk 39", min=0.0, max=1.0
+    )  # boolean flag, true= >0.5, false= <=0.5
     unk_40: FloatProp("Unk 40")
     unk_41: FloatProp("Unk 41")
     unk_42: Vec3Prop("Unk 42", subtype="XYZ")
@@ -333,10 +441,16 @@ class AnimationTracks(bpy.types.PropertyGroup):
     camera_dof_plane_far_unk: FloatProp("Camera DOF Plane Far Unk")
     camera_dof_plane_far: FloatProp("Camera DOF Plane Far")
     unk_47: FloatProp("Unk 47")
-    camera_unk_48: FloatProp("Camera Unk 48", min=0.0, max=1.0)  # boolean flag, true= >0.5, false= <=0.5
-    camera_dof_unk_49: FloatProp("Camera DOF Unk 49")  # used with camera_dof_plane_* tracks
+    camera_unk_48: FloatProp(
+        "Camera Unk 48", min=0.0, max=1.0
+    )  # boolean flag, true= >0.5, false= <=0.5
+    camera_dof_unk_49: FloatProp(
+        "Camera DOF Unk 49"
+    )  # used with camera_dof_plane_* tracks
     unk_50: FloatProp("Unk 50")
-    camera_dof_unk_51: FloatProp("Camera DOF Unk 51")  # used with camera_dof_plane_* tracks
+    camera_dof_unk_51: FloatProp(
+        "Camera DOF Unk 51"
+    )  # used with camera_dof_plane_* tracks
     unk_52: FloatProp("Unk 52")
     unk_53: FloatProp("Unk 53")
     unk_134: FloatProp("Unk 134")
@@ -357,12 +471,15 @@ class AnimationTracks(bpy.types.PropertyGroup):
 
         if bpy.context.screen is not None:
             for area in bpy.context.screen.areas:
-                if area.type == 'VIEW_3D':
+                if area.type == "VIEW_3D":
                     area.tag_redraw()
 
-    uv_transforms: bpy.props.CollectionProperty(type=UVTransform,
-                                                name="UV Transformations")
-    uv_transforms_active_index: bpy.props.IntProperty(name="Active UV Transformation", options=set())
+    uv_transforms: bpy.props.CollectionProperty(
+        type=UVTransform, name="UV Transformations"
+    )
+    uv_transforms_active_index: bpy.props.IntProperty(
+        name="Active UV Transformation", options=set()
+    )
 
 
 def calculate_final_uv_transform_matrix(uv_transforms: Iterable[UVTransform]) -> Matrix:
@@ -380,7 +497,9 @@ def register_tracks(cls, inline=False):
         for prop, info in AnimationTracks.__annotations__.items():
             setattr(cls, f"animation_tracks_{prop}", info)
     else:
-        cls.animation_tracks = bpy.props.PointerProperty(name="Animation Tracks", type=AnimationTracks)
+        cls.animation_tracks = bpy.props.PointerProperty(
+            name="Animation Tracks", type=AnimationTracks
+        )
 
 
 def unregister_tracks(cls, inline=False):
@@ -392,10 +511,10 @@ def unregister_tracks(cls, inline=False):
 
 
 def register():
-    bpy.types.Object.clip_properties = bpy.props.PointerProperty(
-        type=ClipProperties)
+    bpy.types.Object.clip_properties = bpy.props.PointerProperty(type=ClipProperties)
     bpy.types.Object.animation_properties = bpy.props.PointerProperty(
-        type=AnimationProperties)
+        type=AnimationProperties
+    )
 
     register_tracks(bpy.types.PoseBone, inline=True)
     register_tracks(bpy.types.Object)
@@ -403,13 +522,19 @@ def register():
 
     # used during export to temporarily store UV transforms
     bpy.types.ID.export_uv_transforms = bpy.props.CollectionProperty(
-        type=UVTransform, options={"HIDDEN", "SKIP_SAVE"})
+        type=UVTransform, options={"HIDDEN", "SKIP_SAVE"}
+    )
 
     # used with operator SOLLUMZ_OT_animations_set_target
     bpy.types.Scene.sollumz_animations_target_id = bpy.props.PointerProperty(
-        name="Target", type=bpy.types.ID, options={"HIDDEN", "SKIP_SAVE"})
+        name="Target", type=bpy.types.ID, options={"HIDDEN", "SKIP_SAVE"}
+    )
     bpy.types.Scene.sollumz_animations_target_id_type = bpy.props.EnumProperty(
-        name="Target Type", items=AnimationTargetIDTypes, default="ARMATURE", options={"HIDDEN", "SKIP_SAVE"})
+        name="Target Type",
+        items=AnimationTargetIDTypes,
+        default="ARMATURE",
+        options={"HIDDEN", "SKIP_SAVE"},
+    )
 
 
 def unregister():

--- a/ycd/ui.py
+++ b/ycd/ui.py
@@ -7,7 +7,10 @@ from ..sollumz_ui import SOLLUMZ_PT_OBJECT_PANEL, SOLLUMZ_PT_MAT_PANEL
 from . import operators as ycd_ops
 from .properties import AnimationTracks
 from ..ydr.ui import SOLLUMZ_PT_BONE_PANEL
-from ..tools.animationhelper import is_any_sollumz_animation_obj, is_uv_animation_supported
+from ..tools.animationhelper import (
+    is_any_sollumz_animation_obj,
+    is_uv_animation_supported,
+)
 
 
 def draw_clip_properties(self, context):
@@ -16,24 +19,35 @@ def draw_clip_properties(self, context):
         layout = self.layout
 
         clip_properties = obj.clip_properties
-        is_uv = any(a.animation is not None and a.animation.animation_properties.target_id_type == "MATERIAL"
-                    for a in clip_properties.animations)
+        is_uv = any(
+            a.animation is not None
+            and a.animation.animation_properties.target_id_type == "MATERIAL"
+            for a in clip_properties.animations
+        )
         if is_uv:
             row = layout.row()
             row.prop(clip_properties, "hash")
-            row.operator(ycd_ops.SOLLUMZ_OT_clip_recalculate_uv_hash.bl_idname, text="", icon="FILE_REFRESH")
+            row.operator(
+                ycd_ops.SOLLUMZ_OT_clip_recalculate_uv_hash.bl_idname,
+                text="",
+                icon="FILE_REFRESH",
+            )
             split = layout.split(factor=0.4)
             split.row()
             row = split.row()
             row.alignment = "RIGHT"
-            row.label(text="UV clip hash is calculated based on the target material and model name.     ", icon="INFO")
+            row.label(
+                text="UV clip hash is calculated based on the target material and model name.     ",
+                icon="INFO",
+            )
         else:
             layout.prop(clip_properties, "hash")
         layout.prop(clip_properties, "name")
         layout.prop(clip_properties, "duration")
 
-        layout.operator(ycd_ops.SOLLUMZ_OT_clip_apply_nla.bl_idname,
-                        text="Apply Clip to NLA")
+        layout.operator(
+            ycd_ops.SOLLUMZ_OT_clip_apply_nla.bl_idname, text="Apply Clip to NLA"
+        )
 
 
 animation_target_id_type_to_collection_name = {
@@ -50,8 +64,15 @@ animation_target_id_python_type_to_type = {
 
 
 # https://blender.stackexchange.com/a/293222
-def template_animation_target_ID(layout: bpy.types.UILayout, data, property: str, type_property: str,
-                                 text: Optional[str] = "", text_ctxt: str = "", translate: bool = True):
+def template_animation_target_ID(
+    layout: bpy.types.UILayout,
+    data,
+    property: str,
+    type_property: str,
+    text: Optional[str] = "",
+    text_ctxt: str = "",
+    translate: bool = True,
+):
     if text is not None:
         split = layout.split(factor=0.4, align=True)
         row = split.row()
@@ -60,7 +81,11 @@ def template_animation_target_ID(layout: bpy.types.UILayout, data, property: str
             # ` + "  "` is a hack to make the text better aligned with previous prop()'s
             row.label(text=text + "  ", text_ctxt=text_ctxt, translate=translate)
         elif data.bl_rna.properties[property].name != "":
-            row.label(text=data.bl_rna.properties[property].name + "  ", text_ctxt=text_ctxt, translate=translate)
+            row.label(
+                text=data.bl_rna.properties[property].name + "  ",
+                text_ctxt=text_ctxt,
+                translate=translate,
+            )
         else:
             row.label(text="ID-Block:")
         row = split.row(align=True)
@@ -73,13 +98,25 @@ def template_animation_target_ID(layout: bpy.types.UILayout, data, property: str
     type_name = getattr(data, type_property)
     if type_name in animation_target_id_type_to_collection_name:
         data_prop = getattr(data, property)
-        data_prop_type_name = animation_target_id_python_type_to_type.get(type(data_prop), None)
+        data_prop_type_name = animation_target_id_python_type_to_type.get(
+            type(data_prop), None
+        )
         if data_prop_type_name is None:
             icon = "NONE"
         else:
-            icon = data.bl_rna.properties[type_property].enum_items[data_prop_type_name].icon
-        row.prop_search(data, property, bpy.data, animation_target_id_type_to_collection_name[type_name],
-                        text="", icon=icon)
+            icon = (
+                data.bl_rna.properties[type_property]
+                .enum_items[data_prop_type_name]
+                .icon
+            )
+        row.prop_search(
+            data,
+            property,
+            bpy.data,
+            animation_target_id_type_to_collection_name[type_name],
+            text="",
+            icon=icon,
+        )
 
 
 def draw_animation_properties(self, context):
@@ -91,14 +128,16 @@ def draw_animation_properties(self, context):
 
         layout.prop(animation_properties, "hash")
         layout.prop(animation_properties, "action")
-        template_animation_target_ID(layout, animation_properties, "target_id", "target_id_type")
+        template_animation_target_ID(
+            layout, animation_properties, "target_id", "target_id_type"
+        )
 
 
 def draw_range_properties(layout, obj, prop_start, prop_end, label):
     """Draw two properties in a row aligned to each other, with label on the left."""
     split = layout.split(factor=0.4, align=True)
     label_row = split.row()
-    label_row.alignment = 'RIGHT'
+    label_row.alignment = "RIGHT"
     label_row.label(text=label)
     value_row = split.row(align=True)
     value_row.use_property_split = False
@@ -107,10 +146,13 @@ def draw_range_properties(layout, obj, prop_start, prop_end, label):
 
 
 def draw_item_box_header(
-        layout, obj, label, delete_op_cls,
-        show_expanded_prop="ui_show_expanded",
-        visible_prop=None,
-        color_prop=None
+    layout,
+    obj,
+    label,
+    delete_op_cls,
+    show_expanded_prop="ui_show_expanded",
+    visible_prop=None,
+    color_prop=None,
 ):
     """
     Draw a box header with a 'expand' button, label, optional visibility toggle, optional color picker
@@ -136,8 +178,9 @@ def draw_item_box_header(
         row.scale_x = 0.35  # make the color picker smaller
         row.prop(obj, color_prop, text="")
 
-    delete_op = header.operator(delete_op_cls.bl_idname,
-                                text="", emboss=False, icon="X")
+    delete_op = header.operator(
+        delete_op_cls.bl_idname, text="", emboss=False, icon="X"
+    )
     return delete_op
 
 
@@ -165,8 +208,9 @@ def draw_clip_attribute(layout, attr, delete_op_cls):
     elif attr.type == "HashString":
         right_row.prop(attr, "value_string", text="")
 
-    del_op = right_row.operator(delete_op_cls.bl_idname,
-                                text="", emboss=False, icon='X')
+    del_op = right_row.operator(
+        delete_op_cls.bl_idname, text="", emboss=False, icon="X"
+    )
     return del_op
 
 
@@ -258,20 +302,35 @@ class SOLLUMZ_PT_MATERIAL_ANIMATION_TRACKS(bpy.types.Panel):
 
         layout.label(text="UV Transformations")
         if not is_supported:
-            layout.label(text=f"Shader '{mat.shader_properties.name}' does not support UV animations.", icon="ERROR")
+            layout.label(
+                text=f"Shader '{mat.shader_properties.name}' does not support UV animations.",
+                icon="ERROR",
+            )
 
         row = layout.row()
         row.enabled = is_supported
         with context.temp_override(animation_tracks=animation_tracks):
-            row.template_list(SOLLUMZ_UL_uv_transforms_list.bl_idname, "",
-                              animation_tracks, "uv_transforms", animation_tracks, "uv_transforms_active_index")
+            row.template_list(
+                SOLLUMZ_UL_uv_transforms_list.bl_idname,
+                "",
+                animation_tracks,
+                "uv_transforms",
+                animation_tracks,
+                "uv_transforms_active_index",
+            )
 
         col = row.column(align=True)
         col.operator(ycd_ops.SOLLUMZ_OT_uv_transform_add.bl_idname, icon="ADD", text="")
-        col.operator(ycd_ops.SOLLUMZ_OT_uv_transform_remove.bl_idname, icon="REMOVE", text="")
+        col.operator(
+            ycd_ops.SOLLUMZ_OT_uv_transform_remove.bl_idname, icon="REMOVE", text=""
+        )
         col.separator()
-        col.operator(ycd_ops.SOLLUMZ_OT_uv_transform_move.bl_idname, icon="TRIA_UP", text="").direction = "UP"
-        col.operator(ycd_ops.SOLLUMZ_OT_uv_transform_move.bl_idname, icon="TRIA_DOWN", text="").direction = "DOWN"
+        col.operator(
+            ycd_ops.SOLLUMZ_OT_uv_transform_move.bl_idname, icon="TRIA_UP", text=""
+        ).direction = "UP"
+        col.operator(
+            ycd_ops.SOLLUMZ_OT_uv_transform_move.bl_idname, icon="TRIA_DOWN", text=""
+        ).direction = "DOWN"
 
         row = layout.row()
         row.enabled = is_supported
@@ -290,7 +349,7 @@ class SOLLUMZ_PT_POSE_BONE_ANIMATION_TRACKS(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         p_bone = context.active_pose_bone
-        return p_bone is not None and p_bone.parent is None # only root bone
+        return p_bone is not None and p_bone.parent is None  # only root bone
 
     def draw(self, context):
         layout = self.layout
@@ -381,14 +440,17 @@ class SOLLUMZ_PT_CLIP_ANIMATIONS(bpy.types.Panel):
         obj = context.active_object
         clip_properties = obj.clip_properties
 
-        layout.operator(ycd_ops.SOLLUMZ_OT_clip_new_animation.bl_idname,
-                        text="New", icon="ADD")
+        layout.operator(
+            ycd_ops.SOLLUMZ_OT_clip_new_animation.bl_idname, text="New", icon="ADD"
+        )
 
         for animation_index, clip_animation in enumerate(clip_properties.animations):
             box = layout.box()
 
             label = clip_animation.animation.name if clip_animation.animation else None
-            delete_op = draw_item_box_header(box, clip_animation, label, ycd_ops.SOLLUMZ_OT_clip_delete_animation)
+            delete_op = draw_item_box_header(
+                box, clip_animation, label, ycd_ops.SOLLUMZ_OT_clip_delete_animation
+            )
             delete_op.animation_index = animation_index
 
             if clip_animation.ui_show_expanded:
@@ -396,7 +458,9 @@ class SOLLUMZ_PT_CLIP_ANIMATIONS(bpy.types.Panel):
                 box.use_property_decorate = False
                 box.prop(clip_animation, "animation", text="Animation")
 
-                draw_range_properties(box, clip_animation, "start_frame", "end_frame", "Frame Range")
+                draw_range_properties(
+                    box, clip_animation, "start_frame", "end_frame", "Frame Range"
+                )
 
 
 class SOLLUMZ_PT_CLIP_TAGS(bpy.types.Panel):
@@ -422,17 +486,27 @@ class SOLLUMZ_PT_CLIP_TAGS(bpy.types.Panel):
         clip_properties = obj.clip_properties
 
         row = layout.split(factor=0.625, align=True)
-        row.operator(ycd_ops.SOLLUMZ_OT_clip_new_tag.bl_idname,
-                     text="New", icon="ADD").ignore_template = True
-        row.operator_menu_enum(ycd_ops.SOLLUMZ_OT_clip_new_tag.bl_idname, "template",
-                               text="From Template", icon="MENU_PANEL").ignore_template = False
+        row.operator(
+            ycd_ops.SOLLUMZ_OT_clip_new_tag.bl_idname, text="New", icon="ADD"
+        ).ignore_template = True
+        row.operator_menu_enum(
+            ycd_ops.SOLLUMZ_OT_clip_new_tag.bl_idname,
+            "template",
+            text="From Template",
+            icon="MENU_PANEL",
+        ).ignore_template = False
 
         for tag_index, clip_tag in enumerate(clip_properties.tags):
             box = layout.box()
 
-            del_op = draw_item_box_header(box, clip_tag, clip_tag.name, ycd_ops.SOLLUMZ_OT_clip_delete_tag,
-                                          visible_prop="ui_view_on_timeline",
-                                          color_prop="ui_timeline_color")
+            del_op = draw_item_box_header(
+                box,
+                clip_tag,
+                clip_tag.name,
+                ycd_ops.SOLLUMZ_OT_clip_delete_tag,
+                visible_prop="ui_view_on_timeline",
+                color_prop="ui_timeline_color",
+            )
             del_op.tag_index = tag_index
 
             if clip_tag.ui_show_expanded:
@@ -440,16 +514,23 @@ class SOLLUMZ_PT_CLIP_TAGS(bpy.types.Panel):
                 box.use_property_decorate = False
                 box.prop(clip_tag, "name")
 
-                draw_range_properties(box, clip_tag, "start_phase", "end_phase", "Phase Range")
+                draw_range_properties(
+                    box, clip_tag, "start_phase", "end_phase", "Phase Range"
+                )
 
                 attr_box = box.box()
                 attr_header = attr_box.row(align=True)
                 attr_header.label(text="Attributes")
-                new_op = attr_header.operator(ycd_ops.SOLLUMZ_OT_clip_new_tag_attribute.bl_idname,
-                                              text="", icon="ADD")
+                new_op = attr_header.operator(
+                    ycd_ops.SOLLUMZ_OT_clip_new_tag_attribute.bl_idname,
+                    text="",
+                    icon="ADD",
+                )
                 new_op.tag_index = tag_index
                 for attr_index, attr in enumerate(clip_tag.attributes):
-                    del_op = draw_clip_attribute(attr_box, attr, ycd_ops.SOLLUMZ_OT_clip_delete_tag_attribute)
+                    del_op = draw_clip_attribute(
+                        attr_box, attr, ycd_ops.SOLLUMZ_OT_clip_delete_tag_attribute
+                    )
                     del_op.tag_index = tag_index
                     del_op.attribute_index = attr_index
 
@@ -476,12 +557,16 @@ class SOLLUMZ_PT_CLIP_PROPERTIES(bpy.types.Panel):
         obj = context.active_object
         clip_properties = obj.clip_properties
 
-        layout.operator(ycd_ops.SOLLUMZ_OT_clip_new_property.bl_idname, text="New", icon="ADD")
+        layout.operator(
+            ycd_ops.SOLLUMZ_OT_clip_new_property.bl_idname, text="New", icon="ADD"
+        )
 
         for prop_index, clip_prop in enumerate(clip_properties.properties):
             box = layout.box()
 
-            del_op = draw_item_box_header(box, clip_prop, clip_prop.name, ycd_ops.SOLLUMZ_OT_clip_delete_property)
+            del_op = draw_item_box_header(
+                box, clip_prop, clip_prop.name, ycd_ops.SOLLUMZ_OT_clip_delete_property
+            )
             del_op.property_index = prop_index
 
             if clip_prop.ui_show_expanded:
@@ -492,11 +577,18 @@ class SOLLUMZ_PT_CLIP_PROPERTIES(bpy.types.Panel):
                 attr_box = box.box()
                 attr_header = attr_box.row(align=True)
                 attr_header.label(text="Attributes")
-                new_op = attr_header.operator(ycd_ops.SOLLUMZ_OT_clip_new_property_attribute.bl_idname,
-                                              text="", icon="ADD")
+                new_op = attr_header.operator(
+                    ycd_ops.SOLLUMZ_OT_clip_new_property_attribute.bl_idname,
+                    text="",
+                    icon="ADD",
+                )
                 new_op.property_index = prop_index
                 for attr_index, attr in enumerate(clip_prop.attributes):
-                    del_op = draw_clip_attribute(attr_box, attr, ycd_ops.SOLLUMZ_OT_clip_delete_property_attribute)
+                    del_op = draw_clip_attribute(
+                        attr_box,
+                        attr,
+                        ycd_ops.SOLLUMZ_OT_clip_delete_property_attribute,
+                    )
                     del_op.property_index = prop_index
                     del_op.attribute_index = attr_index
 
@@ -527,13 +619,16 @@ class SOLLUMZ_PT_ANIMATIONS_TOOL_PANEL(bpy.types.Panel):
                 row.operator(ycd_ops.SOLLUMZ_OT_create_clip_dictionary.bl_idname)
 
             row = layout.row(align=True)
-            template_animation_target_ID(row, context.scene,
-                                         "sollumz_animations_target_id",
-                                         "sollumz_animations_target_id_type", text=None)
+            template_animation_target_ID(
+                row,
+                context.scene,
+                "sollumz_animations_target_id",
+                "sollumz_animations_target_id_type",
+                text=None,
+            )
             row.operator(ycd_ops.SOLLUMZ_OT_animations_set_target.bl_idname)
         else:
-            layout.operator(
-                ycd_ops.SOLLUMZ_OT_create_clip_dictionary.bl_idname)
+            layout.operator(ycd_ops.SOLLUMZ_OT_create_clip_dictionary.bl_idname)
 
 
 class ClipTagsOnTimelineDrawHandler:
@@ -599,12 +694,18 @@ class ClipTagsOnTimelineDrawHandler:
             start_frame = clip_frame_count * start_phase
             end_frame = clip_frame_count * end_phase
             color = clip_tag.ui_timeline_color
-            color_highlight = (color[0] + (1.0 - color[0]) * 0.25,
-                               color[1] + (1.0 - color[1]) * 0.25,
-                               color[2] + (1.0 - color[2]) * 0.25,
-                               color[3])
-            highlight_start = clip_tag.ui_timeline_hovered_start or clip_tag.ui_timeline_drag_start
-            highlight_end = clip_tag.ui_timeline_hovered_end or clip_tag.ui_timeline_drag_end
+            color_highlight = (
+                color[0] + (1.0 - color[0]) * 0.25,
+                color[1] + (1.0 - color[1]) * 0.25,
+                color[2] + (1.0 - color[2]) * 0.25,
+                color[3],
+            )
+            highlight_start = (
+                clip_tag.ui_timeline_hovered_start or clip_tag.ui_timeline_drag_start
+            )
+            highlight_end = (
+                clip_tag.ui_timeline_hovered_end or clip_tag.ui_timeline_drag_end
+            )
             color_start = color_highlight if highlight_start else color
             color_end = color_highlight if highlight_end else color
             overlay_color = (color[0], color[1], color[2], color[3] * 0.2)
@@ -615,7 +716,7 @@ class ClipTagsOnTimelineDrawHandler:
 
             # tag area highlight
             o = i * 6
-            self.overlay_verts_pos[o:o + 6] = (
+            self.overlay_verts_pos[o : o + 6] = (
                 (start_x, y, 0.0),  # top left triangle
                 (start_x, y - h, 0.0),
                 (end_x, y, 0.0),
@@ -623,10 +724,10 @@ class ClipTagsOnTimelineDrawHandler:
                 (end_x, y - h, 0.0),
                 (start_x, y - h, 0.0),
             )
-            self.overlay_verts_color[o: o + 6] = overlay_color
+            self.overlay_verts_color[o : o + 6] = overlay_color
 
             o = i * 12
-            self.marker_verts_pos[o:o + 12] = (
+            self.marker_verts_pos[o : o + 12] = (
                 # start marker
                 (start_x, y, 0.0),  # start vertical line top
                 (start_x, y - h, 0.0),  # start vertical line bottom
@@ -642,8 +743,8 @@ class ClipTagsOnTimelineDrawHandler:
                 (end_x + notch_size, y, 0.0),
                 (end_x, y - notch_size, 0.0),
             )
-            self.marker_verts_color[o: o + 6] = color_start
-            self.marker_verts_color[o + 6: o + 12] = color_end
+            self.marker_verts_color[o : o + 6] = color_start
+            self.marker_verts_color[o + 6 : o + 12] = color_end
 
             # tag name
             text_offset = 30 + 25 * (i % 4 + 1)
@@ -657,16 +758,24 @@ class ClipTagsOnTimelineDrawHandler:
         gpu.state.blend_set("ALPHA")
 
         shader_smooth_color = gpu.shader.from_builtin("SMOOTH_COLOR")
-        batch = gpu_extras.batch.batch_for_shader(shader_smooth_color, "TRIS", {
-            "pos": self.overlay_verts_pos[:num_visible_tags * 6],
-            "color": self.overlay_verts_color[:num_visible_tags * 6]
-        })
+        batch = gpu_extras.batch.batch_for_shader(
+            shader_smooth_color,
+            "TRIS",
+            {
+                "pos": self.overlay_verts_pos[: num_visible_tags * 6],
+                "color": self.overlay_verts_color[: num_visible_tags * 6],
+            },
+        )
         batch.draw(shader_smooth_color)
 
-        batch = gpu_extras.batch.batch_for_shader(shader_smooth_color, "LINES", {
-            "pos": self.marker_verts_pos[:num_visible_tags * 12],
-            "color": self.marker_verts_color[:num_visible_tags * 12]
-        })
+        batch = gpu_extras.batch.batch_for_shader(
+            shader_smooth_color,
+            "LINES",
+            {
+                "pos": self.marker_verts_pos[: num_visible_tags * 12],
+                "color": self.marker_verts_color[: num_visible_tags * 12],
+            },
+        )
         batch.draw(shader_smooth_color)
 
         theme = context.preferences.themes[0]

--- a/ycd/ycdimport.py
+++ b/ycd/ycdimport.py
@@ -3,7 +3,12 @@ import bpy
 from mathutils import Vector, Quaternion
 from ..cwxml import clipdictionary as ycdxml
 from ..sollumz_properties import SOLLUMZ_UI_NAMES, SollumType
-from ..tools.animationhelper import Track, TrackFormat, TrackFormatMap, get_canonical_track_data_path
+from ..tools.animationhelper import (
+    Track,
+    TrackFormat,
+    TrackFormatMap,
+    get_canonical_track_data_path,
+)
 from ..tools.utils import color_hash
 
 
@@ -28,7 +33,9 @@ def insert_action_data(action_data: ActionData, bone_id: int, track: Track, data
     action_data[bone_id][track].append(data)
 
 
-def get_values_from_sequence_data(sequence_data: ycdxml.Animation.SequenceDataList.SequenceData, frame_id: int) -> list:
+def get_values_from_sequence_data(
+    sequence_data: ycdxml.Animation.SequenceDataList.SequenceData, frame_id: int
+) -> list:
     channel_values = []
 
     for i in range(len(sequence_data.channels)):
@@ -44,26 +51,26 @@ def get_values_from_sequence_data(sequence_data: ycdxml.Animation.SequenceDataLi
 
 
 def get_vector3_from_sequence_data(
-    sequence_data: ycdxml.Animation.SequenceDataList.SequenceData,
-    frame_id: int
+    sequence_data: ycdxml.Animation.SequenceDataList.SequenceData, frame_id: int
 ) -> Vector:
     channel_values = get_values_from_sequence_data(sequence_data, frame_id)
 
     if len(channel_values) == 1:
         location = channel_values[0]
     else:
-        location = Vector([
-            channel_values[0],
-            channel_values[1],
-            channel_values[2],
-        ])
+        location = Vector(
+            [
+                channel_values[0],
+                channel_values[1],
+                channel_values[2],
+            ]
+        )
 
     return location
 
 
 def get_quaternion_from_sequence_data(
-    sequence_data: ycdxml.Animation.SequenceDataList.SequenceData,
-    frame_id: int
+    sequence_data: ycdxml.Animation.SequenceDataList.SequenceData, frame_id: int
 ) -> Quaternion:
     channel_values = get_values_from_sequence_data(sequence_data, frame_id)
 
@@ -72,31 +79,68 @@ def get_quaternion_from_sequence_data(
     else:
         if len(sequence_data.channels) <= 4:
             for channel in sequence_data.channels:
-                if channel.type == "CachedQuaternion1" or channel.type == "CachedQuaternion2":
+                if (
+                    channel.type == "CachedQuaternion1"
+                    or channel.type == "CachedQuaternion2"
+                ):
                     cached_value = channel.get_value(frame_id, channel_values)
 
                     if channel.quat_index == 0:
                         channel_values = [
-                            cached_value, channel_values[0], channel_values[1], channel_values[2]]
+                            cached_value,
+                            channel_values[0],
+                            channel_values[1],
+                            channel_values[2],
+                        ]
                     elif channel.quat_index == 1:
                         channel_values = [
-                            channel_values[0], cached_value, channel_values[1], channel_values[2]]
+                            channel_values[0],
+                            cached_value,
+                            channel_values[1],
+                            channel_values[2],
+                        ]
                     elif channel.quat_index == 2:
                         channel_values = [
-                            channel_values[0], channel_values[1], cached_value, channel_values[2]]
+                            channel_values[0],
+                            channel_values[1],
+                            cached_value,
+                            channel_values[2],
+                        ]
                     elif channel.quat_index == 3:
                         channel_values = [
-                            channel_values[0], channel_values[1], channel_values[2], cached_value]
+                            channel_values[0],
+                            channel_values[1],
+                            channel_values[2],
+                            cached_value,
+                        ]
 
             if channel.type == "CachedQuaternion2":
                 rotation = Quaternion(
-                    (channel_values[0], channel_values[1], channel_values[2], channel_values[3]))
+                    (
+                        channel_values[0],
+                        channel_values[1],
+                        channel_values[2],
+                        channel_values[3],
+                    )
+                )
             else:
                 rotation = Quaternion(
-                    (channel_values[3], channel_values[0], channel_values[1], channel_values[2]))
+                    (
+                        channel_values[3],
+                        channel_values[0],
+                        channel_values[1],
+                        channel_values[2],
+                    )
+                )
         else:
             rotation = Quaternion(
-                (channel_values[3], channel_values[0], channel_values[1], channel_values[2]))
+                (
+                    channel_values[3],
+                    channel_values[0],
+                    channel_values[1],
+                    channel_values[2],
+                )
+            )
 
     return rotation
 
@@ -127,7 +171,9 @@ def combine_sequences_and_build_action_data(animation: ycdxml.Animation) -> Acti
 
             track = bone_data.track
             format = bone_data.format
-            assert TrackFormatMap[track] == format, f"Track format mismatch: {TrackFormatMap[track]} != {format}"
+            assert (
+                TrackFormatMap[track] == format
+            ), f"Track format mismatch: {TrackFormatMap[track]} != {format}"
 
             if format == TrackFormat.Vector3:
                 vec = get_vector3_from_sequence_data(sequence_data, sequence_frame)
@@ -142,7 +188,9 @@ def combine_sequences_and_build_action_data(animation: ycdxml.Animation) -> Acti
     return action_data
 
 
-def apply_action_data_to_action(action_data: ActionData, action: bpy.types.Action, frame_count: int):
+def apply_action_data_to_action(
+    action_data: ActionData, action: bpy.types.Action, frame_count: int
+):
     frames_ids = [*range(frame_count)]
 
     for bone_id, bones_data in action_data.items():
@@ -168,11 +216,14 @@ def apply_action_data_to_action(action_data: ActionData, action: bpy.types.Actio
                 vec_curve_z.keyframe_points.add(len(frames_data))
 
                 vec_curve_x.keyframe_points.foreach_set(
-                    "co", [x for co in zip(frames_ids, vec_tracks_x) for x in co])
+                    "co", [x for co in zip(frames_ids, vec_tracks_x) for x in co]
+                )
                 vec_curve_y.keyframe_points.foreach_set(
-                    "co", [x for co in zip(frames_ids, vec_tracks_y) for x in co])
+                    "co", [x for co in zip(frames_ids, vec_tracks_y) for x in co]
+                )
                 vec_curve_z.keyframe_points.foreach_set(
-                    "co", [x for co in zip(frames_ids, vec_tracks_z) for x in co])
+                    "co", [x for co in zip(frames_ids, vec_tracks_z) for x in co]
+                )
 
                 vec_curve_x.update()
                 vec_curve_y.update()
@@ -199,13 +250,17 @@ def apply_action_data_to_action(action_data: ActionData, action: bpy.types.Actio
                 quat_curve_z.keyframe_points.add(len(frames_data))
 
                 quat_curve_w.keyframe_points.foreach_set(
-                    "co", [x for co in zip(frames_ids, quat_tracks_w) for x in co])
+                    "co", [x for co in zip(frames_ids, quat_tracks_w) for x in co]
+                )
                 quat_curve_x.keyframe_points.foreach_set(
-                    "co", [x for co in zip(frames_ids, quat_tracks_x) for x in co])
+                    "co", [x for co in zip(frames_ids, quat_tracks_x) for x in co]
+                )
                 quat_curve_y.keyframe_points.foreach_set(
-                    "co", [x for co in zip(frames_ids, quat_tracks_y) for x in co])
+                    "co", [x for co in zip(frames_ids, quat_tracks_y) for x in co]
+                )
                 quat_curve_z.keyframe_points.foreach_set(
-                    "co", [x for co in zip(frames_ids, quat_tracks_z) for x in co])
+                    "co", [x for co in zip(frames_ids, quat_tracks_z) for x in co]
+                )
 
                 quat_curve_w.update()
                 quat_curve_x.update()
@@ -216,12 +271,16 @@ def apply_action_data_to_action(action_data: ActionData, action: bpy.types.Actio
                 value_curve.group = group_item
 
                 value_curve.keyframe_points.add(len(frames_data))
-                value_curve.keyframe_points.foreach_set("co", [x for co in zip(frames_ids, frames_data) for x in co])
+                value_curve.keyframe_points.foreach_set(
+                    "co", [x for co in zip(frames_ids, frames_data) for x in co]
+                )
 
                 value_curve.update()
 
 
-def action_data_to_action(action_name: str, action_data, frame_count: int) -> bpy.types.Action:
+def action_data_to_action(
+    action_name: str, action_data, frame_count: int
+) -> bpy.types.Action:
     action = bpy.data.actions.new(f"{action_name}_action")
     apply_action_data_to_action(action_data, action, frame_count)
     return action
@@ -235,8 +294,9 @@ def animation_to_obj(animation: ycdxml.Animation) -> bpy.types.Object:
     animation_obj.animation_properties.frame_count = animation.frame_count
 
     action_data = combine_sequences_and_build_action_data(animation)
-    animation_obj.animation_properties.action = action_data_to_action(animation.hash, action_data,
-                                                                      animation.frame_count)
+    animation_obj.animation_properties.action = action_data_to_action(
+        animation.hash, action_data, animation.frame_count
+    )
 
     return animation_obj
 
@@ -244,7 +304,7 @@ def animation_to_obj(animation: ycdxml.Animation) -> bpy.types.Object:
 def clip_to_obj(
     clip: ycdxml.Clip,
     animations_map: dict[str, ycdxml.Animation],
-    animations_obj_map: dict[str, bpy.types.Object]
+    animations_obj_map: dict[str, bpy.types.Object],
 ) -> bpy.types.Object:
     clip_obj = create_anim_obj(SollumType.CLIP)
 
@@ -260,8 +320,12 @@ def clip_to_obj(
 
         clip_animation = clip_obj.clip_properties.animations.add()
         clip_animation.animation = animations_obj_map[clip.animation_hash]
-        clip_animation.start_frame = int((clip.start_time / animation_data.duration) * animation_data.frame_count)
-        clip_animation.end_frame = int((clip.end_time / animation_data.duration) * animation_data.frame_count)
+        clip_animation.start_frame = int(
+            (clip.start_time / animation_data.duration) * animation_data.frame_count
+        )
+        clip_animation.end_frame = int(
+            (clip.end_time / animation_data.duration) * animation_data.frame_count
+        )
     elif clip.type == "AnimationList":
         clip_obj.clip_properties.duration = clip.duration
 
@@ -271,8 +335,13 @@ def clip_to_obj(
             clip_animation = clip_obj.clip_properties.animations.add()
             clip_animation.animation = animations_obj_map[animation.animation_hash]
             clip_animation.start_frame = int(
-                (animation.start_time / animation_data.duration) * animation_data.frame_count)
-            clip_animation.end_frame = int((animation.end_time / animation_data.duration) * animation_data.frame_count)
+                (animation.start_time / animation_data.duration)
+                * animation_data.frame_count
+            )
+            clip_animation.end_frame = int(
+                (animation.end_time / animation_data.duration)
+                * animation_data.frame_count
+            )
 
     def _init_attribute(attr, xml_attr):
         attr.name = xml_attr.name_hash
@@ -312,7 +381,9 @@ def clip_to_obj(
     return clip_obj
 
 
-def create_clip_dictionary_template(name: str) -> tuple[bpy.types.Object, bpy.types.Object, bpy.types.Object]:
+def create_clip_dictionary_template(
+    name: str,
+) -> tuple[bpy.types.Object, bpy.types.Object, bpy.types.Object]:
     clip_dictionary_obj = create_anim_obj(SollumType.CLIP_DICTIONARY)
     clips_obj = create_anim_obj(SollumType.CLIPS)
     animations_obj = create_anim_obj(SollumType.ANIMATIONS)
@@ -349,6 +420,5 @@ def import_ycd(filepath: str):
     ycd_xml = ycdxml.YCD.from_xml_file(filepath)
 
     clip_dictionary_to_obj(
-        ycd_xml,
-        os.path.basename(filepath.replace(ycdxml.YCD.file_extension, ""))
+        ycd_xml, os.path.basename(filepath.replace(ycdxml.YCD.file_extension, ""))
     )

--- a/ydd/yddexport.py
+++ b/ydd/yddexport.py
@@ -20,8 +20,7 @@ def export_ydd(ydd_obj: bpy.types.Object, filepath: str) -> bool:
 def create_ydd_xml(ydd_obj: bpy.types.Object, exclude_skeleton: bool = False):
     ydd_xml = DrawableDictionary()
 
-    ydd_armature = find_ydd_armature(
-        ydd_obj) if ydd_obj.type != "ARMATURE" else ydd_obj
+    ydd_armature = find_ydd_armature(ydd_obj) if ydd_obj.type != "ARMATURE" else ydd_obj
 
     for child in ydd_obj.children:
         if child.sollum_type != SollumType.DRAWABLE:

--- a/ydd/yddimport.py
+++ b/ydd/yddimport.py
@@ -3,7 +3,11 @@ import os
 from typing import Optional
 from ..cwxml.drawable import YDD, DrawableDictionary, Skeleton
 from ..cwxml.fragment import YFT, Fragment
-from ..ydr.ydrimport import create_drawable_obj, create_drawable_skel, apply_rotation_limits
+from ..ydr.ydrimport import (
+    create_drawable_obj,
+    create_drawable_skel,
+    apply_rotation_limits,
+)
 from ..sollumz_properties import SollumType
 from ..sollumz_preferences import get_import_settings
 from ..tools.blenderhelper import create_empty_object, create_blender_object
@@ -34,7 +38,8 @@ def load_external_skeleton(ydd_filepath: str) -> Optional[Fragment]:
 
     if yft_filepath is None:
         logger.warning(
-            f"Could not find external skeleton yft in directory '{directory}'.")
+            f"Could not find external skeleton yft in directory '{directory}'."
+        )
         return
 
     logger.info(f"Using '{yft_filepath}' as external skeleton...")
@@ -48,7 +53,9 @@ def get_first_yft_path(directory: str):
             return os.path.join(directory, filepath)
 
 
-def create_ydd_obj_ext_skel(ydd_xml: DrawableDictionary, filepath: str, external_skel: Fragment):
+def create_ydd_obj_ext_skel(
+    ydd_xml: DrawableDictionary, filepath: str, external_skel: Fragment
+):
     """Create ydd object with an external skeleton."""
     name = get_filename(filepath)
     dict_obj = create_armature_parent(name, external_skel)
@@ -64,14 +71,17 @@ def create_ydd_obj_ext_skel(ydd_xml: DrawableDictionary, filepath: str, external
             external_armature = dict_obj
 
         drawable_obj = create_drawable_obj(
-            drawable_xml, filepath, external_armature=external_armature, external_bones=external_bones)
+            drawable_xml,
+            filepath,
+            external_armature=external_armature,
+            external_bones=external_bones,
+        )
         drawable_obj.parent = dict_obj
 
     return dict_obj
 
 
 def create_ydd_obj(ydd_xml: DrawableDictionary, filepath: str):
-
     name = get_filename(filepath)
     dict_obj = create_empty_object(SollumType.DRAWABLE_DICTIONARY, name)
 
@@ -84,7 +94,8 @@ def create_ydd_obj(ydd_xml: DrawableDictionary, filepath: str):
             external_bones = None
 
         drawable_obj = create_drawable_obj(
-            drawable_xml, filepath, external_bones=external_bones)
+            drawable_xml, filepath, external_bones=external_bones
+        )
         drawable_obj.parent = dict_obj
 
     return dict_obj
@@ -92,8 +103,7 @@ def create_ydd_obj(ydd_xml: DrawableDictionary, filepath: str):
 
 def create_armature_parent(name: str, skel_yft: Fragment):
     armature = bpy.data.armatures.new(f"{name}.skel")
-    dict_obj = create_blender_object(
-        SollumType.DRAWABLE_DICTIONARY, name, armature)
+    dict_obj = create_blender_object(SollumType.DRAWABLE_DICTIONARY, name, armature)
 
     create_drawable_skel(skel_yft.drawable.skeleton, dict_obj)
 

--- a/ydr/lights.py
+++ b/ydr/lights.py
@@ -10,7 +10,9 @@ from .properties import LightProperties
 from .. import logger
 
 
-def create_light_objs(lights: list[Light], armature_obj: Optional[bpy.types.Object] = None):
+def create_light_objs(
+    lights: list[Light], armature_obj: Optional[bpy.types.Object] = None
+):
     lights_parent = create_empty_object(SollumType.NONE, "Lights")
 
     for light_xml in lights:
@@ -25,7 +27,8 @@ def create_light(light_xml: Light, armature_obj: Optional[bpy.types.Object] = No
 
     if light_type is None:
         logger.warning(
-            f"Encountered an unknown light type '{light_xml.type}'! Making a point light...")
+            f"Encountered an unknown light type '{light_xml.type}'! Making a point light..."
+        )
         light_type = LightType.POINT
 
     name = SOLLUMZ_UI_NAMES[light_type]
@@ -67,7 +70,9 @@ def create_light_data(light_type: LightType, name: str):
     return bpy.data.lights.new(name=name, type=bpy_light_type)
 
 
-def create_light_bone_constraint(light_xml: Light, light_obj: bpy.types.Object, armature_obj: bpy.types.Object):
+def create_light_bone_constraint(
+    light_xml: Light, light_obj: bpy.types.Object, armature_obj: bpy.types.Object
+):
     armature = armature_obj.data
 
     for bone in armature.bones:
@@ -107,8 +112,7 @@ def set_light_bpy_properties(light_xml: Light, light_data: bpy.types.Light):
     light_data.shadow_buffer_clip_start = light_xml.shadow_near_clip
 
     if light_data.sollum_type == LightType.SPOT:
-        light_data.spot_blend = abs(
-            (radians(light_xml.cone_inner_angle) / pi) - 1)
+        light_data.spot_blend = abs((radians(light_xml.cone_inner_angle) / pi) - 1)
         light_data.spot_size = radians(light_xml.cone_outer_angle) * 2
 
 
@@ -132,7 +136,8 @@ def set_light_rage_properties(light_xml: Light, light_data: bpy.types.Light):
     light_props.shadow_blur = light_xml.shadow_blur
     light_props.volume_size_scale = light_xml.volume_size_scale
     light_props.volume_outer_color = [
-        channel / 255 for channel in light_xml.volume_outer_color]
+        channel / 255 for channel in light_xml.volume_outer_color
+    ]
     light_props.light_hash = light_xml.light_hash
     light_props.volume_outer_intensity = light_xml.volume_outer_intensity
     light_props.corona_size = light_xml.corona_size
@@ -145,7 +150,9 @@ def set_light_rage_properties(light_xml: Light, light_data: bpy.types.Light):
     light_props.corona_z_bias = light_xml.corona_z_bias
 
 
-def create_xml_lights(parent_obj: bpy.types.Object, armature_obj: Optional[bpy.types.Object] = None):
+def create_xml_lights(
+    parent_obj: bpy.types.Object, armature_obj: Optional[bpy.types.Object] = None
+):
     light_xmls: list[Light] = []
 
     for child in parent_obj.children_recursive:
@@ -155,7 +162,9 @@ def create_xml_lights(parent_obj: bpy.types.Object, armature_obj: Optional[bpy.t
     return light_xmls
 
 
-def create_light_xml(light_obj: bpy.types.Object, armature_obj: Optional[bpy.types.Object] = None):
+def create_light_xml(
+    light_obj: bpy.types.Object, armature_obj: Optional[bpy.types.Object] = None
+):
     light_xml = Light()
     light_xml.position = light_obj.location
     mat = light_obj.matrix_basis
@@ -171,8 +180,7 @@ def create_light_xml(light_obj: bpy.types.Object, armature_obj: Optional[bpy.typ
 
 
 def set_light_xml_direction(light_xml: Light, mat: Matrix):
-    light_xml.direction = Vector(
-        (mat[0][2], mat[1][2], mat[2][2])).normalized()
+    light_xml.direction = Vector((mat[0][2], mat[1][2], mat[2][2])).normalized()
     light_xml.direction.negate()
 
 
@@ -180,7 +188,9 @@ def set_light_xml_tangent(light_xml: Light, mat: Matrix):
     light_xml.tangent = Vector((mat[0][0], mat[1][0], mat[2][0])).normalized()
 
 
-def set_light_xml_bone_id(light_xml: Light, armature: bpy.types.Armature, light_obj: bpy.types.Object):
+def set_light_xml_bone_id(
+    light_xml: Light, armature: bpy.types.Armature, light_obj: bpy.types.Object
+):
     for constraint in light_obj.constraints:
         if not isinstance(constraint, bpy.types.CopyTransformsConstraint):
             continue
@@ -227,6 +237,5 @@ def set_light_xml_properties(light_xml: Light, light_data: bpy.types.Light):
     light_xml.projected_texture_hash = light_props.projected_texture_hash
 
     if light_data.sollum_type == LightType.SPOT:
-        light_xml.cone_inner_angle = degrees(
-            abs((light_data.spot_blend * pi) - pi))
+        light_xml.cone_inner_angle = degrees(abs((light_data.spot_blend * pi) - pi))
         light_xml.cone_outer_angle = degrees(light_data.spot_size) / 2

--- a/ydr/properties.py
+++ b/ydr/properties.py
@@ -4,7 +4,17 @@ from typing import Optional
 from ..tools.blenderhelper import lod_level_enum_flag_prop_factory
 from ..sollumz_helper import find_sollumz_parent
 from ..cwxml.light_preset import LightPresetsFile
-from ..sollumz_properties import SOLLUMZ_UI_NAMES, items_from_enums, TextureUsage, TextureFormat, LODLevel, SollumType, LightType, FlagPropertyGroup, TimeFlags
+from ..sollumz_properties import (
+    SOLLUMZ_UI_NAMES,
+    items_from_enums,
+    TextureUsage,
+    TextureFormat,
+    LODLevel,
+    SollumType,
+    LightType,
+    FlagPropertyGroup,
+    TimeFlags,
+)
 from ..ydr.shader_materials import shadermats
 from bpy.app.handlers import persistent
 from bpy.path import basename
@@ -42,15 +52,20 @@ class DrawableShaderOrder(bpy.types.PropertyGroup):
 
 class DrawableProperties(bpy.types.PropertyGroup):
     lod_dist_high: bpy.props.FloatProperty(
-        min=0, max=10000, default=9998, name="Lod Distance High")
+        min=0, max=10000, default=9998, name="Lod Distance High"
+    )
     lod_dist_med: bpy.props.FloatProperty(
-        min=0, max=10000, default=9998, name="Lod Distance Med")
+        min=0, max=10000, default=9998, name="Lod Distance Med"
+    )
     lod_dist_low: bpy.props.FloatProperty(
-        min=0, max=10000, default=9998, name="Lod Distance Low")
+        min=0, max=10000, default=9998, name="Lod Distance Low"
+    )
     lod_dist_vlow: bpy.props.FloatProperty(
-        min=0, max=10000, default=9998, name="Lod Distance Vlow")
+        min=0, max=10000, default=9998, name="Lod Distance Vlow"
+    )
     unknown_9A: bpy.props.FloatProperty(
-        min=0, max=10000, default=9998, name="Unknown 9A")
+        min=0, max=10000, default=9998, name="Unknown 9A"
+    )
 
     shader_order: bpy.props.PointerProperty(type=DrawableShaderOrder)
 
@@ -61,9 +76,10 @@ class DrawableModelProperties(bpy.types.PropertyGroup):
     unknown_1: bpy.props.IntProperty(name="Unknown 1", default=0)
     sollum_lod: bpy.props.EnumProperty(
         items=items_from_enums(
-            [LODLevel.HIGH, LODLevel.MEDIUM, LODLevel.LOW, LODLevel.VERYLOW]),
+            [LODLevel.HIGH, LODLevel.MEDIUM, LODLevel.LOW, LODLevel.VERYLOW]
+        ),
         name="LOD Level",
-        default="sollumz_high"
+        default="sollumz_high",
     )
 
 
@@ -91,8 +107,7 @@ class ShaderProperties(bpy.types.PropertyGroup):
     index: bpy.props.IntProperty(min=0)
 
     renderbucket: bpy.props.IntProperty(name="Render Bucket", default=0, min=0, max=7)
-    filename: bpy.props.StringProperty(
-        name="Shader Filename", default="default.sps")
+    filename: bpy.props.StringProperty(name="Shader Filename", default="default.sps")
     name: bpy.props.StringProperty(name="Shader Name", default="default")
 
 
@@ -115,8 +130,7 @@ class TextureFlags(bpy.types.PropertyGroup):
     y1024: bpy.props.BoolProperty(name="Y1024", default=False)
     x2048: bpy.props.BoolProperty(name="X2048", default=False)
     y2048: bpy.props.BoolProperty(name="Y2048", default=False)
-    embeddedscriptrt: bpy.props.BoolProperty(
-        name="EMBEDDEDSCRIPTRT", default=False)
+    embeddedscriptrt: bpy.props.BoolProperty(name="EMBEDDEDSCRIPTRT", default=False)
     unk19: bpy.props.BoolProperty(name="UNK19", default=False)
     unk20: bpy.props.BoolProperty(name="UNK20", default=False)
     unk21: bpy.props.BoolProperty(name="UNK21", default=False)
@@ -128,15 +142,11 @@ class TextureFlags(bpy.types.PropertyGroup):
 class TextureProperties(bpy.types.PropertyGroup):
     embedded: bpy.props.BoolProperty(name="Embedded", default=False)
     usage: bpy.props.EnumProperty(
-        items=items_from_enums(TextureUsage),
-        name="Usage",
-        default=TextureUsage.UNKNOWN
+        items=items_from_enums(TextureUsage), name="Usage", default=TextureUsage.UNKNOWN
     )
 
     format: bpy.props.EnumProperty(
-        items=items_from_enums(TextureFormat),
-        name="Format",
-        default=TextureFormat.DXT1
+        items=items_from_enums(TextureFormat), name="Format", default=TextureFormat.DXT1
     )
 
     extra_flags: bpy.props.IntProperty(name="Extra Flags", default=0)
@@ -197,12 +207,20 @@ class BoneProperties(bpy.types.PropertyGroup):
         self.use_manual_tag = value != self.calc_tag()
 
     tag: bpy.props.IntProperty(
-        name="Tag", description="Unique value that identifies this bone in the armature",
-        get=get_tag, set=set_tag, default=0, min=0, max=0xFFFF)
+        name="Tag",
+        description="Unique value that identifies this bone in the armature",
+        get=get_tag,
+        set=set_tag,
+        default=0,
+        min=0,
+        max=0xFFFF,
+    )
     manual_tag: bpy.props.IntProperty(name="Manual Tag", default=0, min=0, max=0xFFFF)
     use_manual_tag: bpy.props.BoolProperty(
-        name="Use Manual Tag", description="Specify a tag instead of auto-calculating it",
-        default=False)
+        name="Use Manual Tag",
+        description="Specify a tag instead of auto-calculating it",
+        default=False,
+    )
     flags: bpy.props.CollectionProperty(type=BoneFlag)
     ul_index: bpy.props.IntProperty(name="UIListIndex", default=0)
 
@@ -217,41 +235,42 @@ class LightProperties(bpy.types.PropertyGroup):
     group_id: bpy.props.IntProperty(name="Group ID")
     falloff: bpy.props.FloatProperty(name="Falloff")
     falloff_exponent: bpy.props.FloatProperty(name="Falloff Exponent")
-    culling_plane_normal: bpy.props.FloatVectorProperty(
-        name="Culling Plane Normal")
+    culling_plane_normal: bpy.props.FloatVectorProperty(name="Culling Plane Normal")
     culling_plane_offset: bpy.props.FloatProperty(name="Culling Plane Offset")
     unknown_45: bpy.props.FloatProperty(name="Unknown 45")
     unknown_46: bpy.props.FloatProperty(name="Unknown 46")
-    volume_intensity: bpy.props.FloatProperty(
-        name="Volume Intensity", default=1.0)
+    volume_intensity: bpy.props.FloatProperty(name="Volume Intensity", default=1.0)
     shadow_blur: bpy.props.FloatProperty(name="Shadow Blur")
-    volume_size_scale: bpy.props.FloatProperty(
-        name="Volume Size Scale", default=1.0)
+    volume_size_scale: bpy.props.FloatProperty(name="Volume Size Scale", default=1.0)
     volume_outer_color: bpy.props.FloatVectorProperty(
-        name="Volume Outer Color", subtype="COLOR", min=0.0, max=1.0, default=(1.0, 1.0, 1.0))
+        name="Volume Outer Color",
+        subtype="COLOR",
+        min=0.0,
+        max=1.0,
+        default=(1.0, 1.0, 1.0),
+    )
     light_hash: bpy.props.IntProperty(name="Light Hash")
     volume_outer_intensity: bpy.props.FloatProperty(
-        name="Volume Outer Intensity", default=1.0)
+        name="Volume Outer Intensity", default=1.0
+    )
     corona_size: bpy.props.FloatProperty(name="Corona Size")
     volume_outer_exponent: bpy.props.FloatProperty(
-        name="Volume Outer Exponent", default=1.0)
+        name="Volume Outer Exponent", default=1.0
+    )
     light_fade_distance: bpy.props.FloatProperty(name="Light Fade Distance")
     shadow_fade_distance: bpy.props.FloatProperty(name="Shadow Fade Distance")
-    specular_fade_distance: bpy.props.FloatProperty(
-        name="Specular Fade Distance")
-    volumetric_fade_distance: bpy.props.FloatProperty(
-        name="Volumetric Fade Distance")
+    specular_fade_distance: bpy.props.FloatProperty(name="Specular Fade Distance")
+    volumetric_fade_distance: bpy.props.FloatProperty(name="Volumetric Fade Distance")
     shadow_near_clip: bpy.props.FloatProperty(name="Shadow Near Clip")
-    corona_intensity: bpy.props.FloatProperty(
-        name="Corona Intensity", default=1.0)
+    corona_intensity: bpy.props.FloatProperty(name="Corona Intensity", default=1.0)
     corona_z_bias: bpy.props.FloatProperty(name="Corona Z Bias", default=0.1)
     tangent: bpy.props.FloatVectorProperty(name="Tangent")
     cone_inner_angle: bpy.props.FloatProperty(name="Cone Inner Angle")
     cone_outer_angle: bpy.props.FloatProperty(name="Cone Outer Angle")
     extent: bpy.props.FloatVectorProperty(
-        name="Extent", default=(1, 1, 1), subtype="XYZ")
-    projected_texture_hash: bpy.props.StringProperty(
-        name="Projected Texture Hash")
+        name="Extent", default=(1, 1, 1), subtype="XYZ"
+    )
+    projected_texture_hash: bpy.props.StringProperty(name="Projected Texture Hash")
 
 
 class LightPresetProp(bpy.types.PropertyGroup):
@@ -260,70 +279,54 @@ class LightPresetProp(bpy.types.PropertyGroup):
 
 
 class LightFlags(FlagPropertyGroup, bpy.types.PropertyGroup):
-    unk1: bpy.props.BoolProperty(
-        name="Unk1", update=FlagPropertyGroup.update_flag)
-    unk2: bpy.props.BoolProperty(
-        name="Unk2", update=FlagPropertyGroup.update_flag)
-    unk3: bpy.props.BoolProperty(
-        name="Unk3", update=FlagPropertyGroup.update_flag)
-    unk4: bpy.props.BoolProperty(
-        name="Unk4", update=FlagPropertyGroup.update_flag)
-    unk5: bpy.props.BoolProperty(
-        name="Unk5", update=FlagPropertyGroup.update_flag)
-    unk6: bpy.props.BoolProperty(
-        name="Unk6", update=FlagPropertyGroup.update_flag)
-    unk7: bpy.props.BoolProperty(
-        name="Unk7", update=FlagPropertyGroup.update_flag)
+    unk1: bpy.props.BoolProperty(name="Unk1", update=FlagPropertyGroup.update_flag)
+    unk2: bpy.props.BoolProperty(name="Unk2", update=FlagPropertyGroup.update_flag)
+    unk3: bpy.props.BoolProperty(name="Unk3", update=FlagPropertyGroup.update_flag)
+    unk4: bpy.props.BoolProperty(name="Unk4", update=FlagPropertyGroup.update_flag)
+    unk5: bpy.props.BoolProperty(name="Unk5", update=FlagPropertyGroup.update_flag)
+    unk6: bpy.props.BoolProperty(name="Unk6", update=FlagPropertyGroup.update_flag)
+    unk7: bpy.props.BoolProperty(name="Unk7", update=FlagPropertyGroup.update_flag)
     shadows: bpy.props.BoolProperty(
-        name="ShadowS", update=FlagPropertyGroup.update_flag)
+        name="ShadowS", update=FlagPropertyGroup.update_flag
+    )
     shadowd: bpy.props.BoolProperty(
-        name="ShadowD", update=FlagPropertyGroup.update_flag)
+        name="ShadowD", update=FlagPropertyGroup.update_flag
+    )
     sunlight: bpy.props.BoolProperty(
-        name="Sunlight", update=FlagPropertyGroup.update_flag)
-    unk11: bpy.props.BoolProperty(
-        name="Unk11", update=FlagPropertyGroup.update_flag)
+        name="Sunlight", update=FlagPropertyGroup.update_flag
+    )
+    unk11: bpy.props.BoolProperty(name="Unk11", update=FlagPropertyGroup.update_flag)
     electric: bpy.props.BoolProperty(
-        name="Electric", update=FlagPropertyGroup.update_flag)
-    volume: bpy.props.BoolProperty(
-        name="Volume", update=FlagPropertyGroup.update_flag)
+        name="Electric", update=FlagPropertyGroup.update_flag
+    )
+    volume: bpy.props.BoolProperty(name="Volume", update=FlagPropertyGroup.update_flag)
     specoff: bpy.props.BoolProperty(
-        name="SpecOff", update=FlagPropertyGroup.update_flag)
-    unk15: bpy.props.BoolProperty(
-        name="Unk15", update=FlagPropertyGroup.update_flag)
+        name="SpecOff", update=FlagPropertyGroup.update_flag
+    )
+    unk15: bpy.props.BoolProperty(name="Unk15", update=FlagPropertyGroup.update_flag)
     lightoff: bpy.props.BoolProperty(
-        name="LightOff", update=FlagPropertyGroup.update_flag)
-    prxoff: bpy.props.BoolProperty(
-        name="PrxOff", update=FlagPropertyGroup.update_flag)
-    unk18: bpy.props.BoolProperty(
-        name="Unk18", update=FlagPropertyGroup.update_flag)
+        name="LightOff", update=FlagPropertyGroup.update_flag
+    )
+    prxoff: bpy.props.BoolProperty(name="PrxOff", update=FlagPropertyGroup.update_flag)
+    unk18: bpy.props.BoolProperty(name="Unk18", update=FlagPropertyGroup.update_flag)
     culling: bpy.props.BoolProperty(
-        name="Culling", update=FlagPropertyGroup.update_flag)
-    unk20: bpy.props.BoolProperty(
-        name="Unk20", update=FlagPropertyGroup.update_flag)
-    unk21: bpy.props.BoolProperty(
-        name="Unk21", update=FlagPropertyGroup.update_flag)
-    unk22: bpy.props.BoolProperty(
-        name="Unk22", update=FlagPropertyGroup.update_flag)
-    unk23: bpy.props.BoolProperty(
-        name="Unk23", update=FlagPropertyGroup.update_flag)
+        name="Culling", update=FlagPropertyGroup.update_flag
+    )
+    unk20: bpy.props.BoolProperty(name="Unk20", update=FlagPropertyGroup.update_flag)
+    unk21: bpy.props.BoolProperty(name="Unk21", update=FlagPropertyGroup.update_flag)
+    unk22: bpy.props.BoolProperty(name="Unk22", update=FlagPropertyGroup.update_flag)
+    unk23: bpy.props.BoolProperty(name="Unk23", update=FlagPropertyGroup.update_flag)
     glassoff: bpy.props.BoolProperty(
-        name="GlassOff", update=FlagPropertyGroup.update_flag)
-    unk25: bpy.props.BoolProperty(
-        name="Unk25", update=FlagPropertyGroup.update_flag)
-    unk26: bpy.props.BoolProperty(
-        name="Unk26", update=FlagPropertyGroup.update_flag)
-    unk27: bpy.props.BoolProperty(
-        name="Unk27", update=FlagPropertyGroup.update_flag)
-    unk28: bpy.props.BoolProperty(
-        name="Unk28", update=FlagPropertyGroup.update_flag)
-    unk29: bpy.props.BoolProperty(
-        name="Unk29", update=FlagPropertyGroup.update_flag)
-    unk30: bpy.props.BoolProperty(
-        name="Unk30", update=FlagPropertyGroup.update_flag)
-    unk31: bpy.props.BoolProperty(
-        name="Unk31", update=FlagPropertyGroup.update_flag)
-    unk32: bpy.props.BoolProperty(
-        name="Unk32", update=FlagPropertyGroup.update_flag)
+        name="GlassOff", update=FlagPropertyGroup.update_flag
+    )
+    unk25: bpy.props.BoolProperty(name="Unk25", update=FlagPropertyGroup.update_flag)
+    unk26: bpy.props.BoolProperty(name="Unk26", update=FlagPropertyGroup.update_flag)
+    unk27: bpy.props.BoolProperty(name="Unk27", update=FlagPropertyGroup.update_flag)
+    unk28: bpy.props.BoolProperty(name="Unk28", update=FlagPropertyGroup.update_flag)
+    unk29: bpy.props.BoolProperty(name="Unk29", update=FlagPropertyGroup.update_flag)
+    unk30: bpy.props.BoolProperty(name="Unk30", update=FlagPropertyGroup.update_flag)
+    unk31: bpy.props.BoolProperty(name="Unk31", update=FlagPropertyGroup.update_flag)
+    unk32: bpy.props.BoolProperty(name="Unk32", update=FlagPropertyGroup.update_flag)
 
 
 @persistent
@@ -366,7 +369,8 @@ def get_light_presets_path() -> str:
         return presets_path
     else:
         raise FileNotFoundError(
-            f"light_presets.xml file not found! Please redownload this file from the github and place it in '{os.path.dirname(presets_path)}'")
+            f"light_presets.xml file not found! Please redownload this file from the github and place it in '{os.path.dirname(presets_path)}'"
+        )
 
 
 light_presets = LightPresetsFile()
@@ -390,7 +394,9 @@ def get_texture_name(self):
     return "None"
 
 
-def get_model_properties(model_obj: bpy.types.Object, lod_level: LODLevel) -> DrawableModelProperties:
+def get_model_properties(
+    model_obj: bpy.types.Object, lod_level: LODLevel
+) -> DrawableModelProperties:
     drawable_obj = find_sollumz_parent(model_obj, SollumType.DRAWABLE)
 
     if drawable_obj is not None and model_obj.vertex_groups:
@@ -400,91 +406,135 @@ def get_model_properties(model_obj: bpy.types.Object, lod_level: LODLevel) -> Dr
 
     if lod is None or lod.mesh is None:
         raise ValueError(
-            f"Failed to get Drawable Model properties: {model_obj.name} has no {SOLLUMZ_UI_NAMES[lod_level]} LOD!")
+            f"Failed to get Drawable Model properties: {model_obj.name} has no {SOLLUMZ_UI_NAMES[lod_level]} LOD!"
+        )
 
     return lod.mesh.drawable_model_properties
 
 
 def register():
     bpy.types.Scene.shader_material_index = bpy.props.IntProperty(
-        name="Shader Material Index")  # MAKE ENUM WITH THE MATERIALS NAMES
+        name="Shader Material Index"
+    )  # MAKE ENUM WITH THE MATERIALS NAMES
     bpy.types.Scene.shader_materials = bpy.props.CollectionProperty(
-        type=ShaderMaterial, name="Shader Materials")
+        type=ShaderMaterial, name="Shader Materials"
+    )
     bpy.app.handlers.load_post.append(on_file_loaded)
     bpy.types.Object.drawable_properties = bpy.props.PointerProperty(
-        type=DrawableProperties)
+        type=DrawableProperties
+    )
     bpy.types.Material.shader_properties = bpy.props.PointerProperty(
-        type=ShaderProperties)
+        type=ShaderProperties
+    )
     bpy.types.ShaderNodeTexImage.texture_properties = bpy.props.PointerProperty(
-        type=TextureProperties)
+        type=TextureProperties
+    )
     bpy.types.ShaderNodeTexImage.texture_flags = bpy.props.PointerProperty(
-        type=TextureFlags)
+        type=TextureFlags
+    )
     bpy.types.ShaderNodeTexImage.sollumz_texture_name = bpy.props.StringProperty(
-        name="Texture Name", description="Name of texture.", get=get_texture_name)
+        name="Texture Name", description="Name of texture.", get=get_texture_name
+    )
 
     # Store properties for the DrawableModel with HasSkin=1. This is so all skinned objects share
     # the same drawable model properties even when split by group. It seems there is only ever 1
     # DrawableModel with HasSkin=1 in any given Drawable.
     bpy.types.Object.skinned_model_properties = bpy.props.PointerProperty(
-        type=SkinnedDrawableModelProperties)
+        type=SkinnedDrawableModelProperties
+    )
     # DrawableModel properties stored per mesh for LOD system
     bpy.types.Mesh.drawable_model_properties = bpy.props.PointerProperty(
-        type=DrawableModelProperties)
+        type=DrawableModelProperties
+    )
     # For backwards compatibility
     bpy.types.Object.drawable_model_properties = bpy.props.PointerProperty(
-        type=DrawableModelProperties)
+        type=DrawableModelProperties
+    )
 
     bpy.types.Scene.create_seperate_drawables = bpy.props.BoolProperty(
-        name="Separate Objects", description="Create a separate Drawable for each selected object")
+        name="Separate Objects",
+        description="Create a separate Drawable for each selected object",
+    )
     bpy.types.Scene.auto_create_embedded_col = bpy.props.BoolProperty(
-        name="Auto-Embed Collision", description="Automatically create embedded static collision")
+        name="Auto-Embed Collision",
+        description="Automatically create embedded static collision",
+    )
     bpy.types.Scene.center_drawable_to_selection = bpy.props.BoolProperty(
-        name="Center to Selection", description="Center Drawable(s) to selection", default=True)
+        name="Center to Selection",
+        description="Center Drawable(s) to selection",
+        default=True,
+    )
 
-    bpy.types.Bone.bone_properties = bpy.props.PointerProperty(
-        type=BoneProperties)
+    bpy.types.Bone.bone_properties = bpy.props.PointerProperty(type=BoneProperties)
     bpy.types.Light.sollum_type = bpy.props.EnumProperty(
         items=items_from_enums(LightType),
         name="Light Type",
         default=LightType.POINT,
         options={"HIDDEN"},
         get=get_light_type,
-        set=set_light_type
+        set=set_light_type,
     )
     bpy.types.Light.is_capsule = bpy.props.BoolProperty()
-    bpy.types.Light.light_properties = bpy.props.PointerProperty(
-        type=LightProperties)
+    bpy.types.Light.light_properties = bpy.props.PointerProperty(type=LightProperties)
     bpy.types.Scene.create_light_type = bpy.props.EnumProperty(
         items=[
-            (LightType.POINT.value,
-             SOLLUMZ_UI_NAMES[LightType.POINT], SOLLUMZ_UI_NAMES[LightType.POINT]),
-            (LightType.SPOT.value,
-             SOLLUMZ_UI_NAMES[LightType.SPOT], SOLLUMZ_UI_NAMES[LightType.SPOT]),
-            (LightType.CAPSULE.value,
-             SOLLUMZ_UI_NAMES[LightType.CAPSULE], SOLLUMZ_UI_NAMES[LightType.CAPSULE]),
+            (
+                LightType.POINT.value,
+                SOLLUMZ_UI_NAMES[LightType.POINT],
+                SOLLUMZ_UI_NAMES[LightType.POINT],
+            ),
+            (
+                LightType.SPOT.value,
+                SOLLUMZ_UI_NAMES[LightType.SPOT],
+                SOLLUMZ_UI_NAMES[LightType.SPOT],
+            ),
+            (
+                LightType.CAPSULE.value,
+                SOLLUMZ_UI_NAMES[LightType.CAPSULE],
+                SOLLUMZ_UI_NAMES[LightType.CAPSULE],
+            ),
         ],
         name="Light Type",
         default=LightType.POINT,
-        options={"HIDDEN"}
+        options={"HIDDEN"},
     )
     bpy.types.Light.time_flags = bpy.props.PointerProperty(type=TimeFlags)
     bpy.types.Light.light_flags = bpy.props.PointerProperty(type=LightFlags)
 
     bpy.types.Scene.sollumz_auto_lod_ref_mesh = bpy.props.PointerProperty(
-        type=bpy.types.Mesh, name="Reference Mesh", description="The mesh to copy and decimate for each LOD level. You'd usually want to set this as the highest LOD then run the tool for all lower LODs")
+        type=bpy.types.Mesh,
+        name="Reference Mesh",
+        description="The mesh to copy and decimate for each LOD level. You'd usually want to set this as the highest LOD then run the tool for all lower LODs",
+    )
     bpy.types.Scene.sollumz_auto_lod_levels = lod_level_enum_flag_prop_factory()
     bpy.types.Scene.sollumz_auto_lod_decimate_step = bpy.props.FloatProperty(
-        name="Decimate Step", min=0.0, max=0.99, default=0.6)
+        name="Decimate Step", min=0.0, max=0.99, default=0.6
+    )
 
-    bpy.types.Scene.light_preset_index = bpy.props.IntProperty(name="Light Preset Index")
-    bpy.types.Scene.light_presets = bpy.props.CollectionProperty(type=LightPresetProp, name="Light Presets")
+    bpy.types.Scene.light_preset_index = bpy.props.IntProperty(
+        name="Light Preset Index"
+    )
+    bpy.types.Scene.light_presets = bpy.props.CollectionProperty(
+        type=LightPresetProp, name="Light Presets"
+    )
 
     bpy.types.Scene.sollumz_extract_lods_levels = lod_level_enum_flag_prop_factory()
-    bpy.types.Scene.sollumz_extract_lods_parent_type = bpy.props.EnumProperty(name="Parent Type", items=(
-        ("sollumz_extract_lods_parent_type_object", "Object", "Parent to an Object"),
-        ("sollumz_extract_lods_parent_type_collection",
-         "Collection", "Parent to a Collection")
-    ), default=0)
+    bpy.types.Scene.sollumz_extract_lods_parent_type = bpy.props.EnumProperty(
+        name="Parent Type",
+        items=(
+            (
+                "sollumz_extract_lods_parent_type_object",
+                "Object",
+                "Parent to an Object",
+            ),
+            (
+                "sollumz_extract_lods_parent_type_collection",
+                "Collection",
+                "Parent to a Collection",
+            ),
+        ),
+        default=0,
+    )
 
 
 def unregister():

--- a/ydr/shader_materials.py
+++ b/ydr/shader_materials.py
@@ -27,8 +27,7 @@ shadermats = []
 for shader in ShaderManager._shaders.values():
     name = shader.filename.replace(".sps", "").upper()
 
-    shadermats.append(ShaderMaterial(
-        name, name.replace("_", " "), shader.filename))
+    shadermats.append(ShaderMaterial(name, name.replace("_", " "), shader.filename))
 
 
 def try_get_node(node_tree: bpy.types.NodeTree, name: str) -> Optional[bpy.types.Node]:
@@ -39,7 +38,9 @@ def try_get_node(node_tree: bpy.types.NodeTree, name: str) -> Optional[bpy.types
     return node_tree.nodes.get(name, None)
 
 
-def try_get_node_by_cls(node_tree: bpy.types.NodeTree, node_cls: type) -> Optional[bpy.types.Node]:
+def try_get_node_by_cls(
+    node_tree: bpy.types.NodeTree, node_cls: type
+) -> Optional[bpy.types.Node]:
     """Gets a node by its type. Returns `None` if not found."""
     for node in node_tree.nodes:
         if isinstance(node, node_cls):
@@ -120,10 +121,14 @@ def organize_loose_nodes(node_tree, start_x, start_y):
         grid_x -= node.width + 25
 
 
-def get_tint_sampler_node(mat: bpy.types.Material) -> Optional[bpy.types.ShaderNodeTexImage]:
+def get_tint_sampler_node(
+    mat: bpy.types.Material,
+) -> Optional[bpy.types.ShaderNodeTexImage]:
     nodes = mat.node_tree.nodes
     for node in nodes:
-        if node.name == "TintPaletteSampler" and isinstance(node, bpy.types.ShaderNodeTexImage):
+        if node.name == "TintPaletteSampler" and isinstance(
+            node, bpy.types.ShaderNodeTexImage
+        ):
             return node
 
     return None
@@ -155,19 +160,25 @@ def create_tinted_shader_graph(obj: bpy.types.Object):
         else:
             input_color_attr_name = "Color 1"
 
-        tint_color_attr_name = f"TintColor ({palette_img.name})" if palette_img else "TintColor"
-        tint_color_attr = obj.data.attributes.new(name=tint_color_attr_name, type="BYTE_COLOR", domain="CORNER")
+        tint_color_attr_name = (
+            f"TintColor ({palette_img.name})" if palette_img else "TintColor"
+        )
+        tint_color_attr = obj.data.attributes.new(
+            name=tint_color_attr_name, type="BYTE_COLOR", domain="CORNER"
+        )
 
         rename_tint_attr_node(mat.node_tree, name=tint_color_attr.name)
 
-        create_tint_geom_modifier(obj, tint_color_attr.name, input_color_attr_name, palette_img)
+        create_tint_geom_modifier(
+            obj, tint_color_attr.name, input_color_attr_name, palette_img
+        )
 
 
 def create_tint_geom_modifier(
     obj: bpy.types.Object,
     tint_color_attr_name: str,
     input_color_attr_name: Optional[str],
-    palette_img: Optional[bpy.types.Image]
+    palette_img: Optional[bpy.types.Image],
 ) -> bpy.types.NodesModifier:
     tnt_ng = create_tinted_geometry_graph()
     mod = obj.modifiers.new("GeometryNodes", "NODES")
@@ -175,7 +186,9 @@ def create_tint_geom_modifier(
 
     # set input / output variables
     input_id = tnt_ng.inputs[1].identifier
-    mod[input_id + "_attribute_name"] = input_color_attr_name if input_color_attr_name is not None else ""
+    mod[input_id + "_attribute_name"] = (
+        input_color_attr_name if input_color_attr_name is not None else ""
+    )
     mod[input_id + "_use_attribute"] = True
 
     input_palette_id = tnt_ng.inputs[3].identifier
@@ -190,7 +203,10 @@ def create_tint_geom_modifier(
 
 def rename_tint_attr_node(node_tree: bpy.types.NodeTree, name: str):
     for node in node_tree.nodes:
-        if not isinstance(node, bpy.types.ShaderNodeAttribute) or node.attribute_name != "TintColor":
+        if (
+            not isinstance(node, bpy.types.ShaderNodeAttribute)
+            or node.attribute_name != "TintColor"
+        ):
             continue
 
         node.attribute_name = name
@@ -229,10 +245,14 @@ def create_tinted_geometry_graph():  # move to blenderhelper.py?
     gnt.inputs.new("NodeSocketGeometry", "Geometry")
     gnt.inputs.new("NodeSocketVector", "Vertex Colors")
     in_palette = gnt.inputs.new("NodeSocketInt", "Palette (Preview)")
-    in_palette.description = "Index of the tint palette to preview. Has no effect on export"
+    in_palette.description = (
+        "Index of the tint palette to preview. Has no effect on export"
+    )
     in_palette.min_value = 0
     in_palette_tex = gnt.inputs.new("NodeSocketImage", "Palette Texture")
-    in_palette_tex.description = "Should be the same as 'TintPaletteSampler' of the material"
+    in_palette_tex.description = (
+        "Should be the same as 'TintPaletteSampler' of the material"
+    )
     gnt.outputs.new("NodeSocketGeometry", "Geometry")
     gnt.outputs.new("NodeSocketColor", "Tint Color")
 
@@ -477,8 +497,7 @@ def link_normal(b: ShaderBuilder, nrmtex):
 
 def create_normal_invert_node(node_tree: bpy.types.NodeTree):
     """Create RGB curves node that inverts that green channel of normal maps"""
-    rgb_curves: bpy.types.ShaderNodeRGBCurve = node_tree.nodes.new(
-        "ShaderNodeRGBCurve")
+    rgb_curves: bpy.types.ShaderNodeRGBCurve = node_tree.nodes.new("ShaderNodeRGBCurve")
 
     green_curves = rgb_curves.mapping.curves[1]
     green_curves.points[0].location = (0, 1)
@@ -497,7 +516,7 @@ def link_specular(b: ShaderBuilder, spctex):
 def create_diff_palette_nodes(
     b: ShaderBuilder,
     palette_tex: bpy.types.ShaderNodeTexImage,
-    diffuse_tex: bpy.types.ShaderNodeTexImage
+    diffuse_tex: bpy.types.ShaderNodeTexImage,
 ):
     palette_tex.interpolation = "Closest"
     node_tree = b.node_tree
@@ -543,10 +562,7 @@ def create_diff_palette_nodes(
     links.new(palette_tex.outputs[0], bsdf.inputs["Base Color"])
 
 
-def create_tint_nodes(
-    b: ShaderBuilder,
-    diffuse_tex: bpy.types.ShaderNodeTexImage
-):
+def create_tint_nodes(b: ShaderBuilder, diffuse_tex: bpy.types.ShaderNodeTexImage):
     # create shader attribute node
     # TintColor attribute is filled by tint geometry nodes
     node_tree = b.node_tree
@@ -588,7 +604,9 @@ def create_decal_nodes(b: ShaderBuilder, texture, decalflag):
     links.new(mix.outputs["Shader"], output.inputs["Surface"])
 
 
-def create_distance_map_nodes(b: ShaderBuilder, distance_map_texture: bpy.types.ShaderNodeTexImage):
+def create_distance_map_nodes(
+    b: ShaderBuilder, distance_map_texture: bpy.types.ShaderNodeTexImage
+):
     node_tree = b.node_tree
     output = b.material_output
     bsdf = b.bsdf
@@ -617,7 +635,9 @@ def create_distance_map_nodes(b: ShaderBuilder, distance_map_texture: bpy.types.
     links.new(fill_color_b.outputs["Value"], fill_color_combine.inputs["Z"])
 
     # extract distance value from texture and check > 0.5
-    links.new(distance_map_texture.outputs["Color"], distance_separate_x.inputs["Vector"])
+    links.new(
+        distance_map_texture.outputs["Color"], distance_separate_x.inputs["Vector"]
+    )
     links.remove(distance_map_texture.outputs["Alpha"].links[0])
     links.new(distance_separate_x.outputs["X"], distance_greater_than.inputs["Value"])
 
@@ -715,29 +735,28 @@ def create_water_nodes(b: ShaderBuilder):
     vol_absorb.inputs[0].default_value = (0.772, 0.91, 0.882, 1.0)
     vol_absorb.inputs[1].default_value = 0.25  # Density
     bsdf.inputs[0].default_value = (0.588, 0.91, 0.851, 1.0)
-    bsdf.inputs[19].default_value = (
-        0.49102, 0.938685, 1.0, 1.0)  # Emission Colour
-    bsdf.inputs['Emission Strength'].default_value = 0.1
+    bsdf.inputs[19].default_value = (0.49102, 0.938685, 1.0, 1.0)  # Emission Colour
+    bsdf.inputs["Emission Strength"].default_value = 0.1
     glass_shader = node_tree.nodes.new("ShaderNodeBsdfGlass")
-    glass_shader.inputs['IOR'].default_value = 1.333
+    glass_shader.inputs["IOR"].default_value = 1.333
     trans_shader = node_tree.nodes.new("ShaderNodeBsdfTransparent")
     light_path = node_tree.nodes.new("ShaderNodeLightPath")
     bump = node_tree.nodes.new("ShaderNodeBump")
-    bump.inputs['Strength'].default_value = 0.05
+    bump.inputs["Strength"].default_value = 0.05
     noise_tex = node_tree.nodes.new("ShaderNodeTexNoise")
-    noise_tex.inputs['Scale'].default_value = 12.0
-    noise_tex.inputs['Detail'].default_value = 3.0
+    noise_tex.inputs["Scale"].default_value = 12.0
+    noise_tex.inputs["Detail"].default_value = 3.0
     noise_tex.inputs[4].default_value = 0.85  # Roughness
 
     links.new(glass_shader.outputs[0], mix_shader.inputs[1])
     links.new(trans_shader.outputs[0], mix_shader.inputs[2])
     links.new(bsdf.outputs[0], add_shader.inputs[0])
     links.new(vol_absorb.outputs[0], add_shader.inputs[1])
-    links.new(add_shader.outputs[0], output.inputs['Volume'])
-    links.new(mix_shader.outputs[0], output.inputs['Surface'])
-    links.new(light_path.outputs['Is Shadow Ray'], mix_shader.inputs['Fac'])
-    links.new(noise_tex.outputs['Fac'], bump.inputs['Height'])
-    links.new(bump.outputs['Normal'], glass_shader.inputs['Normal'])
+    links.new(add_shader.outputs[0], output.inputs["Volume"])
+    links.new(mix_shader.outputs[0], output.inputs["Surface"])
+    links.new(light_path.outputs["Is Shadow Ray"], mix_shader.inputs["Fac"])
+    links.new(noise_tex.outputs["Fac"], bump.inputs["Height"])
+    links.new(bump.outputs["Normal"], glass_shader.inputs["Normal"])
 
 
 def create_basic_shader_nodes(b: ShaderBuilder):
@@ -785,8 +804,7 @@ def create_basic_shader_nodes(b: ShaderBuilder):
         elif param.type == "Array":
             create_array_nodes(node_tree, param)
         else:
-            raise Exception(
-                f"Unknown shader parameter! {param.type} {param.name}")
+            raise Exception(f"Unknown shader parameter! {param.type} {param.name}")
 
     use_diff = True if texture else False
     use_diff2 = True if texture2 else False
@@ -814,7 +832,11 @@ def create_basic_shader_nodes(b: ShaderBuilder):
             # txt_alpha_mask = ?
             decalflag = 2
         # decal_normal_only.sps / mirror_decal.sps / reflect_decal.sps
-        elif filename in [ShaderManager.decals[4], ShaderManager.decals[21], ShaderManager.decals[19]]:
+        elif filename in [
+            ShaderManager.decals[4],
+            ShaderManager.decals[21],
+            ShaderManager.decals[19],
+        ]:
             decalflag = 3
         # decal_spec_only.sps / spec_decal.sps
         elif filename in [ShaderManager.decals[3], ShaderManager.decals[17]]:
@@ -913,8 +935,7 @@ def create_terrain_shader(b: ShaderBuilder):
         elif param.type == "Array":
             create_array_nodes(node_tree, param)
         else:
-            raise Exception(
-                f"Unknown shader parameter! {param.type} {param.name}")
+            raise Exception(f"Unknown shader parameter! {param.type} {param.name}")
 
     mixns = []
     for _ in range(8 if tm else 7):
@@ -1024,15 +1045,19 @@ def create_shader(filename: str):
     mat.shader_properties.renderbucket = shader.render_bucket
 
     bsdf, material_output = find_bsdf_and_material_output(mat)
-    assert material_output is not None, "ShaderNodeOutputMaterial not found in default node_tree!"
+    assert (
+        material_output is not None
+    ), "ShaderNodeOutputMaterial not found in default node_tree!"
     assert bsdf is not None, "ShaderNodeBsdfPrincipled not found in default node_tree!"
 
-    builder = ShaderBuilder(shader=shader,
-                            filename=filename,
-                            material=mat,
-                            node_tree=mat.node_tree,
-                            material_output=material_output,
-                            bsdf=bsdf)
+    builder = ShaderBuilder(
+        shader=shader,
+        filename=filename,
+        material=mat,
+        node_tree=mat.node_tree,
+        material_output=material_output,
+        bsdf=bsdf,
+    )
 
     create_uv_map_nodes(builder)
 

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -19,7 +19,10 @@ class SOLLUMZ_PT_DRAWABLE_PANEL(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.sollum_type == SollumType.DRAWABLE
+        return (
+            context.active_object is not None
+            and context.active_object.sollum_type == SollumType.DRAWABLE
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -80,10 +83,14 @@ class SOLLUMZ_PT_DRAWABLE_MODEL_PANEL(bpy.types.Panel):
             return False
 
         active_lod = obj.sollumz_lods.active_lod
-        sollumz_parent = find_sollumz_parent(
-            obj, parent_type=SollumType.DRAWABLE)
+        sollumz_parent = find_sollumz_parent(obj, parent_type=SollumType.DRAWABLE)
 
-        return active_lod is not None and obj.sollum_type == SollumType.DRAWABLE_MODEL and obj.type == "MESH" and sollumz_parent is not None
+        return (
+            active_lod is not None
+            and obj.sollum_type == SollumType.DRAWABLE_MODEL
+            and obj.type == "MESH"
+            and sollumz_parent is not None
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -93,8 +100,7 @@ class SOLLUMZ_PT_DRAWABLE_MODEL_PANEL(bpy.types.Panel):
         obj = context.active_object
         active_lod_level = obj.sollumz_lods.active_lod.level
         mesh = obj.data
-        sollumz_parent = find_sollumz_parent(
-            obj, parent_type=SollumType.DRAWABLE)
+        sollumz_parent = find_sollumz_parent(obj, parent_type=SollumType.DRAWABLE)
 
         model_props = mesh.drawable_model_properties
 
@@ -102,18 +108,23 @@ class SOLLUMZ_PT_DRAWABLE_MODEL_PANEL(bpy.types.Panel):
         col.alignment = "RIGHT"
         col.enabled = False
 
-        is_skinned_model = obj.vertex_groups and sollumz_parent is not None and not obj.sollumz_is_physics_child_mesh
+        is_skinned_model = (
+            obj.vertex_groups
+            and sollumz_parent is not None
+            and not obj.sollumz_is_physics_child_mesh
+        )
 
         # All skinned objects (objects with vertex groups) go in the same drawable model
         if is_skinned_model:
             model_props = sollumz_parent.skinned_model_properties.get_lod(
-                active_lod_level)
+                active_lod_level
+            )
 
             col.label(
-                text=f"Active LOD: {SOLLUMZ_UI_NAMES[active_lod_level]} (Skinned)")
+                text=f"Active LOD: {SOLLUMZ_UI_NAMES[active_lod_level]} (Skinned)"
+            )
         else:
-            col.label(
-                text=f"Active LOD: {SOLLUMZ_UI_NAMES[active_lod_level]}")
+            col.label(text=f"Active LOD: {SOLLUMZ_UI_NAMES[active_lod_level]}")
 
         col.separator()
 
@@ -135,8 +146,7 @@ class SOLLUMZ_UL_SHADER_MATERIALS_LIST(bpy.types.UIList):
             row.label(text=name, icon="SHADING_TEXTURE")
         elif self.layout_type in {"GRID"}:
             layout.alignment = "CENTER"
-            layout.prop(item, "name",
-                        text=name, emboss=False, icon="SHADING_TEXTURE")
+            layout.prop(item, "name", text=name, emboss=False, icon="SHADING_TEXTURE")
 
 
 class SOLLUMZ_PT_LIGHT_PANEL(bpy.types.Panel):
@@ -217,7 +227,11 @@ class SOLLUMZ_PT_LIGHT_TIME_FLAGS_PANEL(TimeFlagsPanel, bpy.types.Panel):
     @classmethod
     def poll(self, context):
         obj = context.active_object
-        return obj is not None and obj.type == "LIGHT" and obj.sollum_type == SollumType.LIGHT
+        return (
+            obj is not None
+            and obj.type == "LIGHT"
+            and obj.sollum_type == SollumType.LIGHT
+        )
 
     def get_flags(self, context):
         light = context.light
@@ -235,7 +249,11 @@ class SOLLUMZ_PT_LIGHT_FLAGS_PANEL(FlagsPanel, bpy.types.Panel):
     @classmethod
     def poll(self, context):
         obj = context.active_object
-        return obj is not None and obj.type == "LIGHT" and obj.sollum_type == SollumType.LIGHT
+        return (
+            obj is not None
+            and obj.type == "LIGHT"
+            and obj.sollum_type == SollumType.LIGHT
+        )
 
     def get_flags(self, context):
         light = context.light
@@ -277,33 +295,48 @@ class SOLLUMZ_PT_SHADER_TOOLS_PANEL(bpy.types.Panel):
         layout = self.layout
         layout.label(text="Create")
         layout.template_list(
-            SOLLUMZ_UL_SHADER_MATERIALS_LIST.bl_idname, "", context.scene, "shader_materials", context.scene, "shader_material_index"
+            SOLLUMZ_UL_SHADER_MATERIALS_LIST.bl_idname,
+            "",
+            context.scene,
+            "shader_materials",
+            context.scene,
+            "shader_material_index",
         )
         row = layout.row()
         row.operator(
-            ydr_ops.SOLLUMZ_OT_create_shader_material.bl_idname, text="Create Shader Material")
+            ydr_ops.SOLLUMZ_OT_create_shader_material.bl_idname,
+            text="Create Shader Material",
+        )
         grid = layout.grid_flow(align=True)
-        grid.operator(ydr_ops.SOLLUMZ_OT_convert_material_to_selected.bl_idname,
-                      text="Convert Active Material", icon="FILE_REFRESH")
         grid.operator(
-            ydr_ops.SOLLUMZ_OT_convert_allmaterials_to_selected.bl_idname, text="Convert All Materials")
+            ydr_ops.SOLLUMZ_OT_convert_material_to_selected.bl_idname,
+            text="Convert Active Material",
+            icon="FILE_REFRESH",
+        )
+        grid.operator(
+            ydr_ops.SOLLUMZ_OT_convert_allmaterials_to_selected.bl_idname,
+            text="Convert All Materials",
+        )
 
         layout.separator()
         layout.label(text="Tools")
 
         row = layout.row()
         row.operator(
-            ydr_ops.SOLLUMZ_OT_auto_convert_material.bl_idname, text="Auto Convert", icon="FILE_REFRESH")
+            ydr_ops.SOLLUMZ_OT_auto_convert_material.bl_idname,
+            text="Auto Convert",
+            icon="FILE_REFRESH",
+        )
         grid = layout.grid_flow(align=True)
         grid.operator(
-            ydr_ops.SOLLUMZ_OT_set_all_textures_embedded.bl_idname, icon="TEXTURE")
-        grid.operator(
-            ydr_ops.SOLLUMZ_OT_remove_all_textures_embedded.bl_idname)
+            ydr_ops.SOLLUMZ_OT_set_all_textures_embedded.bl_idname, icon="TEXTURE"
+        )
+        grid.operator(ydr_ops.SOLLUMZ_OT_remove_all_textures_embedded.bl_idname)
         grid = layout.grid_flow(align=True)
         grid.operator(
-            ydr_ops.SOLLUMZ_OT_set_all_materials_embedded.bl_idname, icon="MATERIAL")
-        grid.operator(
-            ydr_ops.SOLLUMZ_OT_unset_all_materials_embedded.bl_idname)
+            ydr_ops.SOLLUMZ_OT_set_all_materials_embedded.bl_idname, icon="MATERIAL"
+        )
+        grid.operator(ydr_ops.SOLLUMZ_OT_unset_all_materials_embedded.bl_idname)
 
 
 class SOLLUMZ_PT_CREATE_DRAWABLE_PANEL(bpy.types.Panel):
@@ -327,11 +360,13 @@ class SOLLUMZ_PT_CREATE_DRAWABLE_PANEL(bpy.types.Panel):
 
         row = layout.row()
         row.operator(
-            ydr_ops.SOLLUMZ_OT_convert_to_drawable_model.bl_idname, icon="MESH_DATA")
+            ydr_ops.SOLLUMZ_OT_convert_to_drawable_model.bl_idname, icon="MESH_DATA"
+        )
 
         row = layout.row()
         row.operator(
-            ydr_ops.SOLLUMZ_OT_convert_to_drawable.bl_idname, icon="OUTLINER_OB_MESH")
+            ydr_ops.SOLLUMZ_OT_convert_to_drawable.bl_idname, icon="OUTLINER_OB_MESH"
+        )
         row = layout.row()
         row.prop(context.scene, "create_seperate_drawables")
         row.prop(context.scene, "auto_create_embedded_col")
@@ -342,10 +377,10 @@ class SOLLUMZ_PT_CREATE_DRAWABLE_PANEL(bpy.types.Panel):
         layout.label(text="Create", icon="ADD")
 
         row = layout.row(align=True)
-        row.operator(ydr_ops.SOLLUMZ_OT_create_drawable.bl_idname,
-                     icon="OUTLINER_OB_MESH")
         row.operator(
-            ydr_ops.SOLLUMZ_OT_create_drawable_dict.bl_idname, icon="TEXT")
+            ydr_ops.SOLLUMZ_OT_create_drawable.bl_idname, icon="OUTLINER_OB_MESH"
+        )
+        row.operator(ydr_ops.SOLLUMZ_OT_create_drawable_dict.bl_idname, icon="TEXT")
 
 
 class SOLLUMZ_PT_CREATE_LIGHT_PANEL(bpy.types.Panel):
@@ -366,13 +401,23 @@ class SOLLUMZ_PT_CREATE_LIGHT_PANEL(bpy.types.Panel):
         layout = self.layout
 
         row = layout.row()
-        row.template_list(SOLLUMZ_UL_LIGHT_PRESET_LIST.bl_idname, "light_presets",
-                          context.scene, "light_presets", context.scene, "light_preset_index")
+        row.template_list(
+            SOLLUMZ_UL_LIGHT_PRESET_LIST.bl_idname,
+            "light_presets",
+            context.scene,
+            "light_presets",
+            context.scene,
+            "light_preset_index",
+        )
         col = row.column(align=True)
-        col.operator(ydr_ops.SOLLUMZ_OT_save_light_preset.bl_idname, text="", icon="ADD")
-        col.operator(ydr_ops.SOLLUMZ_OT_delete_light_preset.bl_idname, text="", icon="REMOVE")
+        col.operator(
+            ydr_ops.SOLLUMZ_OT_save_light_preset.bl_idname, text="", icon="ADD"
+        )
+        col.operator(
+            ydr_ops.SOLLUMZ_OT_delete_light_preset.bl_idname, text="", icon="REMOVE"
+        )
         row = layout.row()
-        row.operator(ydr_ops.SOLLUMZ_OT_load_light_preset.bl_idname, icon='CHECKMARK')
+        row.operator(ydr_ops.SOLLUMZ_OT_load_light_preset.bl_idname, icon="CHECKMARK")
 
         layout.separator()
         row = layout.row(align=True)
@@ -391,8 +436,7 @@ class SOLLUMZ_UL_LIGHT_PRESET_LIST(bpy.types.UIList):
             row.label(text=item.name, icon="BOOKMARKS")
         elif self.layout_type in {"GRID"}:
             layout.alignment = "CENTER"
-            layout.prop(item, "name",
-                        text=item.name, emboss=False, icon="BOOKMARKS")
+            layout.prop(item, "name", text=item.name, emboss=False, icon="BOOKMARKS")
 
 
 class SOLLUMZ_PT_BONE_TOOLS_PANEL(bpy.types.Panel):
@@ -413,44 +457,43 @@ class SOLLUMZ_PT_BONE_TOOLS_PANEL(bpy.types.Panel):
         layout = self.layout
 
         layout.label(text="Rigging", icon="ARMATURE_DATA")
-        layout.operator("sollumz.add_child_of_constraint",
-                        icon="CONSTRAINT_BONE")
-        layout.operator("sollumz.add_armature_modifier",
-                        icon="MOD_ARMATURE")
+        layout.operator("sollumz.add_child_of_constraint", icon="CONSTRAINT_BONE")
+        layout.operator("sollumz.add_armature_modifier", icon="MOD_ARMATURE")
         layout.separator()
 
         layout.label(text="Apply Bone Properties", icon="MODIFIER_ON")
         row = layout.row(align=True)
+        row.operator(ydr_ops.SOLLUMZ_OT_apply_bone_properties_to_armature.bl_idname)
         row.operator(
-            ydr_ops.SOLLUMZ_OT_apply_bone_properties_to_armature.bl_idname)
-        row.operator(
-            ydr_ops.SOLLUMZ_OT_apply_bone_properties_to_selected_bones.bl_idname)
+            ydr_ops.SOLLUMZ_OT_apply_bone_properties_to_selected_bones.bl_idname
+        )
         layout.separator()
         layout.label(text="Apply Bone Flags", icon="BOOKMARKS")
         row = layout.row(align=True)
-        row.operator(ydr_ops.SOLLUMZ_OT_clear_bone_flags.bl_idname,
-                     text="Clear All")
+        row.operator(ydr_ops.SOLLUMZ_OT_clear_bone_flags.bl_idname, text="Clear All")
+        row.operator(ydr_ops.SOLLUMZ_OT_rotation_bone_flags.bl_idname, text="Rotation")
         row.operator(
-            ydr_ops.SOLLUMZ_OT_rotation_bone_flags.bl_idname, text="Rotation")
-        row.operator(
-            ydr_ops.SOLLUMZ_OT_translation_bone_flags.bl_idname, text="Translation")
-        row.operator(
-            ydr_ops.SOLLUMZ_OT_scale_bone_flags.bl_idname, text="Scale")
-        row.operator(
-            ydr_ops.SOLLUMZ_OT_limit_bone_flags.bl_idname, text="Limit")
+            ydr_ops.SOLLUMZ_OT_translation_bone_flags.bl_idname, text="Translation"
+        )
+        row.operator(ydr_ops.SOLLUMZ_OT_scale_bone_flags.bl_idname, text="Scale")
+        row.operator(ydr_ops.SOLLUMZ_OT_limit_bone_flags.bl_idname, text="Limit")
 
 
 class SOLLUMZ_UL_BONE_FLAGS(bpy.types.UIList):
-    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+    def draw_item(
+        self, context, layout, data, item, icon, active_data, active_propname, index
+    ):
         custom_icon = "FILE"
 
         if self.layout_type in {"DEFAULT", "COMPACT"}:
-            layout.prop(item, "name", text="", icon=custom_icon,
-                        emboss=False, translate=False)
+            layout.prop(
+                item, "name", text="", icon=custom_icon, emboss=False, translate=False
+            )
         elif self.layout_type in {"GRID"}:
             layout.alignment = "CENTER"
-            layout.prop(item, "name", text="", icon=custom_icon,
-                        emboss=False, translate=False)
+            layout.prop(
+                item, "name", text="", icon=custom_icon, emboss=False, translate=False
+            )
 
 
 class SOLLUMZ_PT_BONE_PANEL(bpy.types.Panel):
@@ -476,13 +519,25 @@ class SOLLUMZ_PT_BONE_PANEL(bpy.types.Panel):
 
         row = layout.row(align=True)
         row.prop(bone.bone_properties, "tag")
-        row.prop(bone.bone_properties, "use_manual_tag", toggle=True, icon="MODIFIER_ON", icon_only=True)
+        row.prop(
+            bone.bone_properties,
+            "use_manual_tag",
+            toggle=True,
+            icon="MODIFIER_ON",
+            icon_only=True,
+        )
         layout.separator()
 
         layout.label(text="Flags")
         row = layout.row()
-        row.template_list("SOLLUMZ_UL_BONE_FLAGS", "Flags",
-                          bone.bone_properties, "flags", bone.bone_properties, "ul_index")
+        row.template_list(
+            "SOLLUMZ_UL_BONE_FLAGS",
+            "Flags",
+            bone.bone_properties,
+            "flags",
+            bone.bone_properties,
+            "ul_index",
+        )
         col = row.column(align=True)
         col.operator("sollumz.bone_flags_new_item", text="", icon="ADD")
         col.operator("sollumz.bone_flags_delete_item", text="", icon="REMOVE")
@@ -531,7 +586,11 @@ class SOLLUMZ_PT_TXTPARAMS_PANEL(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.active_material is not None and context.active_object.active_material.sollum_type == MaterialType.SHADER
+        return (
+            context.active_object is not None
+            and context.active_object.active_material is not None
+            and context.active_object.active_material.sollum_type == MaterialType.SHADER
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -560,8 +619,7 @@ class SOLLUMZ_PT_TXTPARAMS_PANEL(bpy.types.Panel):
                     row.enabled = n.image.filepath != ""
                 else:
                     row = box.row()
-                    row.label(
-                        text="Image Texture has no linked image.", icon="ERROR")
+                    row.label(text="Image Texture has no linked image.", icon="ERROR")
 
                 box.prop(n.texture_properties, "usage")
 
@@ -577,7 +635,11 @@ class SOLLUMZ_PT_VALUEPARAMS_PANEL(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.active_material is not None and context.active_object.active_material.sollum_type == MaterialType.SHADER
+        return (
+            context.active_object is not None
+            and context.active_object.active_material is not None
+            and context.active_object.active_material.sollum_type == MaterialType.SHADER
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -710,8 +772,7 @@ class SOLLUMZ_PT_AUTO_LOD_PANEL(bpy.types.Panel):
 
         box.prop(context.scene, "sollumz_auto_lod_levels")
         box.separator(factor=0.25)
-        box.prop(context.scene, "sollumz_auto_lod_ref_mesh",
-                 text="Reference Mesh")
+        box.prop(context.scene, "sollumz_auto_lod_ref_mesh", text="Reference Mesh")
         box.prop(context.scene, "sollumz_auto_lod_decimate_step")
         box.separator()
         box.operator("sollumz.auto_lod", icon="MOD_DECIM")

--- a/yft/fragment_merger.py
+++ b/yft/fragment_merger.py
@@ -16,6 +16,7 @@ def get_all_frag_geoms(frag_xml: Fragment) -> list[Geometry]:
 
 class FragmentMerger:
     """Merge hi and non hi Fragments."""
+
     @property
     def phys_children(self) -> list[PhysicsChild]:
         return self.frag.physics.lod1.children
@@ -30,7 +31,8 @@ class FragmentMerger:
 
         if len(self.phys_children) != len(self.phys_children_hi):
             raise ValueError(
-                f"Cannot merge Fragments '{self.frag.name}' and '{self.hi_frag.name}': Both Fragments must have same number of children!")
+                f"Cannot merge Fragments '{self.frag.name}' and '{self.hi_frag.name}': Both Fragments must have same number of children!"
+            )
 
     def merge(self) -> Fragment:
         shaders: list[Shader] = self.frag.drawable.shader_group.shaders
@@ -143,8 +145,7 @@ class FragShaderMerger:
         self._update_hi_shader_ind()
 
     def _update_hi_shader_ind(self):
-        self.new_hi_shader_inds[self._hi_shader_ind] = len(
-            self.merged_shaders) - 1
+        self.new_hi_shader_inds[self._hi_shader_ind] = len(self.merged_shaders) - 1
         self._hi_shader_ind += 1
 
     def update_geom_shader_inds(self, frag: Fragment):

--- a/yft/operators.py
+++ b/yft/operators.py
@@ -7,22 +7,33 @@ from itertools import chain
 from ..tools.meshhelper import calculate_volume, get_combined_bound_box
 
 from ..sollumz_helper import find_sollumz_parent
-from ..sollumz_properties import BOUND_POLYGON_TYPES, BOUND_TYPES, MaterialType, SollumType, VehicleLightID
-from ..tools.blenderhelper import add_child_of_bone_constraint, create_blender_object, create_empty_object, get_child_of_bone
+from ..sollumz_properties import (
+    BOUND_POLYGON_TYPES,
+    BOUND_TYPES,
+    MaterialType,
+    SollumType,
+    VehicleLightID,
+)
+from ..tools.blenderhelper import (
+    add_child_of_bone_constraint,
+    create_blender_object,
+    create_empty_object,
+    get_child_of_bone,
+)
 from ..ybn.collision_materials import collisionmats
 
 
 class SOLLUMZ_OT_CREATE_FRAGMENT(bpy.types.Operator):
     """Create a Fragment object. If a Drawable or Bound Composite is selected,
     they will be parented to the Fragment."""
+
     bl_idname = "sollumz.createfragment"
     bl_label = "Create Fragment"
     bl_options = {"REGISTER", "UNDO"}
 
     def execute(self, context):
         armature = bpy.data.armatures.new(name="skel")
-        frag_obj = create_blender_object(
-            SollumType.FRAGMENT, object_data=armature)
+        frag_obj = create_blender_object(SollumType.FRAGMENT, object_data=armature)
 
         self.parent_selected_objs(frag_obj, context)
 
@@ -38,14 +49,14 @@ class SOLLUMZ_OT_CREATE_FRAGMENT(bpy.types.Operator):
 
 class SOLLUMZ_OT_CREATE_BONES_AT_OBJECTS(bpy.types.Operator):
     """Create bones with physics enabled for all selected objects. Bones are positioned at the location of each object"""
+
     bl_idname = "sollumz.createbonesatobjects"
     bl_label = "Create Physics Bones at Object(s)"
     bl_options = {"UNDO"}
 
     def execute(self, context):
         armature_obj: bpy.types.Object = context.scene.create_bones_fragment
-        selected = [
-            obj for obj in context.selected_objects if obj != armature_obj]
+        selected = [obj for obj in context.selected_objects if obj != armature_obj]
         parent_to_selected = context.scene.create_bones_parent_to_selected
         # parent_bone: bpy.types.Bone | None = context.scene.create_bones_parent_bone
 
@@ -92,6 +103,7 @@ class SOLLUMZ_OT_CREATE_BONES_AT_OBJECTS(bpy.types.Operator):
 
 class SOLLUMZ_OT_SET_MASS(bpy.types.Operator):
     """Set the mass of all selected objects"""
+
     bl_idname = "sollumz.setmass"
     bl_label = "Set Mass"
     bl_options = {"UNDO"}
@@ -107,13 +119,18 @@ class SOLLUMZ_OT_SET_MASS(bpy.types.Operator):
 
 class SOLLUMZ_OT_COPY_FRAG_BONE_PHYSICS(bpy.types.Operator):
     """Copy the physics properties of the active bone to all selected bones. Can only be used in Pose Mode."""
+
     bl_idname = "sollumz.copy_frag_bone_physics"
     bl_label = "Copy Bone Physics"
     bl_options = {"UNDO"}
 
     @classmethod
     def poll(cls, context):
-        return context.mode == "POSE" and context.active_pose_bone is not None and len(context.selected_pose_bones) > 1
+        return (
+            context.mode == "POSE"
+            and context.active_pose_bone is not None
+            and len(context.selected_pose_bones) > 1
+        )
 
     def execute(self, context):
         src_pose_bone = context.active_pose_bone
@@ -127,8 +144,12 @@ class SOLLUMZ_OT_COPY_FRAG_BONE_PHYSICS(bpy.types.Operator):
             dst_props.flags = src_props.flags
             dst_props.glass_type = src_props.glass_type
             dst_props.strength = src_props.strength
-            dst_props.force_transmission_scale_up = src_props.force_transmission_scale_up
-            dst_props.force_transmission_scale_down = src_props.force_transmission_scale_down
+            dst_props.force_transmission_scale_up = (
+                src_props.force_transmission_scale_up
+            )
+            dst_props.force_transmission_scale_down = (
+                src_props.force_transmission_scale_down
+            )
             dst_props.joint_stiffness = src_props.joint_stiffness
             dst_props.min_soft_angle_1 = src_props.min_soft_angle_1
             dst_props.max_soft_angle_1 = src_props.max_soft_angle_1
@@ -152,16 +173,19 @@ class SOLLUMZ_OT_COPY_FRAG_BONE_PHYSICS(bpy.types.Operator):
 
             num_dst_bones += 1
 
-        self.report({'INFO'},
-                    f"Physics properties of '{src_pose_bone.name}' copied to {num_dst_bones} bones successfully")
-        return {'FINISHED'}
+        self.report(
+            {"INFO"},
+            f"Physics properties of '{src_pose_bone.name}' copied to {num_dst_bones} bones successfully",
+        )
+        return {"FINISHED"}
 
 
 class SOLLUMZ_OT_SET_LIGHT_ID(bpy.types.Operator):
     """
-    Set the vehicle light ID of the selected vertices (must be in edit mode). 
+    Set the vehicle light ID of the selected vertices (must be in edit mode).
     This determines which action causes the emissive shader to activate, and is stored in the alpha channel of the vertex colors
     """
+
     bl_idname = "sollumz.setlightid"
     bl_label = "Set Light ID"
     bl_options = {"UNDO"}
@@ -169,7 +193,8 @@ class SOLLUMZ_OT_SET_LIGHT_ID(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         selected_mesh_objs = [
-            obj for obj in context.selected_objects if obj.type == "MESH"]
+            obj for obj in context.selected_objects if obj.type == "MESH"
+        ]
 
         face_mode = context.scene.tool_settings.mesh_select_mode[2]
 
@@ -177,7 +202,8 @@ class SOLLUMZ_OT_SET_LIGHT_ID(bpy.types.Operator):
 
     def execute(self, context):
         selected_mesh_objs = [
-            obj for obj in context.selected_objects if obj.type == "MESH"]
+            obj for obj in context.selected_objects if obj.type == "MESH"
+        ]
 
         set_light_id = context.scene.set_vehicle_light_id
 
@@ -193,7 +219,9 @@ class SOLLUMZ_OT_SET_LIGHT_ID(bpy.types.Operator):
 
             if not bm.loops.layers.color:
                 self.report(
-                    {"INFO"}, f"'{obj.name}' has no 'Face Corner > Byte Color' color attribute layers! Skipping...")
+                    {"INFO"},
+                    f"'{obj.name}' has no 'Face Corner > Byte Color' color attribute layers! Skipping...",
+                )
                 continue
 
             color_layer = bm.loops.layers.color[0]
@@ -212,6 +240,7 @@ class SOLLUMZ_OT_SELECT_LIGHT_ID(bpy.types.Operator):
     """
     Select vertices that have this light ID
     """
+
     bl_idname = "sollumz.selectlightid"
     bl_label = "Select Light ID"
     bl_options = {"UNDO"}
@@ -219,7 +248,8 @@ class SOLLUMZ_OT_SELECT_LIGHT_ID(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         selected_mesh_objs = [
-            obj for obj in context.selected_objects if obj.type == "MESH"]
+            obj for obj in context.selected_objects if obj.type == "MESH"
+        ]
 
         face_mode = context.scene.tool_settings.mesh_select_mode[2]
 
@@ -227,7 +257,8 @@ class SOLLUMZ_OT_SELECT_LIGHT_ID(bpy.types.Operator):
 
     def execute(self, context):
         selected_mesh_objs = [
-            obj for obj in context.selected_objects if obj.type == "MESH"]
+            obj for obj in context.selected_objects if obj.type == "MESH"
+        ]
 
         select_light_id = context.scene.select_vehicle_light_id
 
@@ -258,7 +289,12 @@ class SOLLUMZ_OT_SELECT_LIGHT_ID(bpy.types.Operator):
 
         return {"FINISHED"}
 
-    def get_light_id_faces(self, bm: bmesh.types.BMesh, color_layer: bmesh.types.BMLayerCollection, light_id: int):
+    def get_light_id_faces(
+        self,
+        bm: bmesh.types.BMesh,
+        color_layer: bmesh.types.BMLayerCollection,
+        light_id: int,
+    ):
         """Get light id of the given selection of ``mesh``. Returns -1 if not found or vertices contain different light IDs"""
         face_inds: list[int] = []
 
@@ -275,6 +311,7 @@ class SOLLUMZ_OT_SELECT_LIGHT_ID(bpy.types.Operator):
 
 class SOLLUMZ_OT_GENERATE_WHEEL_INSTANCES(bpy.types.Operator):
     """Generate instances of wheel meshes to preview all wheels at once (has no effect on export)"""
+
     bl_idname = "sollumz.generate_wheel_instances"
     bl_label = "Generate Wheel Instances"
     bl_options = {"REGISTER", "UNDO"}
@@ -283,29 +320,51 @@ class SOLLUMZ_OT_GENERATE_WHEEL_INSTANCES(bpy.types.Operator):
     def poll(cls, context):
         obj = context.active_object
 
-        return obj is not None and find_sollumz_parent(obj, SollumType.FRAGMENT) is not None
+        return (
+            obj is not None
+            and find_sollumz_parent(obj, SollumType.FRAGMENT) is not None
+        )
 
     def execute(self, context):
         obj = context.active_object
         frag_obj = find_sollumz_parent(obj, SollumType.FRAGMENT)
 
-        drawable_obj = next((obj for obj in frag_obj.children if obj.sollum_type == SollumType.DRAWABLE), None)
+        drawable_obj = next(
+            (
+                obj
+                for obj in frag_obj.children
+                if obj.sollum_type == SollumType.DRAWABLE
+            ),
+            None,
+        )
         if drawable_obj is None:
-            self.report({"WARNING"}, "This fragment object is missing the drawable object!")
+            self.report(
+                {"WARNING"}, "This fragment object is missing the drawable object!"
+            )
             return {"CANCELLED"}
 
         wheel_bones_front = {
-            "wheel_lf", "wheel_rf",
+            "wheel_lf",
+            "wheel_rf",
         }
         wheel_bones_rear = {
-            "wheel_lr", "wheel_lm1", "wheel_lm2", "wheel_lm3",
-            "wheel_rr", "wheel_rm1", "wheel_rm2", "wheel_rm3",
+            "wheel_lr",
+            "wheel_lm1",
+            "wheel_lm2",
+            "wheel_lm3",
+            "wheel_rr",
+            "wheel_rm1",
+            "wheel_rm2",
+            "wheel_rm3",
         }
 
         wheel_front_obj = None
         wheel_rear_obj = None
         for model_obj in drawable_obj.children:
-            if model_obj.sollum_type != SollumType.DRAWABLE_MODEL or not model_obj.sollumz_is_physics_child_mesh:
+            if (
+                model_obj.sollum_type != SollumType.DRAWABLE_MODEL
+                or not model_obj.sollumz_is_physics_child_mesh
+            ):
                 continue
 
             parent_bone = get_child_of_bone(model_obj)
@@ -325,26 +384,36 @@ class SOLLUMZ_OT_GENERATE_WHEEL_INSTANCES(bpy.types.Operator):
 
         # create objects in same collection as the fragment object
         with context.temp_override(collection=frag_obj.users_collection[0]):
-            empty = create_empty_object(SollumType.NONE, f"{frag_obj.name}.wheel_previews")
+            empty = create_empty_object(
+                SollumType.NONE, f"{frag_obj.name}.wheel_previews"
+            )
             empty.parent = frag_obj
 
             for bone_name in chain(wheel_bones_front, wheel_bones_rear):
                 if bone_name not in frag_obj.data.bones:
                     continue
 
-                wheel_obj = wheel_front_obj if bone_name in wheel_bones_front else wheel_rear_obj
+                wheel_obj = (
+                    wheel_front_obj
+                    if bone_name in wheel_bones_front
+                    else wheel_rear_obj
+                )
                 wheel_obj_bone_name = get_child_of_bone(wheel_obj).name
                 if wheel_obj_bone_name == bone_name:
                     continue
 
-                instance = create_blender_object(SollumType.NONE, f"{bone_name}.preview", wheel_obj.data)
+                instance = create_blender_object(
+                    SollumType.NONE, f"{bone_name}.preview", wheel_obj.data
+                )
                 add_child_of_bone_constraint(instance, frag_obj, bone_name)
 
                 # Rotate wheels on the other side
                 instance_is_left_side = "_l" in bone_name
                 wheel_is_left_side = "_l" in wheel_obj_bone_name
                 if instance_is_left_side != wheel_is_left_side:
-                    instance.matrix_world = Matrix.Rotation(radians(180), 4, "Y") @ instance.matrix_world
+                    instance.matrix_world = (
+                        Matrix.Rotation(radians(180), 4, "Y") @ instance.matrix_world
+                    )
 
                 instance.parent = empty
 
@@ -353,6 +422,7 @@ class SOLLUMZ_OT_GENERATE_WHEEL_INSTANCES(bpy.types.Operator):
 
 class SOLLUMZ_OT_CALCULATE_MASS(bpy.types.Operator):
     """Calculate (approximate) mass for collision based on it's volume and density"""
+
     bl_idname = "sollumz.calculate_mass"
     bl_label = "Calculate Collision Mass"
     bl_options = {"REGISTER", "UNDO"}
@@ -365,12 +435,18 @@ class SOLLUMZ_OT_CALCULATE_MASS(bpy.types.Operator):
         for obj in context.selected_objects:
             if obj.sollum_type in BOUND_POLYGON_TYPES:
                 self.report(
-                    {"INFO"}, f"{obj.name} is a Bound Polygon! Select the Bound Geometry BVH instead! Skipping...")
+                    {"INFO"},
+                    f"{obj.name} is a Bound Polygon! Select the Bound Geometry BVH instead! Skipping...",
+                )
                 continue
 
-            if obj.sollum_type not in BOUND_TYPES or obj.sollum_type == SollumType.BOUND_COMPOSITE:
+            if (
+                obj.sollum_type not in BOUND_TYPES
+                or obj.sollum_type == SollumType.BOUND_COMPOSITE
+            ):
                 self.report(
-                    {"INFO"}, f"{obj.name} not a Sollumz bound type! Skipping...")
+                    {"INFO"}, f"{obj.name} not a Sollumz bound type! Skipping..."
+                )
                 continue
 
             if obj.sollum_type == SollumType.BOUND_GEOMETRYBVH:
@@ -382,7 +458,8 @@ class SOLLUMZ_OT_CALCULATE_MASS(bpy.types.Operator):
 
             if mat is None:
                 self.report(
-                    {"INFO"}, f"{obj.name} has no collision materials! Skipping...")
+                    {"INFO"}, f"{obj.name} has no collision materials! Skipping..."
+                )
                 continue
 
             mass = self.calculate_mass(obj, mat)

--- a/yft/properties.py
+++ b/yft/properties.py
@@ -3,18 +3,21 @@ import bmesh
 from enum import IntEnum
 
 from ..tools.blenderhelper import remove_number_suffix
-from ..sollumz_properties import SOLLUMZ_UI_NAMES, SollumType, VehicleLightID, VehiclePaintLayer, items_from_enums
+from ..sollumz_properties import (
+    SOLLUMZ_UI_NAMES,
+    SollumType,
+    VehicleLightID,
+    VehiclePaintLayer,
+    items_from_enums,
+)
 
 
 class FragArchetypeProperties(bpy.types.PropertyGroup):
     unknown_48: bpy.props.FloatProperty(name="Unknown48", default=1)
-    unknown_4c: bpy.props.FloatProperty(
-        name="Unknown4c", default=150)
-    unknown_50: bpy.props.FloatProperty(
-        name="Unknown50", default=6.28)
+    unknown_4c: bpy.props.FloatProperty(name="Unknown4c", default=150)
+    unknown_50: bpy.props.FloatProperty(name="Unknown50", default=6.28)
     unknown_54: bpy.props.FloatProperty(name="Unknown54", default=1)
-    inertia_tensor: bpy.props.FloatVectorProperty(
-        name="Inertia Tensor")
+    inertia_tensor: bpy.props.FloatVectorProperty(name="Inertia Tensor")
 
 
 class LODProperties(bpy.types.PropertyGroup):
@@ -25,20 +28,25 @@ class LODProperties(bpy.types.PropertyGroup):
     unknown_40: bpy.props.FloatVectorProperty(name="Unknown40")
     unknown_50: bpy.props.FloatVectorProperty(name="Unknown50")
     damping_linear_c: bpy.props.FloatVectorProperty(
-        name="Damping Linear C", default=(0.02, 0.02, 0.02))
+        name="Damping Linear C", default=(0.02, 0.02, 0.02)
+    )
     damping_linear_v: bpy.props.FloatVectorProperty(
-        name="Damping Linear V", default=(0.02, 0.02, 0.02))
+        name="Damping Linear V", default=(0.02, 0.02, 0.02)
+    )
     damping_linear_v2: bpy.props.FloatVectorProperty(
-        name="Damping Linear V2", default=(0.01, 0.01, 0.01))
+        name="Damping Linear V2", default=(0.01, 0.01, 0.01)
+    )
     damping_angular_c: bpy.props.FloatVectorProperty(
-        name="Damping Angular C", default=(0.02, 0.02, 0.02))
+        name="Damping Angular C", default=(0.02, 0.02, 0.02)
+    )
     damping_angular_v: bpy.props.FloatVectorProperty(
-        name="Damping Angular V", default=(0.02, 0.02, 0.02))
+        name="Damping Angular V", default=(0.02, 0.02, 0.02)
+    )
     damping_angular_v2: bpy.props.FloatVectorProperty(
-        name="Damping Angular V2", default=(0.01, 0.01, 0.01))
+        name="Damping Angular V2", default=(0.01, 0.01, 0.01)
+    )
 
-    archetype_properties: bpy.props.PointerProperty(
-        type=FragArchetypeProperties)
+    archetype_properties: bpy.props.PointerProperty(type=FragArchetypeProperties)
 
 
 GlassTypes = [
@@ -69,24 +77,21 @@ class GroupProperties(bpy.types.PropertyGroup):
     glass_type: bpy.props.EnumProperty(name="Glass Type", items=GlassTypes)
     strength: bpy.props.FloatProperty(name="Strength", default=100)
     force_transmission_scale_up: bpy.props.FloatProperty(
-        name="Force Transmission Scale Up", default=0.25)
+        name="Force Transmission Scale Up", default=0.25
+    )
     force_transmission_scale_down: bpy.props.FloatProperty(
-        name="Force Transmission Scale Down", default=0.25)
+        name="Force Transmission Scale Down", default=0.25
+    )
     joint_stiffness: bpy.props.FloatProperty(name="Joint Stiffness")
-    min_soft_angle_1: bpy.props.FloatProperty(
-        name="Min Soft Angle 1", default=-1)
-    max_soft_angle_1: bpy.props.FloatProperty(
-        name="Max Soft Angle 1", default=1)
-    max_soft_angle_2: bpy.props.FloatProperty(
-        name="Max Soft Angle 2", default=1)
-    max_soft_angle_3: bpy.props.FloatProperty(
-        name="Max Soft Angle 3", default=1)
+    min_soft_angle_1: bpy.props.FloatProperty(name="Min Soft Angle 1", default=-1)
+    max_soft_angle_1: bpy.props.FloatProperty(name="Max Soft Angle 1", default=1)
+    max_soft_angle_2: bpy.props.FloatProperty(name="Max Soft Angle 2", default=1)
+    max_soft_angle_3: bpy.props.FloatProperty(name="Max Soft Angle 3", default=1)
     rotation_speed: bpy.props.FloatProperty(name="Rotation Speed")
     rotation_strength: bpy.props.FloatProperty(name="Restoring Strength")
     restoring_max_torque: bpy.props.FloatProperty(name="Restoring Max Torque")
     latch_strength: bpy.props.FloatProperty(name="Latch Strength")
-    min_damage_force: bpy.props.FloatProperty(
-        name="Min Damage Force", default=100)
+    min_damage_force: bpy.props.FloatProperty(name="Min Damage Force", default=100)
     damage_health: bpy.props.FloatProperty(name="Damage Health", default=1000)
     unk_float_5c: bpy.props.FloatProperty(name="Weapon Health")
     unk_float_60: bpy.props.FloatProperty(name="Weapon Scale", default=1)
@@ -104,16 +109,19 @@ class ChildProperties(bpy.types.PropertyGroup):
     damaged: bpy.props.BoolProperty(name="Damaged")
 
     window_mat: bpy.props.PointerProperty(
-        type=bpy.types.Material, name="Window Material", description="The material of the window mesh (usually a vehglass shader)")
-    is_veh_window: bpy.props.BoolProperty(
-        name="Is Glass Window")
+        type=bpy.types.Material,
+        name="Window Material",
+        description="The material of the window mesh (usually a vehglass shader)",
+    )
+    is_veh_window: bpy.props.BoolProperty(name="Is Glass Window")
 
 
 class VehicleWindowProperties(bpy.types.PropertyGroup):
     unk_float_17: bpy.props.FloatProperty(name="Unk Float 17")
     unk_float_18: bpy.props.FloatProperty(name="Unk Float 18")
     cracks_texture_tiling: bpy.props.FloatProperty(
-        name="Cracks Texture Tiling", default=1.5)
+        name="Cracks Texture Tiling", default=1.5
+    )
 
 
 class FragmentProperties(bpy.types.PropertyGroup):
@@ -124,8 +132,7 @@ class FragmentProperties(bpy.types.PropertyGroup):
     unk_c4: bpy.props.FloatProperty(name="UnknownC4", default=1.0)
     unk_cc: bpy.props.FloatProperty(name="UnknownCC")
     gravity_factor: bpy.props.FloatProperty(name="Gravity Factor", default=1.0)
-    buoyancy_factor: bpy.props.FloatProperty(
-        name="Buoyancy Factor", default=1.0)
+    buoyancy_factor: bpy.props.FloatProperty(name="Buoyancy Factor", default=1.0)
 
     lod_properties: bpy.props.PointerProperty(type=LODProperties)
 
@@ -137,7 +144,8 @@ def get_light_id_of_selection(self):
         return -1
 
     selected_mesh_objs = [
-        obj for obj in bpy.context.selected_objects if obj.type == "MESH"]
+        obj for obj in bpy.context.selected_objects if obj.type == "MESH"
+    ]
 
     if not selected_mesh_objs:
         return -1
@@ -180,6 +188,7 @@ PAINT_LAYER_VALUES = {
 
 def update_mat_paint_name(mat: bpy.types.Material):
     """Update material name to have [PAINT_LAYER] extension at the end."""
+
     def get_paint_layer_name(_paint_layer: VehiclePaintLayer):
         if _paint_layer == VehiclePaintLayer.NOT_PAINTABLE:
             return ""
@@ -202,71 +211,122 @@ def update_mat_paint_name(mat: bpy.types.Material):
 
 def register():
     bpy.types.Object.fragment_properties = bpy.props.PointerProperty(
-        type=FragmentProperties)
-    bpy.types.Object.child_properties = bpy.props.PointerProperty(
-        type=ChildProperties)
+        type=FragmentProperties
+    )
+    bpy.types.Object.child_properties = bpy.props.PointerProperty(type=ChildProperties)
     bpy.types.Object.vehicle_window_properties = bpy.props.PointerProperty(
-        type=VehicleWindowProperties)
+        type=VehicleWindowProperties
+    )
     bpy.types.Object.sollumz_is_physics_child_mesh = bpy.props.BoolProperty(
-        name="Is Physics Child", description="Whether or not this fragment mesh is a physics child. Usually wheels meshes are physics children")
+        name="Is Physics Child",
+        description="Whether or not this fragment mesh is a physics child. Usually wheels meshes are physics children",
+    )
 
     bpy.types.Object.glass_thickness = bpy.props.FloatProperty(
-        name="Thickness", default=0.1)
+        name="Thickness", default=0.1
+    )
 
     bpy.types.Scene.create_fragment_type = bpy.props.EnumProperty(
         items=[
-            (SollumType.FRAGMENT.value,
-             SOLLUMZ_UI_NAMES[SollumType.FRAGMENT], "Create a fragment object"),
-            (SollumType.FRAGLOD.value,
-             SOLLUMZ_UI_NAMES[SollumType.FRAGLOD], "Create a fragment LOD object"),
-            (SollumType.FRAGGROUP.value,
-             SOLLUMZ_UI_NAMES[SollumType.FRAGGROUP], "Create a fragment group object"),
-            (SollumType.FRAGCHILD.value,
-             SOLLUMZ_UI_NAMES[SollumType.FRAGCHILD], "Create a fragment child object"),
+            (
+                SollumType.FRAGMENT.value,
+                SOLLUMZ_UI_NAMES[SollumType.FRAGMENT],
+                "Create a fragment object",
+            ),
+            (
+                SollumType.FRAGLOD.value,
+                SOLLUMZ_UI_NAMES[SollumType.FRAGLOD],
+                "Create a fragment LOD object",
+            ),
+            (
+                SollumType.FRAGGROUP.value,
+                SOLLUMZ_UI_NAMES[SollumType.FRAGGROUP],
+                "Create a fragment group object",
+            ),
+            (
+                SollumType.FRAGCHILD.value,
+                SOLLUMZ_UI_NAMES[SollumType.FRAGCHILD],
+                "Create a fragment child object",
+            ),
         ],
         name="Type",
-        default=SollumType.FRAGMENT.value
+        default=SollumType.FRAGMENT.value,
     )
 
-    bpy.types.Bone.group_properties = bpy.props.PointerProperty(
-        type=GroupProperties)
+    bpy.types.Bone.group_properties = bpy.props.PointerProperty(type=GroupProperties)
     bpy.types.Bone.sollumz_use_physics = bpy.props.BoolProperty(
-        name="Use Physics", description="Whether or not to use physics for this fragment bone")
+        name="Use Physics",
+        description="Whether or not to use physics for this fragment bone",
+    )
 
-    bpy.types.Scene.create_bones_fragment = bpy.props.PointerProperty(type=bpy.types.Object,
-                                                                      name="Fragment", description="The Fragment to add the bones to")
+    bpy.types.Scene.create_bones_fragment = bpy.props.PointerProperty(
+        type=bpy.types.Object,
+        name="Fragment",
+        description="The Fragment to add the bones to",
+    )
     bpy.types.Scene.create_bones_parent_to_selected = bpy.props.BoolProperty(
-        name="Parent to selected bone", description="Parent all bones to the currently selected bone")
+        name="Parent to selected bone",
+        description="Parent all bones to the currently selected bone",
+    )
     bpy.types.Scene.set_mass_amount = bpy.props.FloatProperty(
-        name="Mass", description="Mass", min=0)
+        name="Mass", description="Mass", min=0
+    )
 
-    bpy.types.Scene.set_vehicle_light_id = bpy.props.EnumProperty(items=items_from_enums(
-        VehicleLightID, exclude=VehicleLightID.NONE), name="Vehicle Light ID", description="Determines which action causes the emissive shader to activate (this is stored in the alpha channel of the vertex colors)")
-    bpy.types.Scene.select_vehicle_light_id = bpy.props.EnumProperty(items=items_from_enums(
-        VehicleLightID, exclude=VehicleLightID.NONE), name="Vehicle Light ID", description="Determines which action causes the emissive shader to activate (this is stored in the alpha channel of the vertex colors)")
-    bpy.types.Scene.set_custom_vehicle_light_id = bpy.props.IntProperty(
-        name="Custom")
+    bpy.types.Scene.set_vehicle_light_id = bpy.props.EnumProperty(
+        items=items_from_enums(VehicleLightID, exclude=VehicleLightID.NONE),
+        name="Vehicle Light ID",
+        description="Determines which action causes the emissive shader to activate (this is stored in the alpha channel of the vertex colors)",
+    )
+    bpy.types.Scene.select_vehicle_light_id = bpy.props.EnumProperty(
+        items=items_from_enums(VehicleLightID, exclude=VehicleLightID.NONE),
+        name="Vehicle Light ID",
+        description="Determines which action causes the emissive shader to activate (this is stored in the alpha channel of the vertex colors)",
+    )
+    bpy.types.Scene.set_custom_vehicle_light_id = bpy.props.IntProperty(name="Custom")
     bpy.types.Scene.select_custom_vehicle_light_id = bpy.props.IntProperty(
-        name="Custom")
+        name="Custom"
+    )
     bpy.types.Scene.selected_vehicle_light_id = bpy.props.IntProperty(
-        name="Light ID", get=get_light_id_of_selection)
+        name="Light ID", get=get_light_id_of_selection
+    )
 
     bpy.types.Material.sollumz_paint_layer = bpy.props.EnumProperty(
         items=(
-            (VehiclePaintLayer.NOT_PAINTABLE.value, SOLLUMZ_UI_NAMES[VehiclePaintLayer.NOT_PAINTABLE],
-             "Material cannot be painted at mod shops"),
-            (VehiclePaintLayer.PRIMARY.value, SOLLUMZ_UI_NAMES[VehiclePaintLayer.PRIMARY],
-             "Primary paint color will use this material"),
-            (VehiclePaintLayer.SECONDARY.value, SOLLUMZ_UI_NAMES[VehiclePaintLayer.SECONDARY],
-             "Secondary paint color will use this material"),
-            (VehiclePaintLayer.WHEEL.value, SOLLUMZ_UI_NAMES[VehiclePaintLayer.WHEEL],
-             "Wheel color will use this material"),
-            (VehiclePaintLayer.INTERIOR_TRIM.value, SOLLUMZ_UI_NAMES[VehiclePaintLayer.INTERIOR_TRIM],
-             "Interior trim color will use this material"),
-            (VehiclePaintLayer.INTERIOR_DASH.value, SOLLUMZ_UI_NAMES[VehiclePaintLayer.INTERIOR_DASH],
-             "Interior dash color will use this material"),
+            (
+                VehiclePaintLayer.NOT_PAINTABLE.value,
+                SOLLUMZ_UI_NAMES[VehiclePaintLayer.NOT_PAINTABLE],
+                "Material cannot be painted at mod shops",
+            ),
+            (
+                VehiclePaintLayer.PRIMARY.value,
+                SOLLUMZ_UI_NAMES[VehiclePaintLayer.PRIMARY],
+                "Primary paint color will use this material",
+            ),
+            (
+                VehiclePaintLayer.SECONDARY.value,
+                SOLLUMZ_UI_NAMES[VehiclePaintLayer.SECONDARY],
+                "Secondary paint color will use this material",
+            ),
+            (
+                VehiclePaintLayer.WHEEL.value,
+                SOLLUMZ_UI_NAMES[VehiclePaintLayer.WHEEL],
+                "Wheel color will use this material",
+            ),
+            (
+                VehiclePaintLayer.INTERIOR_TRIM.value,
+                SOLLUMZ_UI_NAMES[VehiclePaintLayer.INTERIOR_TRIM],
+                "Interior trim color will use this material",
+            ),
+            (
+                VehiclePaintLayer.INTERIOR_DASH.value,
+                SOLLUMZ_UI_NAMES[VehiclePaintLayer.INTERIOR_DASH],
+                "Interior dash color will use this material",
+            ),
         ),
-        name="Paint Layer", default=VehiclePaintLayer.NOT_PAINTABLE, update=lambda mat, context: update_mat_paint_name(mat))
+        name="Paint Layer",
+        default=VehiclePaintLayer.NOT_PAINTABLE,
+        update=lambda mat, context: update_mat_paint_name(mat),
+    )
 
 
 def unregister():

--- a/yft/ui.py
+++ b/yft/ui.py
@@ -5,13 +5,21 @@ from ..ybn.ui import SOLLUMZ_PT_BOUND_PROPERTIES_PANEL
 from ..sollumz_properties import MaterialType, SollumType, BOUND_TYPES
 from ..sollumz_helper import find_sollumz_parent
 from .properties import (
-    GroupProperties, FragmentProperties, VehicleWindowProperties, VehicleLightID,
+    GroupProperties,
+    FragmentProperties,
+    VehicleWindowProperties,
+    VehicleLightID,
     GroupFlagBit,
 )
 from .operators import (
-    SOLLUMZ_OT_CREATE_FRAGMENT, SOLLUMZ_OT_CREATE_BONES_AT_OBJECTS, SOLLUMZ_OT_SET_MASS, SOLLUMZ_OT_SET_LIGHT_ID,
-    SOLLUMZ_OT_SELECT_LIGHT_ID, SOLLUMZ_OT_COPY_FRAG_BONE_PHYSICS
+    SOLLUMZ_OT_CREATE_FRAGMENT,
+    SOLLUMZ_OT_CREATE_BONES_AT_OBJECTS,
+    SOLLUMZ_OT_SET_MASS,
+    SOLLUMZ_OT_SET_LIGHT_ID,
+    SOLLUMZ_OT_SELECT_LIGHT_ID,
+    SOLLUMZ_OT_COPY_FRAG_BONE_PHYSICS,
 )
+
 
 class SOLLUMZ_PT_FRAGMENT_TOOL_PANEL(bpy.types.Panel):
     bl_label = "Fragments"
@@ -43,22 +51,21 @@ class SOLLUMZ_PT_FRAGMENT_CREATE_PANEL(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.operator(SOLLUMZ_OT_CREATE_FRAGMENT.bl_idname,
-                        icon="MOD_PHYSICS")
+        layout.operator(SOLLUMZ_OT_CREATE_FRAGMENT.bl_idname, icon="MOD_PHYSICS")
 
         layout.separator()
 
         row = layout.row()
-        row.operator(SOLLUMZ_OT_CREATE_BONES_AT_OBJECTS.bl_idname,
-                     icon="BONE_DATA")
+        row.operator(SOLLUMZ_OT_CREATE_BONES_AT_OBJECTS.bl_idname, icon="BONE_DATA")
         row = layout.row()
         row.prop(context.scene, "create_bones_fragment")
         row.prop(context.scene, "create_bones_parent_to_selected")
 
         layout.separator()
         layout.label(text="Wheel Instances")
-        layout.operator("sollumz.generate_wheel_instances",
-                        icon="OUTLINER_OB_GROUP_INSTANCE")
+        layout.operator(
+            "sollumz.generate_wheel_instances", icon="OUTLINER_OB_GROUP_INSTANCE"
+        )
 
 
 class SOLLUMZ_PT_FRAGMENT_SET_MASS_PANEL(bpy.types.Panel):
@@ -117,8 +124,7 @@ class SOLLUMZ_PT_LIGHT_ID_PANEL(bpy.types.Panel):
         layout.use_property_split = True
 
         row = layout.row(align=True)
-        row.operator(SOLLUMZ_OT_SET_LIGHT_ID.bl_idname,
-                     icon="OUTLINER_OB_LIGHT")
+        row.operator(SOLLUMZ_OT_SET_LIGHT_ID.bl_idname, icon="OUTLINER_OB_LIGHT")
         row.prop(context.scene, "set_vehicle_light_id", text="")
 
         if context.scene.set_vehicle_light_id == VehicleLightID.CUSTOM:
@@ -127,8 +133,7 @@ class SOLLUMZ_PT_LIGHT_ID_PANEL(bpy.types.Panel):
 
         row = layout.row(align=True)
 
-        row.operator(SOLLUMZ_OT_SELECT_LIGHT_ID.bl_idname,
-                     icon="GROUP_VERTEX")
+        row.operator(SOLLUMZ_OT_SELECT_LIGHT_ID.bl_idname, icon="GROUP_VERTEX")
         row.prop(context.scene, "select_vehicle_light_id", text="")
 
         if context.scene.select_vehicle_light_id == VehicleLightID.CUSTOM:
@@ -143,11 +148,9 @@ class SOLLUMZ_PT_LIGHT_ID_PANEL(bpy.types.Panel):
         if face_mode:
             if light_id == -1:
                 light_id = "N/A"
-            layout.label(
-                text=f"Selection Light ID: {light_id}")
+            layout.label(text=f"Selection Light ID: {light_id}")
         else:
-            layout.label(
-                text="Must be in Edit Mode > Face Selection.", icon="ERROR")
+            layout.label(text="Must be in Edit Mode > Face Selection.", icon="ERROR")
 
 
 class SOLLUMZ_PT_FRAGMENT_PANEL(bpy.types.Panel):
@@ -160,7 +163,10 @@ class SOLLUMZ_PT_FRAGMENT_PANEL(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.sollum_type == SollumType.FRAGMENT
+        return (
+            context.active_object is not None
+            and context.active_object.sollum_type == SollumType.FRAGMENT
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -231,7 +237,10 @@ class SOLLUMZ_PT_BONE_PHYSICS_PANEL(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.active_bone is not None and context.active_object.sollum_type == SollumType.FRAGMENT
+        return (
+            context.active_bone is not None
+            and context.active_object.sollum_type == SollumType.FRAGMENT
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -253,7 +262,9 @@ class SOLLUMZ_PT_BONE_PHYSICS_SUBPANEL(bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.active_bone is not None and context.active_bone.sollumz_use_physics
+        return (
+            context.active_bone is not None and context.active_bone.sollumz_use_physics
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -264,7 +275,12 @@ class SOLLUMZ_PT_BONE_PHYSICS_SUBPANEL(bpy.types.Panel):
         props = bone.group_properties
 
         col = layout.column(heading="Flags")
-        col.prop(props, "flags", index=GroupFlagBit.DISAPPEAR_WHEN_DEAD, text="Disappear When Dead")
+        col.prop(
+            props,
+            "flags",
+            index=GroupFlagBit.DISAPPEAR_WHEN_DEAD,
+            text="Disappear When Dead",
+        )
         col.prop(props, "flags", index=GroupFlagBit.UNK_4, text="Unk 4")
         col.prop(props, "flags", index=GroupFlagBit.UNK_8, text="Unk 8")
         col.prop(props, "flags", index=GroupFlagBit.UNK_16, text="Unk 16")
@@ -299,7 +315,12 @@ class SOLLUMZ_PT_PHYSICS_CHILD_PANEL(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         aobj = context.active_object
-        return aobj is not None and aobj.sollum_type != SollumType.BOUND_COMPOSITE and aobj.sollum_type in BOUND_TYPES and find_sollumz_parent(aobj)
+        return (
+            aobj is not None
+            and aobj.sollum_type != SollumType.BOUND_COMPOSITE
+            and aobj.sollum_type in BOUND_TYPES
+            and find_sollumz_parent(aobj)
+        )
 
     def draw(self, context):
         layout = self.layout
@@ -369,8 +390,9 @@ class SOLLUMZ_PT_FRAGMENT_GEOMETRY_PANEL(bpy.types.Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
 
-        layout.prop(context.active_object,
-                    "sollumz_is_physics_child_mesh", text="Is Wheel Mesh")
+        layout.prop(
+            context.active_object, "sollumz_is_physics_child_mesh", text="Is Wheel Mesh"
+        )
 
 
 class SOLLUMZ_PT_FRAGMENT_MAT_PANEL(bpy.types.Panel):
@@ -389,21 +411,29 @@ class SOLLUMZ_PT_FRAGMENT_MAT_PANEL(bpy.types.Panel):
         if aobj is None or aobj.sollum_type != SollumType.DRAWABLE_MODEL:
             return False
 
-        has_frag_parent = find_sollumz_parent(
-            aobj, parent_type=SollumType.FRAGMENT) is not None
+        has_frag_parent = (
+            find_sollumz_parent(aobj, parent_type=SollumType.FRAGMENT) is not None
+        )
         mat = aobj.active_material
 
-        return mat is not None and mat.sollum_type == MaterialType.SHADER and has_frag_parent
+        return (
+            mat is not None
+            and mat.sollum_type == MaterialType.SHADER
+            and has_frag_parent
+        )
 
     def draw(self, context):
         layout = self.layout
         mat = context.active_object.active_material
 
         has_mat_diffuse_color = any(
-            "matDiffuseColor" in n.name for n in mat.node_tree.nodes)
+            "matDiffuseColor" in n.name for n in mat.node_tree.nodes
+        )
         row = layout.row()
         row.enabled = has_mat_diffuse_color
         row.prop(mat, "sollumz_paint_layer")
         if not has_mat_diffuse_color:
             layout.label(
-                text="Not a paint shader. Shader must have a matDiffuseColor parameter.", icon="ERROR")
+                text="Not a paint shader. Shader must have a matDiffuseColor parameter.",
+                icon="ERROR",
+            )

--- a/ymap/operators.py
+++ b/ymap/operators.py
@@ -9,6 +9,7 @@ from ..sollumz_properties import SOLLUMZ_UI_NAMES, SollumType
 
 class SOLLUMZ_OT_create_ymap(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create a sollumz YMAP object"""
+
     bl_idname = "sollumz.createymap"
     bl_label = f"Create YMAP"
     bl_description = "Create a YMAP"
@@ -22,6 +23,7 @@ class SOLLUMZ_OT_create_ymap(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_create_entity_group(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create a sollumz 'Entities' group object"""
+
     bl_idname = "sollumz.create_entity_group"
     bl_label = f"Entities"
     bl_description = "Create 'Entities' group.\n\nOnly 1 per YMAP maximum.\nYou can't create 'Entities' group if the current YMAP already includes occlusions"
@@ -34,18 +36,27 @@ class SOLLUMZ_OT_create_entity_group(SOLLUMZ_OT_base, bpy.types.Operator):
         for child in aobj.children:
             existing_groups.append(child.name)
         for group in existing_groups:
-            if group == "Entities" or group == "Box Occluders" or group == "Model Occluders":
+            if (
+                group == "Entities"
+                or group == "Box Occluders"
+                or group == "Model Occluders"
+            ):
                 return False
         return True
 
     def run(self, context):
         ymap_obj = context.active_object
-        create_ymap_group(sollum_type=SollumType.YMAP_ENTITY_GROUP, selected_ymap=ymap_obj, empty_name='Entities')
+        create_ymap_group(
+            sollum_type=SollumType.YMAP_ENTITY_GROUP,
+            selected_ymap=ymap_obj,
+            empty_name="Entities",
+        )
         return True
 
 
 class SOLLUMZ_OT_create_model_occluder_group(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create a sollumz 'Model Occluders' group object"""
+
     bl_idname = "sollumz.create_model_occluder_group"
     bl_label = f"Model Occluders"
     bl_description = "Create 'Model Occluders' group.\n\nOnly 1 per YMAP maximum.\nYou can't create 'Model Occluders' group if the current YMAP already includes an 'Entities' group"
@@ -64,12 +75,17 @@ class SOLLUMZ_OT_create_model_occluder_group(SOLLUMZ_OT_base, bpy.types.Operator
 
     def run(self, context):
         ymap_obj = context.active_object
-        create_ymap_group(sollum_type=SollumType.YMAP_MODEL_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Model Occluders')
+        create_ymap_group(
+            sollum_type=SollumType.YMAP_MODEL_OCCLUDER_GROUP,
+            selected_ymap=ymap_obj,
+            empty_name="Model Occluders",
+        )
         return True
 
 
 class SOLLUMZ_OT_create_box_occluder_group(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create a sollumz 'Box Occluders' group object"""
+
     bl_idname = "sollumz.create_box_occluder_group"
     bl_label = f"Box Occluders"
     bl_description = "Create 'Box Occluders' group.\n\nOnly 1 per YMAP maximum.\nYou can't create 'Box Occluders' group if the current YMAP already includes an 'Entities' group"
@@ -88,12 +104,17 @@ class SOLLUMZ_OT_create_box_occluder_group(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         ymap_obj = context.active_object
-        create_ymap_group(sollum_type=SollumType.YMAP_BOX_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Box Occluders')
+        create_ymap_group(
+            sollum_type=SollumType.YMAP_BOX_OCCLUDER_GROUP,
+            selected_ymap=ymap_obj,
+            empty_name="Box Occluders",
+        )
         return True
 
 
 class SOLLUMZ_OT_create_car_generator_group(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create a sollumz 'Car Generators' group object"""
+
     bl_idname = "sollumz.create_car_generator_group"
     bl_label = f"Car Generators"
     bl_description = "Create 'Car Generators' group.\n\nOnly 1 per YMAP maximum"
@@ -111,12 +132,17 @@ class SOLLUMZ_OT_create_car_generator_group(SOLLUMZ_OT_base, bpy.types.Operator)
 
     def run(self, context):
         ymap_obj = context.active_object
-        create_ymap_group(sollum_type=SollumType.YMAP_CAR_GENERATOR_GROUP, selected_ymap=ymap_obj, empty_name='Car Generators')
+        create_ymap_group(
+            sollum_type=SollumType.YMAP_CAR_GENERATOR_GROUP,
+            selected_ymap=ymap_obj,
+            empty_name="Car Generators",
+        )
         return True
 
 
 class SOLLUMZ_OT_create_box_occluder(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create a sollumz 'Box Occluder' object"""
+
     bl_idname = "sollumz.create_box_occluder"
     bl_label = "Create Box Occluder"
     bl_description = "Create a 'Box Occluder' object"
@@ -135,6 +161,7 @@ class SOLLUMZ_OT_create_box_occluder(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_create_model_occluder(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create a sollumz 'Model Occluder' object"""
+
     bl_idname = "sollumz.create_model_occluder"
     bl_label = "Create Model Occluder"
     bl_description = "Create a 'Model Occluder' object"
@@ -146,7 +173,9 @@ class SOLLUMZ_OT_create_model_occluder(SOLLUMZ_OT_base, bpy.types.Operator):
         model_obj.name = "Model"
         model_obj.sollum_type = SollumType.YMAP_MODEL_OCCLUDER
         model_obj.ymap_properties.flags = 0
-        model_obj.active_material = add_occluder_material(SollumType.YMAP_MODEL_OCCLUDER)
+        model_obj.active_material = add_occluder_material(
+            SollumType.YMAP_MODEL_OCCLUDER
+        )
         set_object_collection(model_obj)
         bpy.context.view_layer.objects.active = model_obj
         model_obj.parent = group_obj
@@ -156,6 +185,7 @@ class SOLLUMZ_OT_create_model_occluder(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_create_car_generator(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create a sollumz 'Car Generator' object"""
+
     bl_idname = "sollumz.create_car_generator"
     bl_label = "Create Car Generator"
     bl_description = "Create a 'Car Generator' object"

--- a/ymap/properties.py
+++ b/ymap/properties.py
@@ -1,8 +1,15 @@
 import bpy
 
 from ..tools.utils import int_to_bool_list, flag_prop_to_list, flag_list_to_int
-from bpy.props import (EnumProperty, FloatProperty, PointerProperty,
-                       StringProperty, IntProperty, FloatVectorProperty, BoolProperty)
+from bpy.props import (
+    EnumProperty,
+    FloatProperty,
+    PointerProperty,
+    StringProperty,
+    IntProperty,
+    FloatVectorProperty,
+    BoolProperty,
+)
 
 
 def update_uint_prop(self, context, var_name):
@@ -10,13 +17,13 @@ def update_uint_prop(self, context, var_name):
     try:
         int(getattr(self, var_name))
     except ValueError:
-        setattr(self, var_name, '0')
+        setattr(self, var_name, "0")
 
     value = int(getattr(self, var_name))
     max_val = (2**32) - 1
 
     if value < 0:
-        setattr(self, var_name, '0')
+        setattr(self, var_name, "0")
     elif value > max_val:
         setattr(self, var_name, str(max_val))
 
@@ -53,41 +60,46 @@ class ContentFlagPropertyGroup:
 
 class MapFlags(bpy.types.PropertyGroup):
     script_loaded: bpy.props.BoolProperty(
-        name="Script Loaded", update=FlagPropertyGroup.update_flag)
-    has_lod: bpy.props.BoolProperty(
-        name="LOD", update=FlagPropertyGroup.update_flag)
+        name="Script Loaded", update=FlagPropertyGroup.update_flag
+    )
+    has_lod: bpy.props.BoolProperty(name="LOD", update=FlagPropertyGroup.update_flag)
 
 
 class ContentFlags(bpy.types.PropertyGroup):
-    has_hd: BoolProperty(
-        name="HD", update=ContentFlagPropertyGroup.update_flag)
-    has_lod: BoolProperty(
-        name="LOD", update=ContentFlagPropertyGroup.update_flag)
-    has_slod2: BoolProperty(
-        name="SLOD2", update=ContentFlagPropertyGroup.update_flag)
-    has_int: BoolProperty(
-        name="Interior", update=ContentFlagPropertyGroup.update_flag)
-    has_slod: BoolProperty(
-        name="SLOD", update=ContentFlagPropertyGroup.update_flag)
+    has_hd: BoolProperty(name="HD", update=ContentFlagPropertyGroup.update_flag)
+    has_lod: BoolProperty(name="LOD", update=ContentFlagPropertyGroup.update_flag)
+    has_slod2: BoolProperty(name="SLOD2", update=ContentFlagPropertyGroup.update_flag)
+    has_int: BoolProperty(name="Interior", update=ContentFlagPropertyGroup.update_flag)
+    has_slod: BoolProperty(name="SLOD", update=ContentFlagPropertyGroup.update_flag)
     has_occl: BoolProperty(
-        name="Occlusion", update=ContentFlagPropertyGroup.update_flag)
+        name="Occlusion", update=ContentFlagPropertyGroup.update_flag
+    )
     has_physics: BoolProperty(
-        name="Physics", update=ContentFlagPropertyGroup.update_flag)
+        name="Physics", update=ContentFlagPropertyGroup.update_flag
+    )
     has_lod_lights: BoolProperty(
-        name="Lod Lights", update=ContentFlagPropertyGroup.update_flag)
+        name="Lod Lights", update=ContentFlagPropertyGroup.update_flag
+    )
     has_dis_lod_lights: BoolProperty(
-        name="Distant Lod Lights", update=ContentFlagPropertyGroup.update_flag)
+        name="Distant Lod Lights", update=ContentFlagPropertyGroup.update_flag
+    )
     has_critical: BoolProperty(
-        name="Critical", update=ContentFlagPropertyGroup.update_flag)
-    has_grass: BoolProperty(
-        name="Grass", update=ContentFlagPropertyGroup.update_flag)
+        name="Critical", update=ContentFlagPropertyGroup.update_flag
+    )
+    has_grass: BoolProperty(name="Grass", update=ContentFlagPropertyGroup.update_flag)
 
 
 class YmapBlockProperties(bpy.types.PropertyGroup):
-    version: StringProperty(name="Version", default='0', update=lambda self,
-                            context: update_uint_prop(self, context, 'version'))
-    flags: StringProperty(name="Flags", default='0', update=lambda self,
-                          context: update_uint_prop(self, context, 'flags'))
+    version: StringProperty(
+        name="Version",
+        default="0",
+        update=lambda self, context: update_uint_prop(self, context, "version"),
+    )
+    flags: StringProperty(
+        name="Flags",
+        default="0",
+        update=lambda self, context: update_uint_prop(self, context, "flags"),
+    )
     # TODO: Sync the name input with the object name?
     name: StringProperty(name="Name")
     exported_by: StringProperty(name="Exported By", default="Sollumz")
@@ -98,10 +110,20 @@ class YmapBlockProperties(bpy.types.PropertyGroup):
 class YmapProperties(bpy.types.PropertyGroup):
     name: StringProperty(name="Name", default="untitled_ymap")
     parent: StringProperty(name="Parent", default="")
-    flags: IntProperty(name="Flags", default=0, min=0, max=3,
-                       update=FlagPropertyGroup.update_flags_total)
-    content_flags: IntProperty(name="Content Flags", default=0, min=0, max=(
-        2**11)-1, update=ContentFlagPropertyGroup.update_flags_total)
+    flags: IntProperty(
+        name="Flags",
+        default=0,
+        min=0,
+        max=3,
+        update=FlagPropertyGroup.update_flags_total,
+    )
+    content_flags: IntProperty(
+        name="Content Flags",
+        default=0,
+        min=0,
+        max=(2**11) - 1,
+        update=ContentFlagPropertyGroup.update_flags_total,
+    )
 
     streaming_extents_min: FloatVectorProperty()
     streaming_extents_max: FloatVectorProperty()
@@ -111,8 +133,7 @@ class YmapProperties(bpy.types.PropertyGroup):
     flags_toggle: PointerProperty(type=MapFlags)
     content_flags_toggle: PointerProperty(type=ContentFlags)
 
-    block: PointerProperty(
-        type=YmapBlockProperties)
+    block: PointerProperty(type=YmapBlockProperties)
 
 
 class YmapModelOccluderProperties(bpy.types.PropertyGroup):
@@ -123,8 +144,7 @@ class YmapCarGeneratorProperties(bpy.types.PropertyGroup):
     car_model: StringProperty(name="CarModel", default="panto")
     cargen_flags: IntProperty(name="Flags", default=0)
     pop_group: StringProperty(name="PopGroup", default="")
-    perpendicular_length: FloatProperty(
-        name="PerpendicularLength", default=2.3)
+    perpendicular_length: FloatProperty(name="PerpendicularLength", default=2.3)
     body_color_remap_1: IntProperty(name="BodyColorRemap1", default=-1)
     body_color_remap_2: IntProperty(name="BodyColorRemap2", default=-1)
     body_color_remap_3: IntProperty(name="BodyColorRemap3", default=-1)
@@ -135,9 +155,11 @@ class YmapCarGeneratorProperties(bpy.types.PropertyGroup):
 def register():
     bpy.types.Object.ymap_properties = PointerProperty(type=YmapProperties)
     bpy.types.Object.ymap_model_occl_properties = PointerProperty(
-        type=YmapModelOccluderProperties)
+        type=YmapModelOccluderProperties
+    )
     bpy.types.Object.ymap_cargen_properties = PointerProperty(
-        type=YmapCarGeneratorProperties)
+        type=YmapCarGeneratorProperties
+    )
 
 
 def unregister():

--- a/ymap/ui.py
+++ b/ymap/ui.py
@@ -26,32 +26,28 @@ def draw_ymap_properties(self, context):
         row.prop(obj.ymap_properties.content_flags_toggle, "has_hd", toggle=1)
         row.prop(obj.ymap_properties.content_flags_toggle, "has_lod", toggle=1)
         row = layout.row()
-        row.prop(obj.ymap_properties.content_flags_toggle,
-                 "has_slod2", toggle=1)
+        row.prop(obj.ymap_properties.content_flags_toggle, "has_slod2", toggle=1)
         row.prop(obj.ymap_properties.content_flags_toggle, "has_int", toggle=1)
         row = layout.row()
         row.prop(obj.ymap_properties.content_flags_toggle, "has_slod", toggle=1)
         row.prop(obj.ymap_properties.content_flags_toggle, "has_occl", toggle=1)
         row = layout.row()
-        row.prop(obj.ymap_properties.content_flags_toggle,
-                 "has_physics", toggle=1)
-        row.prop(obj.ymap_properties.content_flags_toggle,
-                 "has_lod_lights", toggle=1)
+        row.prop(obj.ymap_properties.content_flags_toggle, "has_physics", toggle=1)
+        row.prop(obj.ymap_properties.content_flags_toggle, "has_lod_lights", toggle=1)
         row = layout.row()
-        row.prop(obj.ymap_properties.content_flags_toggle,
-                 "has_dis_lod_lights", toggle=1)
-        row.prop(obj.ymap_properties.content_flags_toggle,
-                 "has_critical", toggle=1)
+        row.prop(
+            obj.ymap_properties.content_flags_toggle, "has_dis_lod_lights", toggle=1
+        )
+        row.prop(obj.ymap_properties.content_flags_toggle, "has_critical", toggle=1)
         row = layout.row()
-        row.prop(obj.ymap_properties.content_flags_toggle,
-                 "has_grass", toggle=1)
+        row.prop(obj.ymap_properties.content_flags_toggle, "has_grass", toggle=1)
 
 
 def draw_ymap_model_occluder_properties(self, context):
     obj = context.active_object
     if obj and obj.sollum_type == SollumType.YMAP_MODEL_OCCLUDER:
         layout = self.layout
-        layout.prop(obj.ymap_model_occl_properties, 'model_occl_flags')
+        layout.prop(obj.ymap_model_occl_properties, "model_occl_flags")
 
 
 def draw_ymap_car_generator_properties(self, context):
@@ -59,15 +55,15 @@ def draw_ymap_car_generator_properties(self, context):
     if obj and obj.sollum_type == SollumType.YMAP_CAR_GENERATOR:
         layout = self.layout
         layout.separator()
-        layout.prop(obj.ymap_cargen_properties, 'car_model')
-        layout.prop(obj.ymap_cargen_properties, 'cargen_flags')
-        layout.prop(obj.ymap_cargen_properties, 'pop_group')
-        layout.prop(obj.ymap_cargen_properties, 'perpendicular_length')
-        layout.prop(obj.ymap_cargen_properties, 'body_color_remap_1')
-        layout.prop(obj.ymap_cargen_properties, 'body_color_remap_2')
-        layout.prop(obj.ymap_cargen_properties, 'body_color_remap_3')
-        layout.prop(obj.ymap_cargen_properties, 'body_color_remap_4')
-        layout.prop(obj.ymap_cargen_properties, 'livery')
+        layout.prop(obj.ymap_cargen_properties, "car_model")
+        layout.prop(obj.ymap_cargen_properties, "cargen_flags")
+        layout.prop(obj.ymap_cargen_properties, "pop_group")
+        layout.prop(obj.ymap_cargen_properties, "perpendicular_length")
+        layout.prop(obj.ymap_cargen_properties, "body_color_remap_1")
+        layout.prop(obj.ymap_cargen_properties, "body_color_remap_2")
+        layout.prop(obj.ymap_cargen_properties, "body_color_remap_3")
+        layout.prop(obj.ymap_cargen_properties, "body_color_remap_4")
+        layout.prop(obj.ymap_cargen_properties, "livery")
 
 
 class SOLLUMZ_PT_YMAP_TOOL_PANEL(bpy.types.Panel):
@@ -87,7 +83,7 @@ class SOLLUMZ_PT_YMAP_TOOL_PANEL(bpy.types.Panel):
         row = layout.row()
         row.operator("sollumz.createymap")
 
-        if (len(bpy.context.selected_objects) > 0):
+        if len(bpy.context.selected_objects) > 0:
             active_object = bpy.context.selected_objects[0]
 
             if active_object.sollum_type == SollumType.YMAP:

--- a/ymap/ymapexport.py
+++ b/ymap/ymapexport.py
@@ -50,19 +50,19 @@ def triangulate_obj(obj):
 def get_verts_from_obj(obj):
     """
     For each vertex get its coordinates in global space (this way we don't need to apply transfroms)
-    then get their bytes hex representation and append. After that for each face get its indices, 
+    then get their bytes hex representation and append. After that for each face get its indices,
     get their bytes hex representation and append.
 
     :return verts: String if vertex coordinates and face indices in hex representation
     :rtype str:
     """
-    verts = ''
+    verts = ""
     for v in obj.data.vertices:
         for c in obj.matrix_world @ v.co:
-            verts += str(hexlify(pack('f', c)))[2:-1].upper()
+            verts += str(hexlify(pack("f", c)))[2:-1].upper()
     for p in obj.data.polygons:
         for i in p.vertices:
-            verts += str(hexlify(pack('B', i)))[2:-1].upper()
+            verts += str(hexlify(pack("B", i)))[2:-1].upper()
     return verts
 
 
@@ -100,14 +100,19 @@ def entity_from_obj(obj):
     entity.child_lod_dist = obj.entity_properties.child_lod_dist
     entity.lod_level = obj.entity_properties.lod_level.upper().replace("SOLLUMZ_", "")
     entity.num_children = int(obj.entity_properties.num_children)
-    entity.priority_level = obj.entity_properties.priority_level.upper().replace("SOLLUMZ_", "")
+    entity.priority_level = obj.entity_properties.priority_level.upper().replace(
+        "SOLLUMZ_", ""
+    )
     entity.ambient_occlusion_multiplier = int(
-        obj.entity_properties.ambient_occlusion_multiplier)
+        obj.entity_properties.ambient_occlusion_multiplier
+    )
     entity.artificial_ambient_occlusion = int(
-        obj.entity_properties.artificial_ambient_occlusion)
+        obj.entity_properties.artificial_ambient_occlusion
+    )
     entity.tint_value = int(obj.entity_properties.tint_value)
 
     return entity
+
 
 # TODO: This needs more work for non occluder object (entities )
 
@@ -115,14 +120,10 @@ def entity_from_obj(obj):
 def calculate_extents(ymap, obj):
     bbmin, bbmax = get_extents(obj)
 
-    ymap.entities_extents_min = get_min_vector(
-        ymap.entities_extents_min, bbmin)
-    ymap.entities_extents_max = get_max_vector(
-        ymap.entities_extents_max, bbmax)
-    ymap.streaming_extents_min = get_min_vector(
-        ymap.streaming_extents_min, bbmin)
-    ymap.streaming_extents_max = get_max_vector(
-        ymap.streaming_extents_max, bbmax)
+    ymap.entities_extents_min = get_min_vector(ymap.entities_extents_min, bbmin)
+    ymap.entities_extents_max = get_max_vector(ymap.entities_extents_max, bbmax)
+    ymap.streaming_extents_min = get_min_vector(ymap.streaming_extents_min, bbmin)
+    ymap.streaming_extents_max = get_max_vector(ymap.streaming_extents_max, bbmax)
 
 
 def cargen_from_obj(obj):
@@ -163,16 +164,23 @@ def ymap_from_object(obj):
 
     for child in obj.children:
         # Entities
-        if export_settings.ymap_exclude_entities == False and child.sollum_type == SollumType.YMAP_ENTITY_GROUP:
+        if (
+            export_settings.ymap_exclude_entities == False
+            and child.sollum_type == SollumType.YMAP_ENTITY_GROUP
+        ):
             for entity in child.children:
                 if entity.sollum_type == SollumType.DRAWABLE:
                     ymap.entities.append(entity_from_obj(entity))
                 else:
                     logger.warning(
-                        f"Object {entity.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.DRAWABLE]} type.")
+                        f"Object {entity.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.DRAWABLE]} type."
+                    )
 
         # Box occluders
-        if export_settings.ymap_box_occluders == False and child.sollum_type == SollumType.YMAP_BOX_OCCLUDER_GROUP:
+        if (
+            export_settings.ymap_box_occluders == False
+            and child.sollum_type == SollumType.YMAP_BOX_OCCLUDER_GROUP
+        ):
             obj.ymap_properties.content_flags_toggle.has_occl = True
 
             for cargen in child.children:
@@ -181,38 +189,47 @@ def ymap_from_object(obj):
                     calculate_extents(ymap, cargen)
                 else:
                     logger.warning(
-                        f"Object {cargen.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_BOX_OCCLUDER]} type.")
+                        f"Object {cargen.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_BOX_OCCLUDER]} type."
+                    )
 
         # Model occluders
-        if export_settings.ymap_model_occluders == False and child.sollum_type == SollumType.YMAP_MODEL_OCCLUDER_GROUP:
+        if (
+            export_settings.ymap_model_occluders == False
+            and child.sollum_type == SollumType.YMAP_MODEL_OCCLUDER_GROUP
+        ):
             obj.ymap_properties.content_flags_toggle.has_occl = True
 
             for model in child.children:
                 if model.sollum_type == SollumType.YMAP_MODEL_OCCLUDER:
                     if len(model.data.vertices) > 256:
                         logger.warning(
-                            f"Object {model.name} has too many vertices and will be skipped. It can not have more than 256 vertices.")
+                            f"Object {model.name} has too many vertices and will be skipped. It can not have more than 256 vertices."
+                        )
                         continue
 
-                    ymap.occlude_models.append(
-                        model_from_obj(model))
+                    ymap.occlude_models.append(model_from_obj(model))
                     calculate_extents(ymap, model)
                 else:
                     logger.warning(
-                        f"Object {model.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_MODEL_OCCLUDER]} type.")
+                        f"Object {model.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_MODEL_OCCLUDER]} type."
+                    )
 
         # TODO: physics_dictionaries
 
         # TODO: time cycle
 
         # Car generators
-        if export_settings.ymap_car_generators == False and child.sollum_type == SollumType.YMAP_CAR_GENERATOR_GROUP:
+        if (
+            export_settings.ymap_car_generators == False
+            and child.sollum_type == SollumType.YMAP_CAR_GENERATOR_GROUP
+        ):
             for cargen in child.children:
                 if cargen.sollum_type == SollumType.YMAP_CAR_GENERATOR:
                     ymap.car_generators.append(cargen_from_obj(cargen))
                 else:
                     logger.warning(
-                        f"Object {cargen.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_CAR_GENERATOR]} type.")
+                        f"Object {cargen.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_CAR_GENERATOR]} type."
+                    )
 
         # TODO: lod ligths
 

--- a/ymap/ymapimport.py
+++ b/ymap/ymapimport.py
@@ -18,18 +18,18 @@ from .. import logger
 def get_mesh_data(model: OccludeModel):
     result = ([], [])
     for i in range(int(model.num_verts_in_bytes / 12)):
-        pos_data: str = model.verts[i * 24:(i * 24) + 24]
-        x = struct.unpack('<f', binascii.a2b_hex(pos_data[:8]))[0]
-        y = struct.unpack('<f', binascii.a2b_hex(pos_data[8:16]))[0]
-        z = struct.unpack('<f', binascii.a2b_hex(pos_data[16:24]))[0]
+        pos_data: str = model.verts[i * 24 : (i * 24) + 24]
+        x = struct.unpack("<f", binascii.a2b_hex(pos_data[:8]))[0]
+        y = struct.unpack("<f", binascii.a2b_hex(pos_data[8:16]))[0]
+        z = struct.unpack("<f", binascii.a2b_hex(pos_data[16:24]))[0]
         result[0].append((x, y, z))
 
-    indicies: str = model.verts[int(model.num_verts_in_bytes * 2):]
+    indicies: str = model.verts[int(model.num_verts_in_bytes * 2) :]
     for i in range(int(model.num_tris - 32768)):
         j = i * 6
-        i0 = int.from_bytes(binascii.a2b_hex(indicies[j:j + 2]), 'little')
-        i1 = int.from_bytes(binascii.a2b_hex(indicies[j + 2:j + 4]), 'little')
-        i2 = int.from_bytes(binascii.a2b_hex(indicies[j + 4:j + 6]), 'little')
+        i0 = int.from_bytes(binascii.a2b_hex(indicies[j : j + 2]), "little")
+        i1 = int.from_bytes(binascii.a2b_hex(indicies[j + 2 : j + 4]), "little")
+        i2 = int.from_bytes(binascii.a2b_hex(indicies[j + 4 : j + 6]), "little")
         result[1].append((i0, i1, i2))
 
     return result
@@ -45,8 +45,12 @@ def apply_entity_properties(obj, entity):
     obj.entity_properties.lod_level = "sollumz_" + entity.lod_level.lower()
     obj.entity_properties.num_children = entity.num_children
     obj.entity_properties.priority_level = "sollumz_" + entity.priority_level.lower()
-    obj.entity_properties.ambient_occlusion_multiplier = entity.ambient_occlusion_multiplier
-    obj.entity_properties.artificial_ambient_occlusion = entity.artificial_ambient_occlusion
+    obj.entity_properties.ambient_occlusion_multiplier = (
+        entity.ambient_occlusion_multiplier
+    )
+    obj.entity_properties.artificial_ambient_occlusion = (
+        entity.artificial_ambient_occlusion
+    )
     obj.entity_properties.tint_value = entity.tint_value
     if entity.type != "CMloInstanceDef":
         # Entities in YMAPs need rotation inverted
@@ -70,15 +74,17 @@ def entity_to_obj(ymap_obj: bpy.types.Object, ymap: CMapData):
     if ymap.entities:
         for obj in bpy.context.collection.all_objects:
             for entity in ymap.entities:
-                if entity.archetype_name == obj.name and obj.name in bpy.context.view_layer.objects:
+                if (
+                    entity.archetype_name == obj.name
+                    and obj.name in bpy.context.view_layer.objects
+                ):
                     found = True
                     apply_entity_properties(obj, entity)
         if found:
             logger.info(f"Succesfully imported: {ymap.name}.ymap")
             return True
         else:
-            logger.info(
-                f"No entities from '{ymap.name}.ymap' exist in the view layer!")
+            logger.info(f"No entities from '{ymap.name}.ymap' exist in the view layer!")
             return False
     else:
         logger.error(f"{ymap.name}.ymap contains no entities to import!")
@@ -106,7 +112,10 @@ def instanced_entity_to_obj(ymap_obj: bpy.types.Object, ymap: CMapData):
         for obj in existing_objects:
             for entity in ymap.entities:
                 if entity.archetype_name == obj.name:
-                    if obj.sollum_type == SollumType.DRAWABLE or obj.sollum_type == SollumType.FRAGMENT:
+                    if (
+                        obj.sollum_type == SollumType.DRAWABLE
+                        or obj.sollum_type == SollumType.FRAGMENT
+                    ):
                         new_obj = duplicate_object_with_children(obj)
                         apply_entity_properties(new_obj, entity)
                         new_obj.parent = group_obj
@@ -114,7 +123,8 @@ def instanced_entity_to_obj(ymap_obj: bpy.types.Object, ymap: CMapData):
                         entity.found = True
                     else:
                         logger.error(
-                            f"Cannot use your '{obj.name}' object because it is not a 'Drawable' type!")
+                            f"Cannot use your '{obj.name}' object because it is not a 'Drawable' type!"
+                        )
 
         # Creating empty entity if no object was found for reference, and notify user
         import_settings = get_import_settings()
@@ -123,19 +133,23 @@ def instanced_entity_to_obj(ymap_obj: bpy.types.Object, ymap: CMapData):
             for entity in ymap.entities:
                 if entity.found is None:
                     empty_obj = bpy.data.objects.new(
-                        entity.archetype_name + " (not found)", None)
+                        entity.archetype_name + " (not found)", None
+                    )
                     empty_obj.parent = group_obj
                     apply_entity_properties(empty_obj, entity)
                     empty_obj.sollum_type = SollumType.DRAWABLE
                     logger.error(
-                        f"'{entity.archetype_name}' is missing in scene, creating an empty drawable instead.")
+                        f"'{entity.archetype_name}' is missing in scene, creating an empty drawable instead."
+                    )
         if count > 0:
             logger.info(
-                f"Succesfully placed {count}/{entities_amount} entities from scene!")
+                f"Succesfully placed {count}/{entities_amount} entities from scene!"
+            )
             return group_obj
         else:
             logger.info(
-                f"No entity from '{ymap_obj.name}.ymap' exist in the view layer!")
+                f"No entity from '{ymap_obj.name}.ymap' exist in the view layer!"
+            )
             return False
     else:
         logger.error(f"{ymap_obj.name}.ymap doesn't contains any entity!")
@@ -159,10 +173,8 @@ def box_to_obj(obj, ymap: CMapData):
         box_obj = bpy.context.view_layer.objects.active
         box_obj.sollum_type = SollumType.YMAP_BOX_OCCLUDER
         box_obj.name = "Box"
-        box_obj.active_material = add_occluder_material(
-            SollumType.YMAP_BOX_OCCLUDER)
-        box_obj.location = Vector(
-            [box.center_x, box.center_y, box.center_z]) / 4
+        box_obj.active_material = add_occluder_material(SollumType.YMAP_BOX_OCCLUDER)
+        box_obj.location = Vector([box.center_x, box.center_y, box.center_z]) / 4
         box_obj.rotation_euler[2] = math.atan2(box.cos_z, box.sin_z)
         box_obj.scale = Vector([box.length, box.width, box.height]) / 4
         box_obj.parent = group_obj
@@ -171,7 +183,7 @@ def box_to_obj(obj, ymap: CMapData):
 
 
 def model_to_obj(obj: bpy.types.Object, ymap: CMapData):
-    group_obj = bpy.data.objects.new('Model Occluders', None)
+    group_obj = bpy.data.objects.new("Model Occluders", None)
     group_obj.parent = obj
     group_obj.sollum_type = SollumType.YMAP_MODEL_OCCLUDER_GROUP
     group_obj.lock_location = (True, True, True)
@@ -190,7 +202,8 @@ def model_to_obj(obj: bpy.types.Object, ymap: CMapData):
         model_obj.sollum_type = SollumType.YMAP_MODEL_OCCLUDER
         model_obj.ymap_properties.flags = model.flags
         model_obj.active_material = add_occluder_material(
-            SollumType.YMAP_MODEL_OCCLUDER)
+            SollumType.YMAP_MODEL_OCCLUDER
+        )
         bpy.context.collection.objects.link(model_obj)
         bpy.context.view_layer.objects.active = model_obj
         mesh.from_pydata(verts, [], faces)
@@ -213,11 +226,12 @@ def cargen_to_obj(obj: bpy.types.Object, ymap: CMapData):
     cargen_ref_mesh = import_cargen_mesh()
 
     for cargen in ymap.car_generators:
-        cargen_obj = bpy.data.objects.new(
-            "Car Generator", object_data=cargen_ref_mesh)
+        cargen_obj = bpy.data.objects.new("Car Generator", object_data=cargen_ref_mesh)
         cargen_obj.ymap_cargen_properties.orient_x = cargen.orient_x
         cargen_obj.ymap_cargen_properties.orient_y = cargen.orient_y
-        cargen_obj.ymap_cargen_properties.perpendicular_length = cargen.perpendicular_length
+        cargen_obj.ymap_cargen_properties.perpendicular_length = (
+            cargen.perpendicular_length
+        )
         cargen_obj.ymap_cargen_properties.car_model = cargen.car_model
         cargen_obj.ymap_cargen_properties.flags = cargen.flags
         cargen_obj.ymap_cargen_properties.body_color_remap_1 = cargen.body_color_remap_1
@@ -313,8 +327,7 @@ def import_ymap(filepath):
     found = False
     for obj in bpy.context.scene.objects:
         if obj.sollum_type == SollumType.YMAP and obj.name == ymap_xml.name:
-            logger.error(
-                f"{ymap_xml.name} is already existing in the scene. Aborting.")
+            logger.error(f"{ymap_xml.name} is already existing in the scene. Aborting.")
             found = True
             break
     if not found:

--- a/ynv/properties.py
+++ b/ynv/properties.py
@@ -3,9 +3,8 @@ import bpy
 
 def register():
     bpy.types.Object.poly_flags = bpy.props.CollectionProperty(
-        type=bpy.props.StringProperty)
-
-
+        type=bpy.props.StringProperty
+    )
 
 
 def unregister():

--- a/ynv/ynvimport.py
+++ b/ynv/ynvimport.py
@@ -13,7 +13,8 @@ def points_to_obj(points):
     for idx, point in enumerate(points):
         mesh = bpy.data.meshes.new(SOLLUMZ_UI_NAMES[SollumType.NAVMESH_POINT])
         obj = bpy.data.objects.new(
-            SOLLUMZ_UI_NAMES[SollumType.NAVMESH_POINT] + " " + str(idx), mesh)
+            SOLLUMZ_UI_NAMES[SollumType.NAVMESH_POINT] + " " + str(idx), mesh
+        )
         obj.sollum_type = SollumType.NAVMESH_POINT
         obj.parent = pobj
 
@@ -40,7 +41,8 @@ def portals_to_obj(portals):
         toobj = bpy.data.objects.new("to", tomesh)
         toobj.location = portal.position_to
         obj = bpy.data.objects.new(
-            SOLLUMZ_UI_NAMES[SollumType.NAVMESH_PORTAL] + " " + str(idx), tomesh)
+            SOLLUMZ_UI_NAMES[SollumType.NAVMESH_PORTAL] + " " + str(idx), tomesh
+        )
         obj.sollum_type = SollumType.NAVMESH_PORTAL
         fromobj.parent = obj
         toobj.parent = obj
@@ -97,8 +99,7 @@ def get_material(flags):
         g = 0.2
 
     bsdf, _ = find_bsdf_and_material_output(mat)
-    bsdf.inputs[0].default_value = (
-        r, g, b, 0.75)
+    bsdf.inputs[0].default_value = (r, g, b, 0.75)
     return mat
 
 
@@ -127,8 +128,7 @@ def polygons_to_obj(polygons):
 
     mesh = bpy.data.meshes.new(SOLLUMZ_UI_NAMES[SollumType.NAVMESH_POLY_MESH])
     mesh.from_pydata(verts, [], indices)
-    obj = bpy.data.objects.new(
-        SOLLUMZ_UI_NAMES[SollumType.NAVMESH_POLY_MESH], mesh)
+    obj = bpy.data.objects.new(SOLLUMZ_UI_NAMES[SollumType.NAVMESH_POLY_MESH], mesh)
     obj.sollum_type = SollumType.NAVMESH_POLY_MESH
 
     for mat in mats:

--- a/ytyp/gizmos/extensions.py
+++ b/ytyp/gizmos/extensions.py
@@ -15,7 +15,9 @@ from ..properties.extensions import ExtensionType, ExtensionProperties
 DEBUG_DRAW = False
 
 
-def iter_archetype_extensions(context) -> Iterator[tuple[ArchetypeProperties, ExtensionProperties]]:
+def iter_archetype_extensions(
+    context,
+) -> Iterator[tuple[ArchetypeProperties, ExtensionProperties]]:
     """Iterate visible archetype extensions from the selected YTYP."""
     selected_ytyp = get_selected_ytyp(context)
     if selected_ytyp is None:
@@ -60,7 +62,9 @@ def get_extension_shapes() -> dict[ExtensionType, object]:
                     model_verts.append(verts[int(v1) - 1])
                     model_verts.append(verts[int(v2) - 1])
 
-            shapes[extension_type] = bpy.types.Gizmo.new_custom_shape("TRIS", model_verts)
+            shapes[extension_type] = bpy.types.Gizmo.new_custom_shape(
+                "TRIS", model_verts
+            )
 
     for ext_type, model_file_name in (
         (ExtensionType.AUDIO_COLLISION, "AudioCollisionSettings.obj"),
@@ -84,42 +88,68 @@ def get_extension_shapes() -> dict[ExtensionType, object]:
 @functools.cache
 def get_cube_shape() -> object:
     """A 1x1x1 cube with origin in the middle."""
-    return bpy.types.Gizmo.new_custom_shape("LINES", (
-        # bottom face
-        (-0.5, -0.5, -0.5), (-0.5, 0.5, -0.5),
-        (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5),
-        (0.5, -0.5, -0.5), (0.5, 0.5, -0.5),
-        (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5),
-        # top face
-        (-0.5, -0.5, 0.5), (-0.5, 0.5, 0.5),
-        (-0.5, -0.5, 0.5), (0.5, -0.5, 0.5),
-        (0.5, -0.5, 0.5), (0.5, 0.5, 0.5),
-        (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5),
-        # connect top and bottom faces
-        (-0.5, -0.5, -0.5), (-0.5, -0.5, 0.5),
-        (-0.5, 0.5, -0.5), (-0.5, 0.5, 0.5),
-        (0.5, -0.5, -0.5), (0.5, -0.5, 0.5),
-        (0.5, 0.5, -0.5), (0.5, 0.5, 0.5),
-    ))
+    return bpy.types.Gizmo.new_custom_shape(
+        "LINES",
+        (
+            # bottom face
+            (-0.5, -0.5, -0.5),
+            (-0.5, 0.5, -0.5),
+            (-0.5, -0.5, -0.5),
+            (0.5, -0.5, -0.5),
+            (0.5, -0.5, -0.5),
+            (0.5, 0.5, -0.5),
+            (-0.5, 0.5, -0.5),
+            (0.5, 0.5, -0.5),
+            # top face
+            (-0.5, -0.5, 0.5),
+            (-0.5, 0.5, 0.5),
+            (-0.5, -0.5, 0.5),
+            (0.5, -0.5, 0.5),
+            (0.5, -0.5, 0.5),
+            (0.5, 0.5, 0.5),
+            (-0.5, 0.5, 0.5),
+            (0.5, 0.5, 0.5),
+            # connect top and bottom faces
+            (-0.5, -0.5, -0.5),
+            (-0.5, -0.5, 0.5),
+            (-0.5, 0.5, -0.5),
+            (-0.5, 0.5, 0.5),
+            (0.5, -0.5, -0.5),
+            (0.5, -0.5, 0.5),
+            (0.5, 0.5, -0.5),
+            (0.5, 0.5, 0.5),
+        ),
+    )
 
 
 @functools.cache
 def get_square_shape() -> object:
     """A 1x1 square, along XZ plane, with origin in the middle."""
-    return bpy.types.Gizmo.new_custom_shape("LINES", (
-        (-0.5, 0.0, -0.5), (0.5, 0.0, -0.5),
-        (-0.5, 0.0, -0.5), (-0.5, 0.0, 0.5),
-        (0.5, 0.0, 0.5), (0.5, 0.0, -0.5),
-        (0.5, 0.0, 0.5), (-0.5, 0.0, 0.5),
-    ))
+    return bpy.types.Gizmo.new_custom_shape(
+        "LINES",
+        (
+            (-0.5, 0.0, -0.5),
+            (0.5, 0.0, -0.5),
+            (-0.5, 0.0, -0.5),
+            (-0.5, 0.0, 0.5),
+            (0.5, 0.0, 0.5),
+            (0.5, 0.0, -0.5),
+            (0.5, 0.0, 0.5),
+            (-0.5, 0.0, 0.5),
+        ),
+    )
 
 
 @functools.cache
 def get_line_shape() -> object:
     """A unit line along Y axis, from Y=0 to Y=1."""
-    return bpy.types.Gizmo.new_custom_shape("LINES", (
-        (0.0, 0.0, 0.0), (0.0, 1.0, 0.0),
-    ))
+    return bpy.types.Gizmo.new_custom_shape(
+        "LINES",
+        (
+            (0.0, 0.0, 0.0),
+            (0.0, 1.0, 0.0),
+        ),
+    )
 
 
 @functools.cache
@@ -127,24 +157,40 @@ def get_ladder_shape() -> object:
     """Shape representing a ladder with a marker in-front to indicate its orientation.
     Origin is at the bottom and extends upwards.
     """
-    return bpy.types.Gizmo.new_custom_shape("LINES", (
-        # pillars
-        (-0.15, 0.0, -0.04), (-0.15, 0.0, 1.04),
-        (0.15, 0.0, -0.04), (0.15, 0.0, 1.04),
-        # steps
-        (-0.15, 0.0, 0.0), (0.15, 0.0, 0.0),
-        (-0.15, 0.0, 0.25), (0.15, 0.0, 0.25),
-        (-0.15, 0.0, 0.5), (0.15, 0.0, 0.5),
-        (-0.15, 0.0, 0.75), (0.15, 0.0, 0.75),
-        (-0.15, 0.0, 1.0), (0.15, 0.0, 1.0),
-        # front marker
-        (-0.2, 0.25, 0.2), (0.0, 0.1, 0.2),
-        (0.2, 0.25, 0.2), (0.0, 0.1, 0.2),
-        (-0.2, 0.25, 0.2), (0.2, 0.25, 0.2),
-        (-0.2, 0.25, 0.2), (-0.2, 0.45, 0.2),
-        (0.2, 0.25, 0.2), (0.2, 0.45, 0.2),
-        (-0.2, 0.45, 0.2), (0.2, 0.45, 0.2),
-    ))
+    return bpy.types.Gizmo.new_custom_shape(
+        "LINES",
+        (
+            # pillars
+            (-0.15, 0.0, -0.04),
+            (-0.15, 0.0, 1.04),
+            (0.15, 0.0, -0.04),
+            (0.15, 0.0, 1.04),
+            # steps
+            (-0.15, 0.0, 0.0),
+            (0.15, 0.0, 0.0),
+            (-0.15, 0.0, 0.25),
+            (0.15, 0.0, 0.25),
+            (-0.15, 0.0, 0.5),
+            (0.15, 0.0, 0.5),
+            (-0.15, 0.0, 0.75),
+            (0.15, 0.0, 0.75),
+            (-0.15, 0.0, 1.0),
+            (0.15, 0.0, 1.0),
+            # front marker
+            (-0.2, 0.25, 0.2),
+            (0.0, 0.1, 0.2),
+            (0.2, 0.25, 0.2),
+            (0.0, 0.1, 0.2),
+            (-0.2, 0.25, 0.2),
+            (0.2, 0.25, 0.2),
+            (-0.2, 0.25, 0.2),
+            (-0.2, 0.45, 0.2),
+            (0.2, 0.25, 0.2),
+            (0.2, 0.45, 0.2),
+            (-0.2, 0.45, 0.2),
+            (0.2, 0.45, 0.2),
+        ),
+    )
 
 
 def is_local_transform(context) -> bool:
@@ -215,7 +261,9 @@ def get_extension_ladder_bottom_offset_matrix(ext: ExtensionProperties) -> Matri
     return Matrix.LocRotScale(offset_pos, offset_rot, (1.0, 1.0, 1.0))
 
 
-def get_extension_world_matrix(ext: ExtensionProperties, archetype: ArchetypeProperties) -> Matrix:
+def get_extension_world_matrix(
+    ext: ExtensionProperties, archetype: ArchetypeProperties
+) -> Matrix:
     offset_mat = get_extension_offset_matrix(ext)
     if archetype.asset is None:
         return offset_mat
@@ -223,7 +271,9 @@ def get_extension_world_matrix(ext: ExtensionProperties, archetype: ArchetypePro
         return archetype.asset.matrix_world @ offset_mat
 
 
-def get_extension_ladder_bottom_world_matrix(ext: ExtensionProperties, archetype: ArchetypeProperties) -> Matrix:
+def get_extension_ladder_bottom_world_matrix(
+    ext: ExtensionProperties, archetype: ArchetypeProperties
+) -> Matrix:
     offset_mat = get_extension_ladder_bottom_offset_matrix(ext)
     if archetype.asset is None:
         return offset_mat
@@ -250,7 +300,7 @@ def get_transform_axis(
     ext: ExtensionProperties,
     archetype: ArchetypeProperties,
     axis: Literal["X", "Y", "Z"],
-    local: bool = False
+    local: bool = False,
 ) -> Vector:
     if axis == "X":
         axis_vec = Vector((1.0, 0.0, 0.0))
@@ -305,7 +355,9 @@ class SOLLUMZ_GT_archetype_extension(bpy.types.Gizmo):
 
         theme = context.preferences.themes[0]
 
-        self.color = theme.view_3d.object_active if is_active else theme.view_3d.object_selected
+        self.color = (
+            theme.view_3d.object_active if is_active else theme.view_3d.object_selected
+        )
         self.color_highlight = self.color
         self.alpha = 0.6
         self.alpha_highlight = 0.8
@@ -316,7 +368,11 @@ class SOLLUMZ_GT_archetype_extension(bpy.types.Gizmo):
         extension_shape = get_extension_shapes().get(ext.extension_type, None)
 
         if is_active and not is_light_shaft:
-            self.draw_custom_shape(get_cube_shape(), matrix=gizmo_matrix @ Matrix.Scale(0.4, 4), select_id=select_id)
+            self.draw_custom_shape(
+                get_cube_shape(),
+                matrix=gizmo_matrix @ Matrix.Scale(0.4, 4),
+                select_id=select_id,
+            )
 
         if extension_shape is not None:
             rv3d = context.space_data.region_3d
@@ -324,26 +380,43 @@ class SOLLUMZ_GT_archetype_extension(bpy.types.Gizmo):
             # make extension shape face the camera so it is recognizable from all view angles
             ext_shape_loc = gizmo_matrix.to_translation()
             if rv3d.is_perspective:
-                ext_shape_dir = (rv3d.view_matrix.inverted().to_translation() - ext_shape_loc)
+                ext_shape_dir = (
+                    rv3d.view_matrix.inverted().to_translation() - ext_shape_loc
+                )
                 ext_shape_dir.normalize()
                 ext_shape_rot = ext_shape_dir.to_track_quat("Z", "Y")
             else:
                 ext_shape_rot = rv3d.view_rotation
-            ext_shape_rot = ext_shape_rot @ Matrix.Rotation(math.radians(90.0), 3, "Y").to_quaternion()
+            ext_shape_rot = (
+                ext_shape_rot
+                @ Matrix.Rotation(math.radians(90.0), 3, "Y").to_quaternion()
+            )
             ext_shape_scale = 0.55, 0.55, 0.55
             if is_light_shaft:
                 # Scale based on light shaft size
-                light_shaft_width, light_shaft_height = get_extension_light_shaft_dimensions(ext)
+                (
+                    light_shaft_width,
+                    light_shaft_height,
+                ) = get_extension_light_shaft_dimensions(ext)
                 size = min(light_shaft_width, light_shaft_height)
                 scale = max(size / 2.0, 0.05)
                 ext_shape_scale = scale, scale, scale
-            ext_shape_mat = Matrix.LocRotScale(ext_shape_loc, ext_shape_rot, ext_shape_scale)
+            ext_shape_mat = Matrix.LocRotScale(
+                ext_shape_loc, ext_shape_rot, ext_shape_scale
+            )
 
-            self.draw_custom_shape(extension_shape, matrix=ext_shape_mat, select_id=select_id)
+            self.draw_custom_shape(
+                extension_shape, matrix=ext_shape_mat, select_id=select_id
+            )
 
         if hasattr(ext_props, "offset_rotation"):
-            self.draw_preset_arrow(gizmo_matrix @ Matrix.Translation((0.0, 0.25, 0.0)) @ Matrix.Scale(0.325, 4),
-                                   axis="POS_Y", select_id=-1 if select_id is None else select_id)
+            self.draw_preset_arrow(
+                gizmo_matrix
+                @ Matrix.Translation((0.0, 0.25, 0.0))
+                @ Matrix.Scale(0.325, 4),
+                axis="POS_Y",
+                select_id=-1 if select_id is None else select_id,
+            )
 
         if is_ladder:
             self.draw_ladder_gizmo(context, select_id)
@@ -361,12 +434,18 @@ class SOLLUMZ_GT_archetype_extension(bpy.types.Gizmo):
         normal = ext_props.normal.normalized()
         offset_rot_mat = normal.to_track_quat("Y", "Z").to_matrix().to_4x4()
 
-        bottom_matrix = asset.matrix_world @ Matrix.Translation(ext_props.bottom) @ offset_rot_mat
-        self.draw_preset_box(bottom_matrix @ Matrix.Scale(0.05, 4), select_id=select_id_int)
+        bottom_matrix = (
+            asset.matrix_world @ Matrix.Translation(ext_props.bottom) @ offset_rot_mat
+        )
+        self.draw_preset_box(
+            bottom_matrix @ Matrix.Scale(0.05, 4), select_id=select_id_int
+        )
 
         length = (ext_props.top - ext_props.bottom).length
         ladder_shape_matrix = bottom_matrix @ Matrix.Scale(length, 4, (0.0, 0.0, 1.0))
-        self.draw_custom_shape(get_ladder_shape(), matrix=ladder_shape_matrix, select_id=select_id)
+        self.draw_custom_shape(
+            get_ladder_shape(), matrix=ladder_shape_matrix, select_id=select_id
+        )
 
     def draw_light_shaft_gizmo(self, context, select_id):
         selected_archetype = get_selected_archetype(context)
@@ -391,54 +470,101 @@ class SOLLUMZ_GT_archetype_extension(bpy.types.Gizmo):
 
         width = (b - a).length
         height = (d - a).length
-        scale_mat = Matrix(((width, 0.0, 0.0, 0.0),
-                            (0.0, 1.0, 0.0, 0.0),
-                            (0.0, 0.0, height, 0.0),
-                            (0.0, 0.0, 0.0, 1.0)))
-        light_shaft_frame_matrix = asset.matrix_world @ translation_mat @ rotation_mat @ scale_mat
-        light_shaft_frame_end_matrix = Matrix.Translation(
-            ext_props.direction * ext_props.length) @ light_shaft_frame_matrix
+        scale_mat = Matrix(
+            (
+                (width, 0.0, 0.0, 0.0),
+                (0.0, 1.0, 0.0, 0.0),
+                (0.0, 0.0, height, 0.0),
+                (0.0, 0.0, 0.0, 1.0),
+            )
+        )
+        light_shaft_frame_matrix = (
+            asset.matrix_world @ translation_mat @ rotation_mat @ scale_mat
+        )
+        light_shaft_frame_end_matrix = (
+            Matrix.Translation(ext_props.direction * ext_props.length)
+            @ light_shaft_frame_matrix
+        )
 
         if not is_active:
-            self.draw_custom_shape(get_square_shape(), matrix=light_shaft_frame_matrix, select_id=select_id)
-            self.draw_custom_shape(get_square_shape(), matrix=light_shaft_frame_end_matrix, select_id=select_id)
+            self.draw_custom_shape(
+                get_square_shape(), matrix=light_shaft_frame_matrix, select_id=select_id
+            )
+            self.draw_custom_shape(
+                get_square_shape(),
+                matrix=light_shaft_frame_end_matrix,
+                select_id=select_id,
+            )
 
-        direction_rotation_mat = ext_props.direction.to_track_quat("Y", "Z").to_matrix().to_4x4()
+        direction_rotation_mat = (
+            ext_props.direction.to_track_quat("Y", "Z").to_matrix().to_4x4()
+        )
         direction_scale_mat = Matrix.Scale(ext_props.length, 4, (0.0, 1.0, 0.0))
 
         line_shape = get_line_shape()
 
         def _calc_line_matrix(corner: Vector) -> Matrix:
-            return asset.matrix_world @  Matrix.Translation(corner) @ direction_rotation_mat @ direction_scale_mat
-        self.draw_custom_shape(line_shape, matrix=_calc_line_matrix(a), select_id=select_id)
-        self.draw_custom_shape(line_shape, matrix=_calc_line_matrix(b), select_id=select_id)
-        self.draw_custom_shape(line_shape, matrix=_calc_line_matrix(c), select_id=select_id)
-        self.draw_custom_shape(line_shape, matrix=_calc_line_matrix(d), select_id=select_id)
+            return (
+                asset.matrix_world
+                @ Matrix.Translation(corner)
+                @ direction_rotation_mat
+                @ direction_scale_mat
+            )
+
+        self.draw_custom_shape(
+            line_shape, matrix=_calc_line_matrix(a), select_id=select_id
+        )
+        self.draw_custom_shape(
+            line_shape, matrix=_calc_line_matrix(b), select_id=select_id
+        )
+        self.draw_custom_shape(
+            line_shape, matrix=_calc_line_matrix(c), select_id=select_id
+        )
+        self.draw_custom_shape(
+            line_shape, matrix=_calc_line_matrix(d), select_id=select_id
+        )
 
         if DEBUG_DRAW:
             self.color = 1.0, 0.0, 0.0
-            self.draw_preset_box(asset.matrix_world @  Matrix.Translation(a) @ Matrix.Scale(0.015, 4),
-                                 select_id=select_id_int)
+            self.draw_preset_box(
+                asset.matrix_world @ Matrix.Translation(a) @ Matrix.Scale(0.015, 4),
+                select_id=select_id_int,
+            )
             self.color = 0.0, 1.0, 0.0
-            self.draw_preset_box(asset.matrix_world @  Matrix.Translation(b) @ Matrix.Scale(0.015, 4),
-                                 select_id=select_id_int)
+            self.draw_preset_box(
+                asset.matrix_world @ Matrix.Translation(b) @ Matrix.Scale(0.015, 4),
+                select_id=select_id_int,
+            )
             self.color = 0.0, 0.0, 1.0
-            self.draw_preset_box(asset.matrix_world @  Matrix.Translation(c) @ Matrix.Scale(0.015, 4),
-                                 select_id=select_id_int)
+            self.draw_preset_box(
+                asset.matrix_world @ Matrix.Translation(c) @ Matrix.Scale(0.015, 4),
+                select_id=select_id_int,
+            )
             self.color = 1.0, 1.0, 1.0
-            self.draw_preset_box(asset.matrix_world @  Matrix.Translation(d) @ Matrix.Scale(0.015, 4),
-                                 select_id=select_id_int)
+            self.draw_preset_box(
+                asset.matrix_world @ Matrix.Translation(d) @ Matrix.Scale(0.015, 4),
+                select_id=select_id_int,
+            )
 
             sc = Matrix.Scale(0.5, 4)
             self.color = 1.0, 0.0, 0.0
-            self.draw_preset_arrow(asset.matrix_world @ translation_mat @ rotation_mat @ sc, axis="POS_X",
-                                   select_id=select_id_int)
+            self.draw_preset_arrow(
+                asset.matrix_world @ translation_mat @ rotation_mat @ sc,
+                axis="POS_X",
+                select_id=select_id_int,
+            )
             self.color = 0.0, 1.0, 0.0
-            self.draw_preset_arrow(asset.matrix_world @ translation_mat @ rotation_mat @ sc, axis="POS_Y",
-                                   select_id=select_id_int)
+            self.draw_preset_arrow(
+                asset.matrix_world @ translation_mat @ rotation_mat @ sc,
+                axis="POS_Y",
+                select_id=select_id_int,
+            )
             self.color = 0.0, 0.0, 1.0
-            self.draw_preset_arrow(asset.matrix_world @ translation_mat @ rotation_mat @ sc, axis="POS_Z",
-                                   select_id=select_id_int)
+            self.draw_preset_arrow(
+                asset.matrix_world @ translation_mat @ rotation_mat @ sc,
+                axis="POS_Z",
+                select_id=select_id_int,
+            )
 
     def invoke(self, context, event):
         selected_ytyp = get_selected_ytyp(context)
@@ -451,9 +577,11 @@ class SOLLUMZ_GT_archetype_extension(bpy.types.Gizmo):
         if self.linked_extension not in extensions:
             return {"PASS_THROUGH"}
 
-        bpy.ops.sollumz.extension_select(True,
-                                         archetype_index=archetypes.index(self.linked_archetype),
-                                         extension_index=extensions.index(self.linked_extension))
+        bpy.ops.sollumz.extension_select(
+            True,
+            archetype_index=archetypes.index(self.linked_archetype),
+            extension_index=extensions.index(self.linked_extension),
+        )
         return {"PASS_THROUGH"}
 
     def modal(self, context, event, tweak):
@@ -486,7 +614,9 @@ class SOLLUMZ_OT_extension_translate(bpy.types.Operator):
     bl_description = bl_label
     bl_options = {"UNDO_GROUPED", "INTERNAL"}
 
-    delta_position: bpy.props.FloatVectorProperty(name="Delta Position", subtype="TRANSLATION", size=3)
+    delta_position: bpy.props.FloatVectorProperty(
+        name="Delta Position", subtype="TRANSLATION", size=3
+    )
 
     def execute(self, context):
         ext = get_selected_extension(context)
@@ -503,7 +633,12 @@ class SOLLUMZ_OT_extension_translate(bpy.types.Operator):
 
             if ext.extension_type == ExtensionType.LIGHT_SHAFT:
                 # move light shaft corners along with the offset_position
-                for c in (ext_props.cornerA, ext_props.cornerB, ext_props.cornerC, ext_props.cornerD):
+                for c in (
+                    ext_props.cornerA,
+                    ext_props.cornerB,
+                    ext_props.cornerC,
+                    ext_props.cornerD,
+                ):
                     c += self.delta_position
         return {"FINISHED"}
 
@@ -514,7 +649,9 @@ class SOLLUMZ_OT_extension_rotate(bpy.types.Operator):
     bl_description = bl_label
     bl_options = {"UNDO_GROUPED", "INTERNAL"}
 
-    delta_rotation: bpy.props.FloatVectorProperty(name="Delta Rotation", subtype="QUATERNION", size=4)
+    delta_rotation: bpy.props.FloatVectorProperty(
+        name="Delta Rotation", subtype="QUATERNION", size=4
+    )
 
     def execute(self, context):
         ext = get_selected_extension(context)
@@ -634,7 +771,9 @@ class SOLLUMZ_OT_extension_offset_light_shaft_end_point(bpy.types.Operator):
     bl_description = bl_label
     bl_options = {"UNDO_GROUPED", "INTERNAL"}
 
-    delta_offset: bpy.props.FloatVectorProperty(name="Delta Offset", subtype="TRANSLATION", size=2)
+    delta_offset: bpy.props.FloatVectorProperty(
+        name="Delta Offset", subtype="TRANSLATION", size=2
+    )
 
     def execute(self, context):
         ext = get_selected_extension(context)
@@ -662,6 +801,7 @@ class SOLLUMZ_OT_extension_offset_light_shaft_end_point(bpy.types.Operator):
 
 class SOLLUMZ_OT_archetype_extensions_detect_ctrl_pressed(bpy.types.Operator):
     """Operator that runs as modal in the background to detect when CTRL is pressed down."""
+
     bl_idname = "sollumz.archetype_extensions_detect_ctrl_pressed"
     bl_label = "DetectCtrlPressed"
     bl_options = {"INTERNAL"}
@@ -674,7 +814,9 @@ class SOLLUMZ_OT_archetype_extensions_detect_ctrl_pressed(bpy.types.Operator):
         tool = context.workspace.tools.from_space_view3d_mode(context.mode)
         if tool.idname != "sollumz.archetype_extension":
             return {"FINISHED"}
-        gg_props = tool.gizmo_group_properties(SOLLUMZ_GGT_archetype_extensions.bl_idname)
+        gg_props = tool.gizmo_group_properties(
+            SOLLUMZ_GGT_archetype_extensions.bl_idname
+        )
         gg_props.ctrl_pressed = event.ctrl
         return {"PASS_THROUGH"}
 
@@ -694,7 +836,9 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
         This returns the struct that holds the properties."""
         context = bpy.context
         tool = context.workspace.tools.from_space_view3d_mode(context.mode)
-        gg_props = tool.gizmo_group_properties(SOLLUMZ_GGT_archetype_extensions.bl_idname)
+        gg_props = tool.gizmo_group_properties(
+            SOLLUMZ_GGT_archetype_extensions.bl_idname
+        )
         return gg_props
 
     @classmethod
@@ -702,16 +846,28 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
         return can_draw_gizmos(context)
 
     def translate_extension(self, context, offset: float, axis: Literal["X", "Y", "Z"]):
-        axis_vec = get_transform_axis(get_selected_extension(context), get_selected_archetype(context), axis,
-                                      local=is_local_transform(context))
+        axis_vec = get_transform_axis(
+            get_selected_extension(context),
+            get_selected_archetype(context),
+            axis,
+            local=is_local_transform(context),
+        )
 
         bpy.ops.sollumz.extension_translate(True, delta_position=axis_vec * offset)
 
-    def rotate_extension(self, context, delta_angle: float, axis: Literal["X", "Y", "Z"]):
-        axis_vec = get_transform_axis(get_selected_extension(context), get_selected_archetype(context), axis,
-                                      local=is_local_transform(context))
+    def rotate_extension(
+        self, context, delta_angle: float, axis: Literal["X", "Y", "Z"]
+    ):
+        axis_vec = get_transform_axis(
+            get_selected_extension(context),
+            get_selected_archetype(context),
+            axis,
+            local=is_local_transform(context),
+        )
 
-        bpy.ops.sollumz.extension_rotate(True, delta_rotation=Quaternion(axis_vec, delta_angle))
+        bpy.ops.sollumz.extension_rotate(
+            True, delta_rotation=Quaternion(axis_vec, delta_angle)
+        )
 
         self.draw_prepare(context)  # refresh view to update dial rotation
 
@@ -731,19 +887,25 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
 
         bpy.ops.sollumz.extension_translate_ladder_bottom_z(True, delta_z=delta_z)
 
-    def scale_extension_light_shaft_frame(self, context, width_scale: float, height_scale: float):
+    def scale_extension_light_shaft_frame(
+        self, context, width_scale: float, height_scale: float
+    ):
         ext = get_selected_extension(context)
         if ext.extension_type != ExtensionType.LIGHT_SHAFT:
             return
 
-        bpy.ops.sollumz.extension_scale_light_shaft_frame(True, width_scale=width_scale, height_scale=height_scale)
+        bpy.ops.sollumz.extension_scale_light_shaft_frame(
+            True, width_scale=width_scale, height_scale=height_scale
+        )
 
     def offset_light_shaft_end_point(self, context, delta_offset: Vector):
         ext = get_selected_extension(context)
         if ext.extension_type != ExtensionType.LIGHT_SHAFT:
             return
 
-        bpy.ops.sollumz.extension_offset_light_shaft_end_point(True, delta_offset=delta_offset)
+        bpy.ops.sollumz.extension_offset_light_shaft_end_point(
+            True, delta_offset=delta_offset
+        )
 
     def get_extension_light_shaft_cage_world_transform(self, context) -> Matrix:
         # Matrix transform with position in the center of the light shaft frame instead
@@ -855,7 +1017,9 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
         self.rotate_extension_ladder_normal(bpy.context, -delta_angle)
 
     def handler_get_light_shaft_transform(self):
-        return [v for row in self.light_shaft_cage_last_transform.transposed() for v in row]
+        return [
+            v for row in self.light_shaft_cage_last_transform.transposed() for v in row
+        ]
 
     def handler_set_light_shaft_transform(self, value):
         m = Matrix((value[0:4], value[4:8], value[8:12], value[12:16]))
@@ -864,11 +1028,19 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
         delta_transform = self.light_shaft_cage_last_transform.inverted() @ m
         self.light_shaft_cage_last_transform = m
 
-        delta_width_scale, delta_height_scale, _ = delta_transform.to_3x3() @ Vector((1.0, 1.0, 0.0))
-        self.scale_extension_light_shaft_frame(bpy.context, delta_width_scale, delta_height_scale)
+        delta_width_scale, delta_height_scale, _ = delta_transform.to_3x3() @ Vector(
+            (1.0, 1.0, 0.0)
+        )
+        self.scale_extension_light_shaft_frame(
+            bpy.context, delta_width_scale, delta_height_scale
+        )
 
     def handler_get_light_shaft_end_transform(self):
-        return [v for row in self.light_shaft_cage_end_last_transform.transposed() for v in row]
+        return [
+            v
+            for row in self.light_shaft_cage_end_last_transform.transposed()
+            for v in row
+        ]
 
     def handler_set_light_shaft_end_transform(self, value):
         m = Matrix((value[0:4], value[4:8], value[8:12], value[12:16]))
@@ -905,10 +1077,14 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
 
         new_width_scale = max(min_width_scale, width_scale)
         new_height_scale = max(min_height_scale, height_scale)
-        return Matrix(((new_width_scale, 0.0, 0.0, 0.0),
-                       (0.0, new_height_scale, 0.0, 0.0),
-                       (0.0, 0.0, 1.0, 0.0),
-                       (0.0, 0.0, 0.0, 1.0)))
+        return Matrix(
+            (
+                (new_width_scale, 0.0, 0.0, 0.0),
+                (0.0, new_height_scale, 0.0, 0.0),
+                (0.0, 0.0, 1.0, 0.0),
+                (0.0, 0.0, 0.0, 1.0),
+            )
+        )
 
     def apply_light_shaft_cage_end_snapping(self, m: Matrix) -> Matrix:
         """Returns a new offset matrix with snapping applied if required."""
@@ -917,11 +1093,19 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
             if self.light_shaft_cage_end_snap_origin_transform is None:
                 self.light_shaft_cage_end_snap_origin_transform = m.copy()
 
-            snap_delta_transform = self.light_shaft_cage_end_snap_origin_transform.inverted() @ m
-            if abs(snap_delta_transform.translation.x) > abs(snap_delta_transform.translation.y):
-                m.translation.y = self.light_shaft_cage_end_snap_origin_transform.translation.y
+            snap_delta_transform = (
+                self.light_shaft_cage_end_snap_origin_transform.inverted() @ m
+            )
+            if abs(snap_delta_transform.translation.x) > abs(
+                snap_delta_transform.translation.y
+            ):
+                m.translation.y = (
+                    self.light_shaft_cage_end_snap_origin_transform.translation.y
+                )
             else:
-                m.translation.x = self.light_shaft_cage_end_snap_origin_transform.translation.x
+                m.translation.x = (
+                    self.light_shaft_cage_end_snap_origin_transform.translation.x
+                )
         else:
             self.light_shaft_cage_end_snap_origin_transform = None
 
@@ -1080,29 +1264,53 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
         self.extension_gizmos = []
 
         # Assign handlers to all interaction gizmos
-        arrow_x.target_set_handler("offset", get=self.handler_get_x, set=self.handler_set_x)
-        arrow_y.target_set_handler("offset", get=self.handler_get_y, set=self.handler_set_y)
-        arrow_z.target_set_handler("offset", get=self.handler_get_z, set=self.handler_set_z)
-        dial_x.target_set_handler("offset", get=self.handler_get_rotation_x, set=self.handler_set_rotation_x)
-        dial_y.target_set_handler("offset", get=self.handler_get_rotation_y, set=self.handler_set_rotation_y)
-        dial_z.target_set_handler("offset", get=self.handler_get_rotation_z, set=self.handler_set_rotation_z)
-        ladder_bottom_arrow.target_set_handler("offset",
-                                               get=self.handler_get_ladder_bottom_z,
-                                               set=self.handler_set_ladder_bottom_z)
-        ladder_normal_dial.target_set_handler("offset",
-                                              get=self.handler_get_ladder_normal_angle,
-                                              set=self.handler_set_ladder_normal_angle)
-        light_shaft_cage.target_set_handler("matrix",
-                                            get=self.handler_get_light_shaft_transform,
-                                            set=self.handler_set_light_shaft_transform)
-        light_shaft_cage_end.target_set_handler("matrix",
-                                                get=self.handler_get_light_shaft_end_transform,
-                                                set=self.handler_set_light_shaft_end_transform)
+        arrow_x.target_set_handler(
+            "offset", get=self.handler_get_x, set=self.handler_set_x
+        )
+        arrow_y.target_set_handler(
+            "offset", get=self.handler_get_y, set=self.handler_set_y
+        )
+        arrow_z.target_set_handler(
+            "offset", get=self.handler_get_z, set=self.handler_set_z
+        )
+        dial_x.target_set_handler(
+            "offset", get=self.handler_get_rotation_x, set=self.handler_set_rotation_x
+        )
+        dial_y.target_set_handler(
+            "offset", get=self.handler_get_rotation_y, set=self.handler_set_rotation_y
+        )
+        dial_z.target_set_handler(
+            "offset", get=self.handler_get_rotation_z, set=self.handler_set_rotation_z
+        )
+        ladder_bottom_arrow.target_set_handler(
+            "offset",
+            get=self.handler_get_ladder_bottom_z,
+            set=self.handler_set_ladder_bottom_z,
+        )
+        ladder_normal_dial.target_set_handler(
+            "offset",
+            get=self.handler_get_ladder_normal_angle,
+            set=self.handler_set_ladder_normal_angle,
+        )
+        light_shaft_cage.target_set_handler(
+            "matrix",
+            get=self.handler_get_light_shaft_transform,
+            set=self.handler_set_light_shaft_transform,
+        )
+        light_shaft_cage_end.target_set_handler(
+            "matrix",
+            get=self.handler_get_light_shaft_end_transform,
+            set=self.handler_set_light_shaft_end_transform,
+        )
 
         # Cannot call operators here, use timers to call it as soon as possible
         def _invoke_archetype_extensions_detect_ctrl_pressed_operator():
             bpy.ops.sollumz.archetype_extensions_detect_ctrl_pressed("INVOKE_DEFAULT")
-        bpy.app.timers.register(_invoke_archetype_extensions_detect_ctrl_pressed_operator, first_interval=0.0)
+
+        bpy.app.timers.register(
+            _invoke_archetype_extensions_detect_ctrl_pressed_operator,
+            first_interval=0.0,
+        )
 
     def refresh(self, context):
         selected_extension = get_selected_extension(context)
@@ -1115,8 +1323,12 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
         if selected_extension is not None:
             # Show necessary interaction gizmos for the current extension type
             is_ladder = selected_extension.extension_type == ExtensionType.LADDER
-            is_light_shaft = selected_extension.extension_type == ExtensionType.LIGHT_SHAFT
-            has_rotation = hasattr(selected_extension.get_properties(), "offset_rotation")
+            is_light_shaft = (
+                selected_extension.extension_type == ExtensionType.LIGHT_SHAFT
+            )
+            has_rotation = hasattr(
+                selected_extension.get_properties(), "offset_rotation"
+            )
 
             hide_translation_gizmos = False
             hide_rotation_gizmos = not has_rotation and not is_light_shaft
@@ -1217,39 +1429,54 @@ class SOLLUMZ_GGT_archetype_extensions(bpy.types.GizmoGroup):
 
         if not self.ladder_bottom_arrow.hide:
             top_mat = get_extension_world_matrix(selected_extension, selected_archetype)
-            bottom_mat = get_extension_ladder_bottom_world_matrix(selected_extension, selected_archetype)
+            bottom_mat = get_extension_ladder_bottom_world_matrix(
+                selected_extension, selected_archetype
+            )
 
-            bottom_arrow_mat = bottom_mat @ Matrix.Rotation(math.radians(-180), 4, 'X')
+            bottom_arrow_mat = bottom_mat @ Matrix.Rotation(math.radians(-180), 4, "X")
             _prepare_arrow(self.ladder_bottom_arrow, bottom_arrow_mat)
 
             middle = (top_mat.translation + bottom_mat.translation) / 2.0
-            normal_dial_mat = Matrix.LocRotScale(middle, top_mat.to_quaternion(), (1.0, 1.0, 1.0))
+            normal_dial_mat = Matrix.LocRotScale(
+                middle, top_mat.to_quaternion(), (1.0, 1.0, 1.0)
+            )
             _prepare_dial(self.ladder_normal_dial, normal_dial_mat, clip=False)
 
         if not self.light_shaft_cage.hide:
             selected_extension = get_selected_extension(context)
             ext_props = selected_extension.get_properties()
 
-            light_shaft_transform = (self.get_extension_light_shaft_cage_world_transform(context) @
-                                     Matrix.Rotation(math.radians(90), 4, 'X'))
+            light_shaft_transform = self.get_extension_light_shaft_cage_world_transform(
+                context
+            ) @ Matrix.Rotation(math.radians(90), 4, "X")
 
             if not self.light_shaft_cage.is_modal:
-                self.light_shaft_cage.dimensions = get_extension_light_shaft_dimensions(selected_extension)
+                self.light_shaft_cage.dimensions = get_extension_light_shaft_dimensions(
+                    selected_extension
+                )
                 self.light_shaft_cage.matrix_basis = light_shaft_transform
                 # Cage gizmo stores edited transform in `matrix_offset`, so reset it when it is not modal
                 # anymore as we update `dimensions` instead
                 self.light_shaft_cage.matrix_offset = Matrix.Identity(4)
                 self.light_shaft_cage_last_transform = Matrix.Identity(4)
             else:
-                m = self.apply_light_shaft_cage_scale_clamping(self.light_shaft_cage.matrix_offset)
+                m = self.apply_light_shaft_cage_scale_clamping(
+                    self.light_shaft_cage.matrix_offset
+                )
                 self.light_shaft_cage.matrix_offset = m
 
             if not self.light_shaft_cage_end.is_modal:
-                self.light_shaft_cage_end.dimensions = get_extension_light_shaft_dimensions(selected_extension)
-                self.light_shaft_cage_end.matrix_basis = (Matrix.Translation(ext_props.direction * ext_props.length) @
-                                                          light_shaft_transform)
+                self.light_shaft_cage_end.dimensions = (
+                    get_extension_light_shaft_dimensions(selected_extension)
+                )
+                self.light_shaft_cage_end.matrix_basis = (
+                    Matrix.Translation(ext_props.direction * ext_props.length)
+                    @ light_shaft_transform
+                )
                 self.light_shaft_cage_end.matrix_offset = Matrix.Identity(4)
                 self.light_shaft_cage_end_last_transform = Matrix.Identity(4)
             else:
-                m = self.apply_light_shaft_cage_end_snapping(self.light_shaft_cage_end.matrix_offset)
+                m = self.apply_light_shaft_cage_end_snapping(
+                    self.light_shaft_cage_end.matrix_offset
+                )
                 self.light_shaft_cage_end.matrix_offset = m

--- a/ytyp/gizmos/mlo.py
+++ b/ytyp/gizmos/mlo.py
@@ -16,7 +16,8 @@ def can_draw_gizmos(context):
         if not selected_archetype.asset.visible_get():
             return False
         return aobj == selected_archetype.asset or find_parent(
-            aobj, selected_archetype.asset.name)
+            aobj, selected_archetype.asset.name
+        )
     return False
 
 
@@ -32,42 +33,30 @@ class RoomGizmo(bpy.types.Gizmo):
         return [
             bbmin,
             Vector((bbmin.x, bbmin.y, bbmax.z)),
-
             bbmin,
             Vector((bbmax.x, bbmin.y, bbmin.z)),
-
             bbmin,
             Vector((bbmin.x, bbmax.y, bbmin.z)),
-
             Vector((bbmax.x, bbmin.y, bbmax.z)),
             Vector((bbmax.x, bbmin.y, bbmin.z)),
-
             Vector((bbmin.x, bbmin.y, bbmax.z)),
             Vector((bbmin.x, bbmax.y, bbmax.z)),
-
             Vector((bbmin.x, bbmax.y, bbmin.z)),
             Vector((bbmin.x, bbmax.y, bbmax.z)),
-
             Vector((bbmax.x, bbmin.y, bbmax.z)),
             Vector((bbmax.x, bbmin.y, bbmax.z)),
-
             Vector((bbmax.x, bbmin.y, bbmax.z)),
             Vector((bbmin.x, bbmin.y, bbmax.z)),
-
             Vector((bbmax.x, bbmin.y, bbmin.z)),
             Vector((bbmax.x, bbmax.y, bbmin.z)),
-
             Vector((bbmin.x, bbmax.y, bbmin.z)),
             Vector((bbmax.x, bbmax.y, bbmin.z)),
-
             Vector((bbmax.x, bbmin.y, bbmax.z)),
             bbmax,
-
             Vector((bbmin.x, bbmax.y, bbmax.z)),
             bbmax,
-
             Vector((bbmax.x, bbmax.y, bbmin.z)),
-            bbmax
+            bbmax,
         ]
 
     def draw(self, context):
@@ -87,9 +76,9 @@ class RoomGizmo(bpy.types.Gizmo):
         asset = selected_archetype.asset
         if asset and room:
             self.custom_shape = self.new_custom_shape(
-                "LINES", RoomGizmo.get_verts(room.bb_min, room.bb_max))
-            self.draw_custom_shape(
-                self.custom_shape, matrix=asset.matrix_world)
+                "LINES", RoomGizmo.get_verts(room.bb_min, room.bb_max)
+            )
+            self.draw_custom_shape(self.custom_shape, matrix=asset.matrix_world)
 
 
 class RoomGizmoGroup(bpy.types.GizmoGroup):
@@ -134,7 +123,6 @@ class PortalGizmo(bpy.types.Gizmo):
             corners[0],
             corners[1],
             corners[3],
-
             corners[2],
             corners[3],
             corners[1],
@@ -160,14 +148,15 @@ class PortalGizmo(bpy.types.Gizmo):
         self.alpha_highlight = self.alpha
 
         if portal and asset:
-            corners = [portal.corner1, portal.corner2,
-                       portal.corner3, portal.corner4]
+            corners = [portal.corner1, portal.corner2, portal.corner3, portal.corner4]
 
             self.portal_poly = self.new_custom_shape(
-                "TRIS", PortalGizmo.get_verts(corners))
+                "TRIS", PortalGizmo.get_verts(corners)
+            )
 
             self.draw_custom_shape(
-                self.portal_poly, matrix=asset.matrix_world, select_id=select_id)
+                self.portal_poly, matrix=asset.matrix_world, select_id=select_id
+            )
 
     def invoke(self, context, event):
         selected_archetype = get_selected_archetype(context)
@@ -178,10 +167,10 @@ class PortalGizmo(bpy.types.Gizmo):
 
         selected_archetype.portal_index = portals.index(self.linked_portal)
 
-        return {'PASS_THROUGH'}
+        return {"PASS_THROUGH"}
 
     def modal(self, context, event, tweak):
-        return {'PASS_THROUGH'}
+        return {"PASS_THROUGH"}
 
 
 class PortalNormalGizmo(bpy.types.Gizmo):
@@ -206,21 +195,31 @@ class PortalNormalGizmo(bpy.types.Gizmo):
             self.alpha = 0.3
 
             if portal and asset:
-                corners = [portal.corner1, portal.corner2,
-                           portal.corner3, portal.corner4]
+                corners = [
+                    portal.corner1,
+                    portal.corner2,
+                    portal.corner3,
+                    portal.corner4,
+                ]
                 x = [p[0] for p in corners]
                 y = [p[1] for p in corners]
                 z = [p[2] for p in corners]
                 centroid = Vector(
-                    (sum(x) / len(corners), sum(y) / len(corners), sum(z) / len(corners)))
-                normal = -(corners[2] - corners[0]
-                           ).cross(corners[1] - corners[0]).normalized()
+                    (
+                        sum(x) / len(corners),
+                        sum(y) / len(corners),
+                        sum(z) / len(corners),
+                    )
+                )
+                normal = (
+                    -(corners[2] - corners[0])
+                    .cross(corners[1] - corners[0])
+                    .normalized()
+                )
                 default_axis = Vector((0, 0, 1))
                 rot = default_axis.rotation_difference(normal)
-                arrow_mat = Matrix.LocRotScale(
-                    centroid, rot, Vector((0.3, 0.3, 0.3)))
-                self.draw_preset_arrow(
-                    matrix=asset.matrix_world @ arrow_mat)
+                arrow_mat = Matrix.LocRotScale(centroid, rot, Vector((0.3, 0.3, 0.3)))
+                self.draw_preset_arrow(matrix=asset.matrix_world @ arrow_mat)
 
 
 class PortalGizmoGroup(bpy.types.GizmoGroup):

--- a/ytyp/operators/entity.py
+++ b/ytyp/operators/entity.py
@@ -5,12 +5,16 @@ from ...sollumz_operators import SOLLUMZ_OT_base, SearchEnumHelper
 from ...tools.blenderhelper import remove_number_suffix
 from ..utils import get_selected_archetype, get_selected_entity
 from ..properties.mlo import (
-    MloEntityProperties, get_portal_items_for_selected_archetype, get_room_items_for_selected_archetype
+    MloEntityProperties,
+    get_portal_items_for_selected_archetype,
+    get_room_items_for_selected_archetype,
 )
 from ..properties.ytyp import ArchetypeProperties
 
 
-def set_entity_properties_from_filter(entity: MloEntityProperties, context: bpy.types.Context):
+def set_entity_properties_from_filter(
+    entity: MloEntityProperties, context: bpy.types.Context
+):
     scene = context.scene
     filter_type = scene.sollumz_entity_filter_type
 
@@ -26,6 +30,7 @@ def set_entity_properties_from_filter(entity: MloEntityProperties, context: bpy.
 
 class SOLLUMZ_OT_create_mlo_entity(SOLLUMZ_OT_base, bpy.types.Operator):
     """Add an entity to the selected mlo archetype"""
+
     bl_idname = "sollumz.createmloentity"
     bl_label = "Create Entity"
 
@@ -48,18 +53,22 @@ class SOLLUMZ_OT_add_obj_as_entity(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return get_selected_archetype(context) is not None and len(context.selected_objects) > 0
+        return (
+            get_selected_archetype(context) is not None
+            and len(context.selected_objects) > 0
+        )
 
     def execute(self, context: bpy.types.Context):
         selected_archetype = get_selected_archetype(context)
 
         for obj in context.selected_objects:
-            existing_entity = self.get_entity_using_obj(
-                obj, selected_archetype)
+            existing_entity = self.get_entity_using_obj(obj, selected_archetype)
 
             if existing_entity is not None:
                 self.report(
-                    {"INFO"}, f"Object '{obj.name}' already linked to entity '{existing_entity.archetype_name}'! Skipping...")
+                    {"INFO"},
+                    f"Object '{obj.name}' already linked to entity '{existing_entity.archetype_name}'! Skipping...",
+                )
                 continue
 
             entity = selected_archetype.new_entity()
@@ -70,7 +79,9 @@ class SOLLUMZ_OT_add_obj_as_entity(bpy.types.Operator):
 
         return {"FINISHED"}
 
-    def get_entity_using_obj(self, obj: bpy.types.Object, archetype: ArchetypeProperties) -> Optional[MloEntityProperties]:
+    def get_entity_using_obj(
+        self, obj: bpy.types.Object, archetype: ArchetypeProperties
+    ) -> Optional[MloEntityProperties]:
         for entity in archetype.entities:
             if entity.linked_object == obj:
                 return entity
@@ -80,6 +91,7 @@ class SOLLUMZ_OT_add_obj_as_entity(bpy.types.Operator):
 
 class SOLLUMZ_OT_set_obj_entity_transforms(bpy.types.Operator):
     """Set the transforms of the selected object(s) to that of the Entity"""
+
     bl_idname = "sollumz.setobjentitytransforms"
     bl_label = "Set Object Transforms to Entity"
 
@@ -87,7 +99,10 @@ class SOLLUMZ_OT_set_obj_entity_transforms(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return get_selected_entity(context) is not None and len(context.selected_objects) > 0
+        return (
+            get_selected_entity(context) is not None
+            and len(context.selected_objects) > 0
+        )
 
     def execute(self, context):
         entity = get_selected_entity(context)
@@ -112,6 +127,7 @@ class SOLLUMZ_OT_set_obj_entity_transforms(bpy.types.Operator):
 
 class SOLLUMZ_OT_delete_mlo_entity(SOLLUMZ_OT_base, bpy.types.Operator):
     """Delete an entity from the selected mlo archetype"""
+
     bl_idname = "sollumz.deletemloentity"
     bl_label = "Delete Entity"
 
@@ -121,20 +137,21 @@ class SOLLUMZ_OT_delete_mlo_entity(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         selected_archetype = get_selected_archetype(context)
-        selected_archetype.entities.remove(
-            selected_archetype.entity_index)
-        selected_archetype.entity_index = max(
-            selected_archetype.entity_index - 1, 0)
+        selected_archetype.entities.remove(selected_archetype.entity_index)
+        selected_archetype.entity_index = max(selected_archetype.entity_index - 1, 0)
 
         return True
 
 
 class SOLLUMZ_OT_search_entity_portals(SearchEnumHelper, bpy.types.Operator):
     """Search for portal"""
+
     bl_idname = "sollumz.search_entity_portals"
     bl_property = "attached_portal_id"
 
-    attached_portal_id: bpy.props.EnumProperty(items=get_portal_items_for_selected_archetype, default=-1)
+    attached_portal_id: bpy.props.EnumProperty(
+        items=get_portal_items_for_selected_archetype, default=-1
+    )
 
     @classmethod
     def poll(cls, context):
@@ -146,10 +163,13 @@ class SOLLUMZ_OT_search_entity_portals(SearchEnumHelper, bpy.types.Operator):
 
 class SOLLUMZ_OT_search_entity_rooms(SearchEnumHelper, bpy.types.Operator):
     """Search for room"""
+
     bl_idname = "sollumz.search_entity_rooms"
     bl_property = "attached_room_id"
 
-    attached_room_id: bpy.props.EnumProperty(items=get_room_items_for_selected_archetype, default=-1)
+    attached_room_id: bpy.props.EnumProperty(
+        items=get_room_items_for_selected_archetype, default=-1
+    )
 
     @classmethod
     def poll(cls, context):

--- a/ytyp/operators/entitysets.py
+++ b/ytyp/operators/entitysets.py
@@ -1,16 +1,24 @@
 import bpy
 from ...sollumz_helper import SOLLUMZ_OT_base
-from ..utils import get_selected_archetype, get_selected_entity, validate_dynamic_enums, validate_dynamic_enum
+from ..utils import (
+    get_selected_archetype,
+    get_selected_entity,
+    validate_dynamic_enums,
+    validate_dynamic_enum,
+)
 from ...sollumz_operators import SearchEnumHelper
 from ..properties.mlo import get_entityset_items_for_selected_archetype
 
 
 class SOLLUMZ_OT_search_entityset(SearchEnumHelper, bpy.types.Operator):
     """Search for Entity Set"""
+
     bl_idname = "sollumz.search_entityset"
     bl_property = "attached_entity_set_id"
 
-    attached_entity_set_id: bpy.props.EnumProperty(items=get_entityset_items_for_selected_archetype, default=-1)
+    attached_entity_set_id: bpy.props.EnumProperty(
+        items=get_entityset_items_for_selected_archetype, default=-1
+    )
 
     @classmethod
     def poll(cls, context):
@@ -22,6 +30,7 @@ class SOLLUMZ_OT_search_entityset(SearchEnumHelper, bpy.types.Operator):
 
 class SOLLUMZ_OT_create_entityset(SOLLUMZ_OT_base, bpy.types.Operator):
     """Add a Entity Set to the selected archetype"""
+
     bl_idname = "sollumz.createentityset"
     bl_label = "Create Entity Set"
 
@@ -38,6 +47,7 @@ class SOLLUMZ_OT_create_entityset(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_delete_entityset(SOLLUMZ_OT_base, bpy.types.Operator):
     """Delete Entity Set from selected archetype"""
+
     bl_idname = "sollumz.deleteentityset"
     bl_label = "Delete Entity Set"
 
@@ -48,16 +58,25 @@ class SOLLUMZ_OT_delete_entityset(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         selected_archetype = get_selected_archetype(context)
-        selected_archetype.entity_sets.remove(
-            selected_archetype.entity_set_index)
+        selected_archetype.entity_sets.remove(selected_archetype.entity_set_index)
         selected_archetype.entity_set_index = max(
-            selected_archetype.entity_set_index - 1, 0)
+            selected_archetype.entity_set_index - 1, 0
+        )
 
-        validate_dynamic_enums(selected_archetype.entities,
-                               "attached_entity_set_id", selected_archetype.entity_sets)
+        validate_dynamic_enums(
+            selected_archetype.entities,
+            "attached_entity_set_id",
+            selected_archetype.entity_sets,
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_add_entity_entityset", selected_archetype.entity_sets)
+            context.scene,
+            "sollumz_add_entity_entityset",
+            selected_archetype.entity_sets,
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_entity_filter_entity_set", selected_archetype.entity_sets)
+            context.scene,
+            "sollumz_entity_filter_entity_set",
+            selected_archetype.entity_sets,
+        )
 
         return True

--- a/ytyp/operators/extensions.py
+++ b/ytyp/operators/extensions.py
@@ -1,12 +1,18 @@
 import bpy
 from mathutils import Vector
 from ..properties.extensions import ExtensionsContainer
-from ..utils import get_selected_archetype, get_selected_entity, get_selected_ytyp, get_selected_extension
+from ..utils import (
+    get_selected_archetype,
+    get_selected_entity,
+    get_selected_ytyp,
+    get_selected_extension,
+)
 from ...tools.blenderhelper import tag_redraw
 
 
 class SOLLUMZ_OT_add_archetype_extension(bpy.types.Operator):
     """Add an extension to the archetype"""
+
     bl_idname = "sollumz.addarchetypeextension"
     bl_options = {"UNDO"}
     bl_label = "Add Extension"
@@ -26,6 +32,7 @@ class SOLLUMZ_OT_add_archetype_extension(bpy.types.Operator):
 
 class SOLLUMZ_OT_delete_archetype_extension(bpy.types.Operator):
     """Delete the selected extension from the archetype"""
+
     bl_idname = "sollumz.deletearchetypeextension"
     bl_options = {"UNDO"}
     bl_label = "Delete Extension"
@@ -46,6 +53,7 @@ class SOLLUMZ_OT_delete_archetype_extension(bpy.types.Operator):
 
 class SOLLUMZ_OT_duplicate_archetype_extension(bpy.types.Operator):
     """Duplicate the selected extension in the archetype"""
+
     bl_idname = "sollumz.duplicatearchetypeextension"
     bl_options = {"UNDO"}
     bl_label = "Duplicate Extension"
@@ -63,8 +71,10 @@ class SOLLUMZ_OT_duplicate_archetype_extension(bpy.types.Operator):
         tag_redraw(context, space_type="VIEW_3D", region_type="TOOL_HEADER")
         return {"FINISHED"}
 
+
 class SOLLUMZ_OT_add_entity_extension(bpy.types.Operator):
     """Add an extension to the entity"""
+
     bl_idname = "sollumz.addentityextension"
     bl_options = {"UNDO"}
     bl_label = "Add Extension"
@@ -82,6 +92,7 @@ class SOLLUMZ_OT_add_entity_extension(bpy.types.Operator):
 
 class SOLLUMZ_OT_delete_entity_extension(bpy.types.Operator):
     """Delete the selected extension from the entity"""
+
     bl_idname = "sollumz.deleteentityextension"
     bl_options = {"UNDO"}
     bl_label = "Delete Extension"
@@ -104,6 +115,7 @@ class SOLLUMZ_OT_delete_entity_extension(bpy.types.Operator):
 
 class SOLLUMZ_OT_duplicate_entity_extension(bpy.types.Operator):
     """Duplicate the selected extension in the entity"""
+
     bl_idname = "sollumz.duplicateentityextension"
     bl_options = {"UNDO"}
     bl_label = "Duplicate Extension"
@@ -129,7 +141,7 @@ class ExtensionUpdateFromSelectionHelper:
     @classmethod
     def poll(cls, context):
         return get_selected_extension(context) is not None
-    
+
     @classmethod
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):
         raise NotImplementedError
@@ -143,12 +155,15 @@ class ExtensionUpdateFromSelectionHelper:
         verts_location = sum(selected_vertices, Vector()) / len(selected_vertices)
 
         self.set_extension_props(context, verts_location)
-        
+
         return {"FINISHED"}
 
 
-class SOLLUMZ_OT_update_offset_and_top_from_selected(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+class SOLLUMZ_OT_update_offset_and_top_from_selected(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update ladder offest and top from selection"""
+
     bl_idname = "sollumz.updateoffsetandtopfromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Offset and Top"
@@ -160,8 +175,11 @@ class SOLLUMZ_OT_update_offset_and_top_from_selected(bpy.types.Operator, Extensi
         ladder_props.top = verts_location
 
 
-class SOLLUMZ_OT_update_bottom_from_selected(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+class SOLLUMZ_OT_update_bottom_from_selected(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update ladder bottom from selection"""
+
     bl_idname = "sollumz.updatebottomfromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Bottom"
@@ -172,8 +190,11 @@ class SOLLUMZ_OT_update_bottom_from_selected(bpy.types.Operator, ExtensionUpdate
         ladder_props.bottom = verts_location
 
 
-class SOLLUMZ_OT_update_particle_effect_location(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+class SOLLUMZ_OT_update_particle_effect_location(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update particle effect offset from selection"""
+
     bl_idname = "sollumz.updateptfxoffsetfromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Offset location"
@@ -184,65 +205,96 @@ class SOLLUMZ_OT_update_particle_effect_location(bpy.types.Operator, ExtensionUp
         particle_props.offset_position = verts_location
 
 
-class SOLLUMZ_OT_update_light_shaft_offeset_location(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+class SOLLUMZ_OT_update_light_shaft_offeset_location(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update light shaft offset from selection"""
+
     bl_idname = "sollumz.updatelightshaftoffsetfromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Offset location"
 
-
     @classmethod
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):
-        light_shaft_props = get_selected_extension(context).light_shaft_extension_properties
+        light_shaft_props = get_selected_extension(
+            context
+        ).light_shaft_extension_properties
         light_shaft_props.offset_position = verts_location
 
 
-class SOLLUMZ_OT_update_corner_a_location(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+class SOLLUMZ_OT_update_corner_a_location(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update light shaft corner A location from selection"""
+
     bl_idname = "sollumz.updatecornerafromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Corner A"
 
     @classmethod
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):
-        light_shaft_props = get_selected_extension(context).light_shaft_extension_properties
+        light_shaft_props = get_selected_extension(
+            context
+        ).light_shaft_extension_properties
         light_shaft_props.cornerA = verts_location
 
-class SOLLUMZ_OT_update_corner_b_location(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+
+class SOLLUMZ_OT_update_corner_b_location(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update light shaft corner B location from selection"""
+
     bl_idname = "sollumz.updatecornerbfromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Corner B"
 
     @classmethod
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):
-        light_shaft_props = get_selected_extension(context).light_shaft_extension_properties
+        light_shaft_props = get_selected_extension(
+            context
+        ).light_shaft_extension_properties
         light_shaft_props.cornerB = verts_location
 
-class SOLLUMZ_OT_update_corner_c_location(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+
+class SOLLUMZ_OT_update_corner_c_location(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update light shaft corner C location from selection"""
+
     bl_idname = "sollumz.updatecornercfromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Corner C"
 
     @classmethod
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):
-        light_shaft_props = get_selected_extension(context).light_shaft_extension_properties
+        light_shaft_props = get_selected_extension(
+            context
+        ).light_shaft_extension_properties
         light_shaft_props.cornerC = verts_location
 
-class SOLLUMZ_OT_update_corner_d_location(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+
+class SOLLUMZ_OT_update_corner_d_location(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update light shaft corner D location from selection"""
+
     bl_idname = "sollumz.updatecornerdfromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Corner D"
 
     @classmethod
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):
-        light_shaft_props = get_selected_extension(context).light_shaft_extension_properties
+        light_shaft_props = get_selected_extension(
+            context
+        ).light_shaft_extension_properties
         light_shaft_props.cornerD = verts_location
 
-class SOLLUMZ_OT_update_light_shaft_direction(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+
+class SOLLUMZ_OT_update_light_shaft_direction(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Update light shaft direction from selection"""
+
     bl_idname = "sollumz.updatelightshaftdirectionfromselection"
     bl_options = {"UNDO"}
     bl_label = "Update Lightshaft Direction"
@@ -251,22 +303,29 @@ class SOLLUMZ_OT_update_light_shaft_direction(bpy.types.Operator, ExtensionUpdat
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):
         aobj = context.active_object
 
-        light_shaft_props = get_selected_extension(context).light_shaft_extension_properties
+        light_shaft_props = get_selected_extension(
+            context
+        ).light_shaft_extension_properties
         start_pos = aobj.matrix_world @ light_shaft_props.offset_position
         end_pos = aobj.matrix_world @ verts_location
         direction = end_pos - start_pos
         light_shaft_props.length = direction.length
         light_shaft_props.direction = direction.normalized()
 
-class SOLLUMZ_OT_calculate_light_shaft_center_offset_location(bpy.types.Operator, ExtensionUpdateFromSelectionHelper):
+
+class SOLLUMZ_OT_calculate_light_shaft_center_offset_location(
+    bpy.types.Operator, ExtensionUpdateFromSelectionHelper
+):
     """Calculates the center based on the corner coordinates"""
+
     bl_idname = "sollumz.calculatelightshaftoffsetlocation"
     bl_options = {"UNDO"}
     bl_label = "Calculate Center Offset location"
 
-
     def execute(self, context):
-        light_shaft_props = get_selected_extension(context).light_shaft_extension_properties
+        light_shaft_props = get_selected_extension(
+            context
+        ).light_shaft_extension_properties
         cornerA = light_shaft_props.cornerA
         cornerB = light_shaft_props.cornerB
         cornerC = light_shaft_props.cornerC
@@ -274,9 +333,11 @@ class SOLLUMZ_OT_calculate_light_shaft_center_offset_location(bpy.types.Operator
 
         verts_location = (cornerA + cornerB + cornerC + cornerD) / 4.0
         self.set_extension_props(context, verts_location)
-        return {'FINISHED'}
+        return {"FINISHED"}
 
     @classmethod
     def set_extension_props(cls, context: bpy.types.Context, verts_location: Vector):
-        light_shaft_props = get_selected_extension(context).light_shaft_extension_properties
+        light_shaft_props = get_selected_extension(
+            context
+        ).light_shaft_extension_properties
         light_shaft_props.offset_position = verts_location

--- a/ytyp/operators/portal.py
+++ b/ytyp/operators/portal.py
@@ -3,13 +3,20 @@ import numpy
 from mathutils import Vector, Matrix
 from ...sollumz_operators import SOLLUMZ_OT_base, SearchEnumHelper
 from ...tools.blenderhelper import get_selected_vertices, get_selected_edit_vertices
-from ..utils import get_selected_archetype, get_selected_portal, get_selected_room, validate_dynamic_enums, validate_dynamic_enum
+from ..utils import (
+    get_selected_archetype,
+    get_selected_portal,
+    get_selected_room,
+    validate_dynamic_enums,
+    validate_dynamic_enum,
+)
 from bpy_extras.view3d_utils import location_3d_to_region_2d
 from ..properties.mlo import PortalProperties, get_room_items_for_selected_archetype
 
 
 class SOLLUMZ_OT_create_portal(SOLLUMZ_OT_base, bpy.types.Operator):
     """Add a portal to the selected archetype"""
+
     bl_idname = "sollumz.createportal"
     bl_label = "Create Portal"
 
@@ -30,7 +37,9 @@ class SOLLUMZ_OT_create_portal(SOLLUMZ_OT_base, bpy.types.Operator):
 class PortalCreatorHelper:
     @classmethod
     def poll(cls, context):
-        return get_selected_archetype(context) is not None and (context.active_object and context.active_object.mode == "EDIT")
+        return get_selected_archetype(context) is not None and (
+            context.active_object and context.active_object.mode == "EDIT"
+        )
 
     def execute(self, context: bpy.types.Context):
         selected_archetype = get_selected_archetype(context)
@@ -58,11 +67,17 @@ class PortalCreatorHelper:
 
         for obj in context.objects_in_mode:
             selected_verts.extend(
-                [obj.matrix_world @ v for v in get_selected_edit_vertices(obj.data)])
+                [obj.matrix_world @ v for v in get_selected_edit_vertices(obj.data)]
+            )
 
         return selected_verts
 
-    def set_portal_corners_to_selected_verts(self, context: bpy.types.Context, portal: PortalProperties, composite_matrix: Matrix):
+    def set_portal_corners_to_selected_verts(
+        self,
+        context: bpy.types.Context,
+        portal: PortalProperties,
+        composite_matrix: Matrix,
+    ):
         """Set portal corners to selected verts in winding order."""
         selected_verts = self.get_selected_portal_verts(context)
 
@@ -73,8 +88,9 @@ class PortalCreatorHelper:
         sort_order = PortalCreatorHelper.sort_coords_2d_winding(selected_verts)
 
         # Unapply the Bound Composite matrix since that is applied to the Gizmo
-        sorted_verts = [composite_matrix.inverted() @ selected_verts[i]
-                        for i in sort_order]
+        sorted_verts = [
+            composite_matrix.inverted() @ selected_verts[i] for i in sort_order
+        ]
 
         portal.corner1 = sorted_verts[2]
         portal.corner2 = sorted_verts[1]
@@ -91,26 +107,29 @@ class PortalCreatorHelper:
         centroid = numpy.sum(np_coords, axis=0) / np_coords.shape[0]
         vector_from_centroid = np_coords - centroid
         vector_angle = numpy.arctan2(
-            vector_from_centroid[:, 1], vector_from_centroid[:, 0])
+            vector_from_centroid[:, 1], vector_from_centroid[:, 0]
+        )
         # Find the indices that give a sorted vector_angle array
         return list(numpy.argsort(-vector_angle))
 
     @staticmethod
-    def get_screen_coords(coords_3d: list[tuple[float, float, float]]) -> list[tuple[float, float]]:
+    def get_screen_coords(
+        coords_3d: list[tuple[float, float, float]]
+    ) -> list[tuple[float, float]]:
         """Get 2D screen coords of the provided 3d coords."""
         region = bpy.context.region
         region_3d = bpy.context.space_data.region_3d
 
         screen_coords = []
         for coord in coords_3d:
-            screen_coords.append(
-                location_3d_to_region_2d(region, region_3d, coord))
+            screen_coords.append(location_3d_to_region_2d(region, region_3d, coord))
 
         return screen_coords
 
 
 class SOLLUMZ_OT_create_portal_from_selection(PortalCreatorHelper, bpy.types.Operator):
     """Create a portal from selected verts"""
+
     bl_idname = "sollumz.createportalfromselection"
     bl_label = "Create Portal From Verts"
     bl_options = {"REGISTER", "UNDO"}
@@ -127,6 +146,7 @@ class SOLLUMZ_OT_create_portal_from_selection(PortalCreatorHelper, bpy.types.Ope
 
 class SOLLUMZ_OT_update_portal_from_selection(PortalCreatorHelper, bpy.types.Operator):
     """Update a portal from selected verts"""
+
     bl_idname = "sollumz.updateportalfromselection"
     bl_label = "Update Portal From Verts"
     bl_options = {"REGISTER", "UNDO"}
@@ -141,6 +161,7 @@ class SOLLUMZ_OT_update_portal_from_selection(PortalCreatorHelper, bpy.types.Ope
 
 class SOLLUMZ_OT_delete_portal(SOLLUMZ_OT_base, bpy.types.Operator):
     """Delete portal from selected archetype"""
+
     bl_idname = "sollumz.deleteportal"
     bl_label = "Delete Portal"
 
@@ -151,23 +172,28 @@ class SOLLUMZ_OT_delete_portal(SOLLUMZ_OT_base, bpy.types.Operator):
     def run(self, context):
         selected_archetype = get_selected_archetype(context)
         selected_archetype.portals.remove(selected_archetype.portal_index)
-        selected_archetype.portal_index = max(
-            selected_archetype.portal_index - 1, 0)
+        selected_archetype.portal_index = max(selected_archetype.portal_index - 1, 0)
         # Force redraw of gizmos
         context.space_data.show_gizmo = context.space_data.show_gizmo
 
         validate_dynamic_enums(
-            selected_archetype.entities, "attached_portal_id", selected_archetype.portals)
+            selected_archetype.entities,
+            "attached_portal_id",
+            selected_archetype.portals,
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_add_entity_portal", selected_archetype.portals)
+            context.scene, "sollumz_add_entity_portal", selected_archetype.portals
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_entity_filter_portal", selected_archetype.portals)
+            context.scene, "sollumz_entity_filter_portal", selected_archetype.portals
+        )
 
         return True
 
 
 class SOLLUMZ_OT_flip_portal(bpy.types.Operator):
     """Flip portal direction"""
+
     bl_idname = "sollumz.flipportal"
     bl_label = "Change portal direction"
 
@@ -178,8 +204,12 @@ class SOLLUMZ_OT_flip_portal(bpy.types.Operator):
     def execute(self, context):
         selected_portal = get_selected_portal(context)
         if selected_portal is not None:
-            corners = [selected_portal.corner1.copy(), selected_portal.corner2.copy(
-            ), selected_portal.corner3.copy(), selected_portal.corner4.copy()]
+            corners = [
+                selected_portal.corner1.copy(),
+                selected_portal.corner2.copy(),
+                selected_portal.corner3.copy(),
+                selected_portal.corner4.copy(),
+            ]
             selected_portal.corner4 = corners[0]
             selected_portal.corner3 = corners[1]
             selected_portal.corner2 = corners[2]
@@ -217,10 +247,13 @@ class SetPortalRoomHelper(SOLLUMZ_OT_base):
 
 class SOLLUMZ_OT_search_portal_room_from(SearchEnumHelper, bpy.types.Operator):
     """Search for room"""
+
     bl_idname = "sollumz.search_portal_room_from"
     bl_property = "room_from_id"
 
-    room_from_id: bpy.props.EnumProperty(items=get_room_items_for_selected_archetype, default=-1)
+    room_from_id: bpy.props.EnumProperty(
+        items=get_room_items_for_selected_archetype, default=-1
+    )
 
     @classmethod
     def poll(cls, context):
@@ -232,10 +265,13 @@ class SOLLUMZ_OT_search_portal_room_from(SearchEnumHelper, bpy.types.Operator):
 
 class SOLLUMZ_OT_search_portal_room_to(SearchEnumHelper, bpy.types.Operator):
     """Search for room"""
+
     bl_idname = "sollumz.search_portal_room_to"
     bl_property = "room_to_id"
 
-    room_to_id: bpy.props.EnumProperty(items=get_room_items_for_selected_archetype, default=-1)
+    room_to_id: bpy.props.EnumProperty(
+        items=get_room_items_for_selected_archetype, default=-1
+    )
 
     @classmethod
     def poll(cls, context):

--- a/ytyp/operators/room.py
+++ b/ytyp/operators/room.py
@@ -3,11 +3,17 @@ from ...sollumz_operators import SOLLUMZ_OT_base
 from ...sollumz_properties import ArchetypeType
 from ...tools.meshhelper import get_extents, get_min_vector_list, get_max_vector_list
 from ...tools.blenderhelper import get_selected_vertices
-from ..utils import get_selected_archetype, get_selected_room, validate_dynamic_enums, validate_dynamic_enum
+from ..utils import (
+    get_selected_archetype,
+    get_selected_room,
+    validate_dynamic_enums,
+    validate_dynamic_enum,
+)
 
 
 class SOLLUMZ_OT_create_room(SOLLUMZ_OT_base, bpy.types.Operator):
     """Add a room to the selected archetype"""
+
     bl_idname = "sollumz.createroom"
     bl_label = "Create Room"
 
@@ -25,13 +31,18 @@ class SOLLUMZ_OT_create_room(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_create_limbo_room(SOLLUMZ_OT_base, bpy.types.Operator):
     """Automatically create a limbo room for the selected archetype (requires linked object to be specified)."""
+
     bl_idname = "sollumz.createlimboroom"
     bl_label = "Create Limbo Room"
 
     @classmethod
     def poll(cls, context):
         selected_archetype = get_selected_archetype(context)
-        return selected_archetype and selected_archetype.type == ArchetypeType.MLO and selected_archetype.asset is not None
+        return (
+            selected_archetype
+            and selected_archetype.type == ArchetypeType.MLO
+            and selected_archetype.asset is not None
+        )
 
     def run(self, context):
         selected_archetype = get_selected_archetype(context)
@@ -46,12 +57,15 @@ class SOLLUMZ_OT_create_limbo_room(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_set_bounds_from_selection(SOLLUMZ_OT_base, bpy.types.Operator):
     """Set room bounds from selection (must be in edit mode)"""
+
     bl_idname = "sollumz.setroomboundsfromselection"
     bl_label = "Set Bounds From Selection"
 
     @classmethod
     def poll(cls, context):
-        return get_selected_room(context) is not None and (context.active_object and context.active_object.mode == "EDIT")
+        return get_selected_room(context) is not None and (
+            context.active_object and context.active_object.mode == "EDIT"
+        )
 
     def run(self, context):
         selected_archetype = get_selected_archetype(context)
@@ -68,15 +82,14 @@ class SOLLUMZ_OT_set_bounds_from_selection(SOLLUMZ_OT_base, bpy.types.Operator):
 
         pos = selected_archetype.asset.location
 
-        selected_room.bb_max = get_max_vector_list(
-            selected_verts) - pos
-        selected_room.bb_min = get_min_vector_list(
-            selected_verts) - pos
+        selected_room.bb_max = get_max_vector_list(selected_verts) - pos
+        selected_room.bb_min = get_min_vector_list(selected_verts) - pos
         return True
 
 
 class SOLLUMZ_OT_delete_room(SOLLUMZ_OT_base, bpy.types.Operator):
     """Delete room from selected archetype"""
+
     bl_idname = "sollumz.deleteroom"
     bl_label = "Delete Room"
 
@@ -87,26 +100,35 @@ class SOLLUMZ_OT_delete_room(SOLLUMZ_OT_base, bpy.types.Operator):
     def run(self, context):
         selected_archetype = get_selected_archetype(context)
         selected_archetype.rooms.remove(selected_archetype.room_index)
-        selected_archetype.room_index = max(
-            selected_archetype.room_index - 1, 0)
+        selected_archetype.room_index = max(selected_archetype.room_index - 1, 0)
         # Force redraw of gizmos
         context.space_data.show_gizmo = context.space_data.show_gizmo
 
-        validate_dynamic_enums(selected_archetype.portals,
-                               "room_from_id", selected_archetype.rooms)
-        validate_dynamic_enums(selected_archetype.portals,
-                               "room_to_id", selected_archetype.rooms)
-        validate_dynamic_enums(selected_archetype.entities,
-                               "attached_room_id", selected_archetype.rooms)
+        validate_dynamic_enums(
+            selected_archetype.portals, "room_from_id", selected_archetype.rooms
+        )
+        validate_dynamic_enums(
+            selected_archetype.portals, "room_to_id", selected_archetype.rooms
+        )
+        validate_dynamic_enums(
+            selected_archetype.entities, "attached_room_id", selected_archetype.rooms
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_add_entity_room", selected_archetype.rooms)
+            context.scene, "sollumz_add_entity_room", selected_archetype.rooms
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_entity_filter_room", selected_archetype.rooms)
+            context.scene, "sollumz_entity_filter_room", selected_archetype.rooms
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_entity_filter_entity_set_room", selected_archetype.rooms)
+            context.scene,
+            "sollumz_entity_filter_entity_set_room",
+            selected_archetype.rooms,
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_add_portal_room_from", selected_archetype.rooms)
+            context.scene, "sollumz_add_portal_room_from", selected_archetype.rooms
+        )
         validate_dynamic_enum(
-            context.scene, "sollumz_add_portal_room_to", selected_archetype.rooms)
+            context.scene, "sollumz_add_portal_room_to", selected_archetype.rooms
+        )
 
         return True

--- a/ytyp/operators/ytyp.py
+++ b/ytyp/operators/ytyp.py
@@ -14,6 +14,7 @@ from ..ytypexport import selected_ytyp_to_xml
 
 class SOLLUMZ_OT_create_ytyp(SOLLUMZ_OT_base, bpy.types.Operator):
     """Add a ytyp to the project"""
+
     bl_idname = "sollumz.createytyp"
     bl_label = "Create YTYP"
 
@@ -28,6 +29,7 @@ class SOLLUMZ_OT_create_ytyp(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_delete_ytyp(SOLLUMZ_OT_base, bpy.types.Operator):
     """Delete a ytyp from the project"""
+
     bl_idname = "sollumz.deleteytyp"
     bl_label = "Delete YTYP"
 
@@ -46,6 +48,7 @@ class SOLLUMZ_OT_delete_ytyp(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_create_archetype(SOLLUMZ_OT_base, bpy.types.Operator):
     """Add an archetype to the selected ytyp"""
+
     bl_idname = "sollumz.createarchetype"
     bl_label = "Create Archetype"
 
@@ -60,8 +63,11 @@ class SOLLUMZ_OT_create_archetype(SOLLUMZ_OT_base, bpy.types.Operator):
         return True
 
 
-class SOLLUMZ_OT_set_texturedictionary_for_all_archetypes(SOLLUMZ_OT_base, bpy.types.Operator):
+class SOLLUMZ_OT_set_texturedictionary_for_all_archetypes(
+    SOLLUMZ_OT_base, bpy.types.Operator
+):
     """Sets texture dictionary for all archetypes within the selected ytyp"""
+
     bl_idname = "sollumz.settexturedictionaryallarchs"
     bl_label = "Set to All Archetypes"
 
@@ -75,11 +81,12 @@ class SOLLUMZ_OT_set_texturedictionary_for_all_archetypes(SOLLUMZ_OT_base, bpy.t
             if archetype.asset_type != AssetType.ASSETLESS:
                 archetype.texture_dictionary = selected_ytyp.all_texture_dictionary
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class SOLLUMZ_OT_set_loddist_for_all_archetypes(SOLLUMZ_OT_base, bpy.types.Operator):
     """Sets lod dist for all archetypes within the selected ytyp"""
+
     bl_idname = "sollumz.setloddistallarchs"
     bl_label = "Set to All Archetypes"
 
@@ -93,29 +100,37 @@ class SOLLUMZ_OT_set_loddist_for_all_archetypes(SOLLUMZ_OT_base, bpy.types.Opera
             if archetype.asset_type != AssetType.ASSETLESS:
                 archetype.lod_dist = selected_ytyp.all_lod_dist
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class SOLLUMZ_OT_set_entity_loddist_for_all_archetypes(bpy.types.Operator):
     """Sets entity lod dist for all entities in all within the selected MLO archetype"""
+
     bl_idname = "sollumz.setentityloddistallarchs"
     bl_label = "Set to All Entities"
 
     @classmethod
     def poll(cls, context):
         selected_archetype = get_selected_archetype(context)
-        return selected_archetype is not None and selected_archetype.type == ArchetypeType.MLO and len(selected_archetype.entities) > 0
+        return (
+            selected_archetype is not None
+            and selected_archetype.type == ArchetypeType.MLO
+            and len(selected_archetype.entities) > 0
+        )
 
     def execute(self, context):
         selected_archetype = get_selected_archetype(context)
         for entity in selected_archetype.entities:
             entity.lod_dist = selected_archetype.all_entity_lod_dist
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
-class SOLLUMZ_OT_set_hdtexturedist_for_all_archetypes(SOLLUMZ_OT_base, bpy.types.Operator):
+class SOLLUMZ_OT_set_hdtexturedist_for_all_archetypes(
+    SOLLUMZ_OT_base, bpy.types.Operator
+):
     """Sets HD textures distance for all archetypes within the selected ytyp"""
+
     bl_idname = "sollumz.sethdtexturedistallarchs"
     bl_label = "Set to All Archetypes"
 
@@ -129,11 +144,12 @@ class SOLLUMZ_OT_set_hdtexturedist_for_all_archetypes(SOLLUMZ_OT_base, bpy.types
             if archetype.asset_type != AssetType.ASSETLESS:
                 archetype.hd_texture_dist = selected_ytyp.all_hd_tex_dist
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class SOLLUMZ_OT_set_flag_for_all_archetypes(SOLLUMZ_OT_base, bpy.types.Operator):
     """Sets flags for all archetypes within the selected ytyp"""
+
     bl_idname = "sollumz.setflagsallarchs"
     bl_label = "Set to All Archetypes"
 
@@ -147,16 +163,21 @@ class SOLLUMZ_OT_set_flag_for_all_archetypes(SOLLUMZ_OT_base, bpy.types.Operator
             if archetype.asset_type != AssetType.ASSETLESS:
                 archetype.flags.total = str(selected_ytyp.all_flags)
 
-        return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class SOLLUMZ_OT_create_archetype_from_selected(SOLLUMZ_OT_base, bpy.types.Operator):
     """Create archetype from selected"""
+
     bl_idname = "sollumz.createarchetypefromselected"
     bl_label = "Auto-Create From Selected"
 
-    allowed_types = [SollumType.DRAWABLE,
-                     SollumType.BOUND_COMPOSITE, SollumType.FRAGMENT, SollumType.DRAWABLE_DICTIONARY]
+    allowed_types = [
+        SollumType.DRAWABLE,
+        SollumType.BOUND_COMPOSITE,
+        SollumType.FRAGMENT,
+        SollumType.DRAWABLE_DICTIONARY,
+    ]
 
     @classmethod
     def poll(cls, context):
@@ -172,7 +193,8 @@ class SOLLUMZ_OT_create_archetype_from_selected(SOLLUMZ_OT_base, bpy.types.Opera
             if archetype_type == ArchetypeType.MLO:
                 if obj.sollum_type != SollumType.BOUND_COMPOSITE:
                     self.message(
-                        f"MLO asset '{obj.name}' must be a {SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE]}!")
+                        f"MLO asset '{obj.name}' must be a {SOLLUMZ_UI_NAMES[SollumType.BOUND_COMPOSITE]}!"
+                    )
                     continue
             found = True
             selected_ytyp = get_selected_ytyp(context)
@@ -181,14 +203,17 @@ class SOLLUMZ_OT_create_archetype_from_selected(SOLLUMZ_OT_base, bpy.types.Opera
             item.name = obj.name
             item.asset = obj
             item.type = archetype_type
-            item.texture_dictionary = obj.name if has_embedded_textures(
-                obj) else ""
+            item.texture_dictionary = obj.name if has_embedded_textures(obj) else ""
             drawable_dictionary = ""
             if obj.parent:
                 if obj.parent.sollum_type == SollumType.DRAWABLE_DICTIONARY:
                     drawable_dictionary = obj.parent.name
             item.drawable_dictionary = drawable_dictionary
-            item.physics_dictionary = obj.name if has_collision(obj) and obj.sollum_type != SollumType.FRAGMENT else ""
+            item.physics_dictionary = (
+                obj.name
+                if has_collision(obj) and obj.sollum_type != SollumType.FRAGMENT
+                else ""
+            )
 
             if obj.sollum_type == SollumType.DRAWABLE:
                 item.asset_type = AssetType.DRAWABLE
@@ -200,13 +225,15 @@ class SOLLUMZ_OT_create_archetype_from_selected(SOLLUMZ_OT_base, bpy.types.Opera
                 item.asset_type = AssetType.FRAGMENT
         if not found:
             self.message(
-                f"No asset of type '{','.join([SOLLUMZ_UI_NAMES[type] for type in self.allowed_types])}' found!")
+                f"No asset of type '{','.join([SOLLUMZ_UI_NAMES[type] for type in self.allowed_types])}' found!"
+            )
             return False
         return True
 
 
 class SOLLUMZ_OT_delete_archetype(SOLLUMZ_OT_base, bpy.types.Operator):
     """Delete archetype from selected ytyp"""
+
     bl_idname = "sollumz.deletearchetype"
     bl_label = "Delete Archetype"
 
@@ -218,8 +245,7 @@ class SOLLUMZ_OT_delete_archetype(SOLLUMZ_OT_base, bpy.types.Operator):
     def run(self, context):
         selected_ytyp = get_selected_ytyp(context)
         selected_ytyp.archetypes.remove(selected_ytyp.archetype_index)
-        selected_ytyp.archetype_index = max(
-            selected_ytyp.archetype_index - 1, 0)
+        selected_ytyp.archetype_index = max(selected_ytyp.archetype_index - 1, 0)
         # Force redraw of gizmos
         context.space_data.show_gizmo = context.space_data.show_gizmo
 
@@ -228,6 +254,7 @@ class SOLLUMZ_OT_delete_archetype(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_create_timecycle_modifier(SOLLUMZ_OT_base, bpy.types.Operator):
     """Add a timecycle modifier to the selected archetype"""
+
     bl_idname = "sollumz.createtimecyclemodifier"
     bl_label = "Create Timecycle Modifier"
 
@@ -244,6 +271,7 @@ class SOLLUMZ_OT_create_timecycle_modifier(SOLLUMZ_OT_base, bpy.types.Operator):
 
 class SOLLUMZ_OT_delete_timecycle_modifier(SOLLUMZ_OT_base, bpy.types.Operator):
     """Delete timecycle modifier from selected archetype"""
+
     bl_idname = "sollumz.deletetimecyclemodifier"
     bl_label = "Delete Timecycle Modifier"
 
@@ -254,8 +282,7 @@ class SOLLUMZ_OT_delete_timecycle_modifier(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         selected_archetype = get_selected_archetype(context)
-        selected_archetype.timecycle_modifiers.remove(
-            selected_archetype.tcm_index)
+        selected_archetype.timecycle_modifiers.remove(selected_archetype.tcm_index)
         selected_archetype.tcm_index = max(selected_archetype.tcm_index - 1, 0)
         return True
 
@@ -284,6 +311,7 @@ class SOLLUMZ_OT_YTYP_TIME_FLAGS_clear(ClearTimeFlags, bpy.types.Operator):
 
 class SOLLUMZ_OT_import_ytyp(SOLLUMZ_OT_base, bpy.types.Operator, ImportHelper):
     """Import a ytyp.xml"""
+
     bl_idname = "sollumz.importytyp"
     bl_label = "Import ytyp.xml"
     bl_action = "Import a YTYP"
@@ -308,6 +336,7 @@ class SOLLUMZ_OT_import_ytyp(SOLLUMZ_OT_base, bpy.types.Operator, ImportHelper):
 
 class SOLLUMZ_OT_export_ytyp(SOLLUMZ_OT_base, bpy.types.Operator):
     """Export the selected YTYP."""
+
     bl_idname = "sollumz.exportytyp"
     bl_label = "Export ytyp.xml"
     bl_action = "Export a YTYP"

--- a/ytyp/properties/extensions.py
+++ b/ytyp/properties/extensions.py
@@ -73,7 +73,8 @@ LightShaftVolumeTypeEnumItems = (
 
 class BaseExtensionProperties:
     offset_position: bpy.props.FloatVectorProperty(
-        name="Offset Position", subtype="TRANSLATION")
+        name="Offset Position", subtype="TRANSLATION"
+    )
 
 
 class DoorExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
@@ -81,14 +82,14 @@ class DoorExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     starts_locked: bpy.props.BoolProperty(name="Starts Locked")
     can_break: bpy.props.BoolProperty(name="Can Break")
     limit_angle: bpy.props.FloatProperty(name="Limit Angle")
-    door_target_ratio: bpy.props.FloatProperty(
-        name="Door Target Ratio", min=0)
+    door_target_ratio: bpy.props.FloatProperty(name="Door Target Ratio", min=0)
     audio_hash: bpy.props.StringProperty(name="Audio Hash")
 
 
 class ParticleExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     offset_rotation: bpy.props.FloatVectorProperty(
-        name="Offset Rotation", subtype="EULER")
+        name="Offset Rotation", subtype="EULER"
+    )
     fx_name: bpy.props.StringProperty(name="FX Name")
     fx_type: bpy.props.IntProperty(name="FX Type")
     bone_tag: bpy.props.IntProperty(name="Bone Tag")
@@ -96,22 +97,27 @@ class ParticleExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperti
     probability: bpy.props.IntProperty(name="Probability")
     flags: bpy.props.IntProperty(name="Flags")
     color: bpy.props.FloatVectorProperty(
-        name="Color", subtype="COLOR", min=0, max=1, size=4, default=(1, 1, 1, 1))
+        name="Color", subtype="COLOR", min=0, max=1, size=4, default=(1, 1, 1, 1)
+    )
 
 
-class AudioCollisionExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
+class AudioCollisionExtensionProperties(
+    bpy.types.PropertyGroup, BaseExtensionProperties
+):
     settings: bpy.props.StringProperty(name="Settings")
 
 
 class AudioEmitterExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     offset_rotation: bpy.props.FloatVectorProperty(
-        name="Offset Rotation", subtype="EULER")
+        name="Offset Rotation", subtype="EULER"
+    )
     effect_hash: bpy.props.StringProperty(name="Effect Hash")
 
 
 class ExplosionExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     offset_rotation: bpy.props.FloatVectorProperty(
-        name="Offset Rotation", subtype="EULER")
+        name="Offset Rotation", subtype="EULER"
+    )
     explosion_name: bpy.props.StringProperty(name="Explosion Name")
     bone_tag: bpy.props.IntProperty(name="Bone Tag")
     explosion_tag: bpy.props.IntProperty(name="Explosion Tag")
@@ -124,12 +130,13 @@ class LadderExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties
     top: bpy.props.FloatVectorProperty(name="Top", subtype="TRANSLATION")
     normal: bpy.props.FloatVectorProperty(name="Normal", subtype="TRANSLATION")
     material_type: bpy.props.StringProperty(
-        name="Material Type", default="METAL_SOLID_LADDER")
+        name="Material Type", default="METAL_SOLID_LADDER"
+    )
     template: bpy.props.StringProperty(name="Template", default="default")
-    can_get_off_at_top: bpy.props.BoolProperty(
-        name="Can Get Off At Top", default=True)
+    can_get_off_at_top: bpy.props.BoolProperty(name="Can Get Off At Top", default=True)
     can_get_off_at_bottom: bpy.props.BoolProperty(
-        name="Can Get Off At Bottom", default=True)
+        name="Can Get Off At Bottom", default=True
+    )
 
 
 class BuoyancyExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
@@ -139,22 +146,26 @@ class BuoyancyExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperti
 
 class ExpressionExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     expression_dictionary_name: bpy.props.StringProperty(
-        name="Expression Dictionary Name")
+        name="Expression Dictionary Name"
+    )
     expression_name: bpy.props.StringProperty(name="Expression Name")
-    creature_metadata_name: bpy.props.StringProperty(
-        name="Creature Metadata Name")
-    initialize_on_collision: bpy.props.BoolProperty(
-        name="Initialize on Collision")
+    creature_metadata_name: bpy.props.StringProperty(name="Creature Metadata Name")
+    initialize_on_collision: bpy.props.BoolProperty(name="Initialize on Collision")
 
 
 class LightShaftExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
-    density_type: bpy.props.EnumProperty(items=LightShaftDensityTypeEnumItems, name="Density Type")
-    volume_type: bpy.props.EnumProperty(items=LightShaftVolumeTypeEnumItems, name="Volume Type")
+    density_type: bpy.props.EnumProperty(
+        items=LightShaftDensityTypeEnumItems, name="Density Type"
+    )
+    volume_type: bpy.props.EnumProperty(
+        items=LightShaftVolumeTypeEnumItems, name="Volume Type"
+    )
     scale_by_sun_intensity: bpy.props.BoolProperty(name="Scale by Sun Intensity")
     direction_amount: bpy.props.FloatProperty(name="Direction Amount")
     length: bpy.props.FloatProperty(name="Length")
     color: bpy.props.FloatVectorProperty(
-        name="Color", subtype="COLOR", min=0, max=1, size=4, default=(1, 1, 1, 1))
+        name="Color", subtype="COLOR", min=0, max=1, size=4, default=(1, 1, 1, 1)
+    )
     intensity: bpy.props.FloatProperty(name="Intensity")
     flashiness: bpy.props.IntProperty(name="Flashiness")
     flags: bpy.props.IntProperty(name="Flags")
@@ -166,21 +177,17 @@ class LightShaftExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProper
     fade_distance_start: bpy.props.FloatProperty(name="Fade Distance Start")
     fade_distance_end: bpy.props.FloatProperty(name="Fade Distance End")
     softness: bpy.props.FloatProperty(name="Softness")
-    cornerA: bpy.props.FloatVectorProperty(
-        name="Corner A", subtype="TRANSLATION")
-    cornerB: bpy.props.FloatVectorProperty(
-        name="Corner B", subtype="TRANSLATION")
-    cornerC: bpy.props.FloatVectorProperty(
-        name="Corner C", subtype="TRANSLATION")
-    cornerD: bpy.props.FloatVectorProperty(
-        name="Corner D", subtype="TRANSLATION")
-    direction: bpy.props.FloatVectorProperty(
-        name="Direction", subtype="XYZ")
+    cornerA: bpy.props.FloatVectorProperty(name="Corner A", subtype="TRANSLATION")
+    cornerB: bpy.props.FloatVectorProperty(name="Corner B", subtype="TRANSLATION")
+    cornerC: bpy.props.FloatVectorProperty(name="Corner C", subtype="TRANSLATION")
+    cornerD: bpy.props.FloatVectorProperty(name="Corner D", subtype="TRANSLATION")
+    direction: bpy.props.FloatVectorProperty(name="Direction", subtype="XYZ")
 
 
 class SpawnPointExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
     offset_rotation: bpy.props.FloatVectorProperty(
-        name="Offset Rotation", subtype="EULER")
+        name="Offset Rotation", subtype="EULER"
+    )
     spawn_type: bpy.props.StringProperty(name="Spawn Type")
     ped_type: bpy.props.StringProperty(name="Ped Type")
     group: bpy.props.StringProperty(name="Group")
@@ -214,9 +221,12 @@ class SpawnPointOverrideProperties(bpy.types.PropertyGroup, BaseExtensionPropert
     scenario_flags: bpy.props.StringProperty(name="Scenario Flags")
 
 
-class WindDisturbanceExtensionProperties(bpy.types.PropertyGroup, BaseExtensionProperties):
+class WindDisturbanceExtensionProperties(
+    bpy.types.PropertyGroup, BaseExtensionProperties
+):
     offset_rotation: bpy.props.FloatVectorProperty(
-        name="Offset Rotation", subtype="EULER")
+        name="Offset Rotation", subtype="EULER"
+    )
     disturbance_type: bpy.props.IntProperty(name="Disturbance Type")
     bone_tag: bpy.props.IntProperty(name="Bone Tag")
     size: bpy.props.FloatVectorProperty(name="Size", size=4, subtype="XYZ")
@@ -270,32 +280,43 @@ class ExtensionProperties(bpy.types.PropertyGroup):
     extension_type: bpy.props.EnumProperty(name="Type", items=ExtensionTypeEnumItems)
     name: bpy.props.StringProperty(name="Name", default="Extension")
 
-    door_extension_properties: bpy.props.PointerProperty(
-        type=DoorExtensionProperties)
+    door_extension_properties: bpy.props.PointerProperty(type=DoorExtensionProperties)
     particle_extension_properties: bpy.props.PointerProperty(
-        type=ParticleExtensionProperties)
+        type=ParticleExtensionProperties
+    )
     audio_collision_extension_properties: bpy.props.PointerProperty(
-        type=AudioCollisionExtensionProperties)
+        type=AudioCollisionExtensionProperties
+    )
     audio_emitter_extension_properties: bpy.props.PointerProperty(
-        type=AudioEmitterExtensionProperties)
+        type=AudioEmitterExtensionProperties
+    )
     explosion_extension_properties: bpy.props.PointerProperty(
-        type=ExplosionExtensionProperties)
+        type=ExplosionExtensionProperties
+    )
     ladder_extension_properties: bpy.props.PointerProperty(
-        type=LadderExtensionProperties)
+        type=LadderExtensionProperties
+    )
     buoyancy_extension_properties: bpy.props.PointerProperty(
-        type=BuoyancyExtensionProperties)
+        type=BuoyancyExtensionProperties
+    )
     expression_extension_properties: bpy.props.PointerProperty(
-        type=ExpressionExtensionProperties)
+        type=ExpressionExtensionProperties
+    )
     light_shaft_extension_properties: bpy.props.PointerProperty(
-        type=LightShaftExtensionProperties)
+        type=LightShaftExtensionProperties
+    )
     spawn_point_extension_properties: bpy.props.PointerProperty(
-        type=SpawnPointExtensionProperties)
+        type=SpawnPointExtensionProperties
+    )
     spawn_point_override_properties: bpy.props.PointerProperty(
-        type=SpawnPointOverrideProperties)
+        type=SpawnPointOverrideProperties
+    )
     wind_disturbance_properties: bpy.props.PointerProperty(
-        type=WindDisturbanceExtensionProperties)
+        type=WindDisturbanceExtensionProperties
+    )
     proc_object_extension_properties: bpy.props.PointerProperty(
-        type=ProcObjectExtensionProperties)
+        type=ProcObjectExtensionProperties
+    )
 
 
 class ExtensionsContainer:
@@ -330,7 +351,9 @@ class ExtensionsContainer:
         self.extension_index = max(self.extension_index - 1, 0)
 
     def duplicate_selected_extension(self) -> ExtensionProperties:
-        def _copy_property_group(dst: bpy.types.PropertyGroup, src: bpy.types.PropertyGroup):
+        def _copy_property_group(
+            dst: bpy.types.PropertyGroup, src: bpy.types.PropertyGroup
+        ):
             if getattr(src, "offset_position", None) is not None:
                 # __annotations__ doesn't include `offset_position` as it is from a base class
                 # manually copy it instead
@@ -352,7 +375,9 @@ class ExtensionsContainer:
         self.extension_index = len(self.extensions) - 1
         return new_ext
 
-    extensions: bpy.props.CollectionProperty(type=ExtensionProperties, name="Extensions")
+    extensions: bpy.props.CollectionProperty(
+        type=ExtensionProperties, name="Extensions"
+    )
     extension_index: bpy.props.IntProperty(name="Extension")
 
     @property

--- a/ytyp/properties/flags.py
+++ b/ytyp/properties/flags.py
@@ -6,256 +6,368 @@ class RoomFlags(FlagPropertyGroup, bpy.types.PropertyGroup):
     size = 10
 
     flag1: bpy.props.BoolProperty(
-        name="Unknown 1", update=FlagPropertyGroup.update_flag)
+        name="Unknown 1", update=FlagPropertyGroup.update_flag
+    )
     flag2: bpy.props.BoolProperty(
-        name="Disables wanted level", update=FlagPropertyGroup.update_flag)
+        name="Disables wanted level", update=FlagPropertyGroup.update_flag
+    )
     flag3: bpy.props.BoolProperty(
-        name="Disable exterior shadows", update=FlagPropertyGroup.update_flag)
+        name="Disable exterior shadows", update=FlagPropertyGroup.update_flag
+    )
     flag4: bpy.props.BoolProperty(
-        name="Unknown 4", update=FlagPropertyGroup.update_flag)
+        name="Unknown 4", update=FlagPropertyGroup.update_flag
+    )
     flag5: bpy.props.BoolProperty(
-        name="Unknown 5", update=FlagPropertyGroup.update_flag)
+        name="Unknown 5", update=FlagPropertyGroup.update_flag
+    )
     flag6: bpy.props.BoolProperty(
-        name="Reduces vehicle population", update=FlagPropertyGroup.update_flag)
+        name="Reduces vehicle population", update=FlagPropertyGroup.update_flag
+    )
     flag7: bpy.props.BoolProperty(
-        name="Reduces ped population", update=FlagPropertyGroup.update_flag)
+        name="Reduces ped population", update=FlagPropertyGroup.update_flag
+    )
     flag8: bpy.props.BoolProperty(
-        name="Unknown 8", update=FlagPropertyGroup.update_flag)
+        name="Unknown 8", update=FlagPropertyGroup.update_flag
+    )
     flag9: bpy.props.BoolProperty(
-        name="Disable limbo portals", update=FlagPropertyGroup.update_flag)
+        name="Disable limbo portals", update=FlagPropertyGroup.update_flag
+    )
     flag10: bpy.props.BoolProperty(
-        name="Unknown 10", update=FlagPropertyGroup.update_flag)
+        name="Unknown 10", update=FlagPropertyGroup.update_flag
+    )
 
 
 class PortalFlags(FlagPropertyGroup, bpy.types.PropertyGroup):
     size = 14
 
     flag1: bpy.props.BoolProperty(
-        name="Disables exterior rendering", update=FlagPropertyGroup.update_flag)
+        name="Disables exterior rendering", update=FlagPropertyGroup.update_flag
+    )
     flag2: bpy.props.BoolProperty(
-        name="Disables interior rendering", update=FlagPropertyGroup.update_flag)
-    flag3: bpy.props.BoolProperty(
-        name="Mirror", update=FlagPropertyGroup.update_flag)
+        name="Disables interior rendering", update=FlagPropertyGroup.update_flag
+    )
+    flag3: bpy.props.BoolProperty(name="Mirror", update=FlagPropertyGroup.update_flag)
     flag4: bpy.props.BoolProperty(
-        name="Extra bloom", update=FlagPropertyGroup.update_flag)
+        name="Extra bloom", update=FlagPropertyGroup.update_flag
+    )
     flag5: bpy.props.BoolProperty(
-        name="Unknown 5", update=FlagPropertyGroup.update_flag)
+        name="Unknown 5", update=FlagPropertyGroup.update_flag
+    )
     flag6: bpy.props.BoolProperty(
-        name="Use exterior LOD", update=FlagPropertyGroup.update_flag)
+        name="Use exterior LOD", update=FlagPropertyGroup.update_flag
+    )
     flag7: bpy.props.BoolProperty(
-        name="Hide when door closed", update=FlagPropertyGroup.update_flag)
+        name="Hide when door closed", update=FlagPropertyGroup.update_flag
+    )
     flag8: bpy.props.BoolProperty(
-        name="Unknown 8", update=FlagPropertyGroup.update_flag)
+        name="Unknown 8", update=FlagPropertyGroup.update_flag
+    )
     flag9: bpy.props.BoolProperty(
-        name="Mirror exterior portals", update=FlagPropertyGroup.update_flag)
+        name="Mirror exterior portals", update=FlagPropertyGroup.update_flag
+    )
     flag10: bpy.props.BoolProperty(
-        name="Unknown 10", update=FlagPropertyGroup.update_flag)
+        name="Unknown 10", update=FlagPropertyGroup.update_flag
+    )
     flag11: bpy.props.BoolProperty(
-        name="Mirror limbo entities", update=FlagPropertyGroup.update_flag)
+        name="Mirror limbo entities", update=FlagPropertyGroup.update_flag
+    )
     flag12: bpy.props.BoolProperty(
-        name="Unknown 12", update=FlagPropertyGroup.update_flag)
+        name="Unknown 12", update=FlagPropertyGroup.update_flag
+    )
     flag13: bpy.props.BoolProperty(
-        name="Unknown 13", update=FlagPropertyGroup.update_flag)
+        name="Unknown 13", update=FlagPropertyGroup.update_flag
+    )
     flag14: bpy.props.BoolProperty(
-        name="Disable farclipping", update=FlagPropertyGroup.update_flag)
+        name="Disable farclipping", update=FlagPropertyGroup.update_flag
+    )
 
 
 class EntityFlags(FlagPropertyGroup, bpy.types.PropertyGroup):
     flag1: bpy.props.BoolProperty(
-        name="Allow full rotation", update=FlagPropertyGroup.update_flag)
+        name="Allow full rotation", update=FlagPropertyGroup.update_flag
+    )
     flag2: bpy.props.BoolProperty(
-        name="Unknown 2", update=FlagPropertyGroup.update_flag)
+        name="Unknown 2", update=FlagPropertyGroup.update_flag
+    )
     flag3: bpy.props.BoolProperty(
-        name="Disable embedded collisions", update=FlagPropertyGroup.update_flag)
+        name="Disable embedded collisions", update=FlagPropertyGroup.update_flag
+    )
     flag4: bpy.props.BoolProperty(
-        name="Unknown 4", update=FlagPropertyGroup.update_flag)
+        name="Unknown 4", update=FlagPropertyGroup.update_flag
+    )
     flag5: bpy.props.BoolProperty(
-        name="Unknown 5", update=FlagPropertyGroup.update_flag)
+        name="Unknown 5", update=FlagPropertyGroup.update_flag
+    )
     flag6: bpy.props.BoolProperty(
-        name="Static entity", update=FlagPropertyGroup.update_flag)
+        name="Static entity", update=FlagPropertyGroup.update_flag
+    )
     flag7: bpy.props.BoolProperty(
-        name="Object isn't dark at night", update=FlagPropertyGroup.update_flag)
+        name="Object isn't dark at night", update=FlagPropertyGroup.update_flag
+    )
     flag8: bpy.props.BoolProperty(
-        name="Unknown 8", update=FlagPropertyGroup.update_flag)
+        name="Unknown 8", update=FlagPropertyGroup.update_flag
+    )
     flag9: bpy.props.BoolProperty(
-        name="Unknown 9", update=FlagPropertyGroup.update_flag)
+        name="Unknown 9", update=FlagPropertyGroup.update_flag
+    )
     flag10: bpy.props.BoolProperty(
-        name="Disable embedded light sources", update=FlagPropertyGroup.update_flag)
+        name="Disable embedded light sources", update=FlagPropertyGroup.update_flag
+    )
     flag11: bpy.props.BoolProperty(
-        name="Unknown 11", update=FlagPropertyGroup.update_flag)
+        name="Unknown 11", update=FlagPropertyGroup.update_flag
+    )
     flag12: bpy.props.BoolProperty(
-        name="Unknown 12", update=FlagPropertyGroup.update_flag)
+        name="Unknown 12", update=FlagPropertyGroup.update_flag
+    )
     flag13: bpy.props.BoolProperty(
-        name="Unknown 13", update=FlagPropertyGroup.update_flag)
+        name="Unknown 13", update=FlagPropertyGroup.update_flag
+    )
     flag14: bpy.props.BoolProperty(
-        name="Unknown 14", update=FlagPropertyGroup.update_flag)
+        name="Unknown 14", update=FlagPropertyGroup.update_flag
+    )
     flag15: bpy.props.BoolProperty(
-        name="Unknown 15", update=FlagPropertyGroup.update_flag)
+        name="Unknown 15", update=FlagPropertyGroup.update_flag
+    )
     flag16: bpy.props.BoolProperty(
-        name="Unknown 16", update=FlagPropertyGroup.update_flag)
+        name="Unknown 16", update=FlagPropertyGroup.update_flag
+    )
     flag17: bpy.props.BoolProperty(
-        name="Unknown 17", update=FlagPropertyGroup.update_flag)
+        name="Unknown 17", update=FlagPropertyGroup.update_flag
+    )
     flag18: bpy.props.BoolProperty(
-        name="Unknown 18", update=FlagPropertyGroup.update_flag)
-    flag19: bpy.props.BoolProperty(name="Disable archetype extensions",
-                                   update=FlagPropertyGroup.update_flag)
+        name="Unknown 18", update=FlagPropertyGroup.update_flag
+    )
+    flag19: bpy.props.BoolProperty(
+        name="Disable archetype extensions", update=FlagPropertyGroup.update_flag
+    )
     flag20: bpy.props.BoolProperty(
-        name="Unknown 20", update=FlagPropertyGroup.update_flag)
+        name="Unknown 20", update=FlagPropertyGroup.update_flag
+    )
     flag21: bpy.props.BoolProperty(
-        name="Unknown 21", update=FlagPropertyGroup.update_flag)
+        name="Unknown 21", update=FlagPropertyGroup.update_flag
+    )
     flag22: bpy.props.BoolProperty(
-        name="Unknown 22", update=FlagPropertyGroup.update_flag)
+        name="Unknown 22", update=FlagPropertyGroup.update_flag
+    )
     flag23: bpy.props.BoolProperty(
-        name="Disable shadow for entity", update=FlagPropertyGroup.update_flag)
+        name="Disable shadow for entity", update=FlagPropertyGroup.update_flag
+    )
     flag24: bpy.props.BoolProperty(
-        name="Disable entity, shadow casted", update=FlagPropertyGroup.update_flag)
+        name="Disable entity, shadow casted", update=FlagPropertyGroup.update_flag
+    )
     flag25: bpy.props.BoolProperty(
-        name="Object will not cast reflections", update=FlagPropertyGroup.update_flag)
+        name="Object will not cast reflections", update=FlagPropertyGroup.update_flag
+    )
     flag26: bpy.props.BoolProperty(
-        name="Interior proxy", update=FlagPropertyGroup.update_flag)
+        name="Interior proxy", update=FlagPropertyGroup.update_flag
+    )
     flag27: bpy.props.BoolProperty(
-        name="Unknown 27", update=FlagPropertyGroup.update_flag)
+        name="Unknown 27", update=FlagPropertyGroup.update_flag
+    )
     flag28: bpy.props.BoolProperty(
-        name="Reflection proxy", update=FlagPropertyGroup.update_flag)
+        name="Reflection proxy", update=FlagPropertyGroup.update_flag
+    )
     flag29: bpy.props.BoolProperty(
-        name="Unknown 29", update=FlagPropertyGroup.update_flag)
+        name="Unknown 29", update=FlagPropertyGroup.update_flag
+    )
     flag30: bpy.props.BoolProperty(
-        name="Mirror proxy", update=FlagPropertyGroup.update_flag)
+        name="Mirror proxy", update=FlagPropertyGroup.update_flag
+    )
     flag31: bpy.props.BoolProperty(
-        name="Unknown 31", update=FlagPropertyGroup.update_flag)
+        name="Unknown 31", update=FlagPropertyGroup.update_flag
+    )
     flag32: bpy.props.BoolProperty(
-        name="Unknown 32", update=FlagPropertyGroup.update_flag)
+        name="Unknown 32", update=FlagPropertyGroup.update_flag
+    )
 
 
 class ArchetypeFlags(FlagPropertyGroup, bpy.types.PropertyGroup):
     flag1: bpy.props.BoolProperty(
-        name="Unknown 1", update=FlagPropertyGroup.update_flag)
+        name="Unknown 1", update=FlagPropertyGroup.update_flag
+    )
     flag2: bpy.props.BoolProperty(
-        name="Unknown 2", update=FlagPropertyGroup.update_flag)
+        name="Unknown 2", update=FlagPropertyGroup.update_flag
+    )
     flag3: bpy.props.BoolProperty(
-        name="Unknown 3", update=FlagPropertyGroup.update_flag)
+        name="Unknown 3", update=FlagPropertyGroup.update_flag
+    )
     flag4: bpy.props.BoolProperty(
-        name="Unknown 4", update=FlagPropertyGroup.update_flag)
+        name="Unknown 4", update=FlagPropertyGroup.update_flag
+    )
     flag5: bpy.props.BoolProperty(
-        name="Unknown 5", update=FlagPropertyGroup.update_flag)
-    flag6: bpy.props.BoolProperty(
-        name="Static", update=FlagPropertyGroup.update_flag)
+        name="Unknown 5", update=FlagPropertyGroup.update_flag
+    )
+    flag6: bpy.props.BoolProperty(name="Static", update=FlagPropertyGroup.update_flag)
     flag7: bpy.props.BoolProperty(
-        name="Disable alpha sorting", update=FlagPropertyGroup.update_flag)
-    flag8: bpy.props.BoolProperty(
-        name="Instance", update=FlagPropertyGroup.update_flag)
+        name="Disable alpha sorting", update=FlagPropertyGroup.update_flag
+    )
+    flag8: bpy.props.BoolProperty(name="Instance", update=FlagPropertyGroup.update_flag)
     flag9: bpy.props.BoolProperty(
-        name="Unknown 9", update=FlagPropertyGroup.update_flag)
+        name="Unknown 9", update=FlagPropertyGroup.update_flag
+    )
     flag10: bpy.props.BoolProperty(
-        name="Bone anims (YCD)", update=FlagPropertyGroup.update_flag)
+        name="Bone anims (YCD)", update=FlagPropertyGroup.update_flag
+    )
     flag11: bpy.props.BoolProperty(
-        name="UV anims (YCD)", update=FlagPropertyGroup.update_flag)
+        name="UV anims (YCD)", update=FlagPropertyGroup.update_flag
+    )
     flag12: bpy.props.BoolProperty(
-        name="Invisible but blocks lights/shadows", update=FlagPropertyGroup.update_flag)
+        name="Invisible but blocks lights/shadows", update=FlagPropertyGroup.update_flag
+    )
     flag13: bpy.props.BoolProperty(
-        name="Unknown 13", update=FlagPropertyGroup.update_flag)
+        name="Unknown 13", update=FlagPropertyGroup.update_flag
+    )
     flag14: bpy.props.BoolProperty(
-        name="Object won't cast shadow", update=FlagPropertyGroup.update_flag)
+        name="Object won't cast shadow", update=FlagPropertyGroup.update_flag
+    )
     flag15: bpy.props.BoolProperty(
-        name="Unknown 15", update=FlagPropertyGroup.update_flag)
+        name="Unknown 15", update=FlagPropertyGroup.update_flag
+    )
     flag16: bpy.props.BoolProperty(
-        name="Unknown 16", update=FlagPropertyGroup.update_flag)
+        name="Unknown 16", update=FlagPropertyGroup.update_flag
+    )
     flag17: bpy.props.BoolProperty(
-        name="Double-sided rendering", update=FlagPropertyGroup.update_flag)
-    flag18: bpy.props.BoolProperty(
-        name="Dynamic", update=FlagPropertyGroup.update_flag)
+        name="Double-sided rendering", update=FlagPropertyGroup.update_flag
+    )
+    flag18: bpy.props.BoolProperty(name="Dynamic", update=FlagPropertyGroup.update_flag)
     flag19: bpy.props.BoolProperty(
-        name="Unknown 19", update=FlagPropertyGroup.update_flag)
+        name="Unknown 19", update=FlagPropertyGroup.update_flag
+    )
     flag20: bpy.props.BoolProperty(
-        name="Dynamic anims (YCD)", update=FlagPropertyGroup.update_flag)
+        name="Dynamic anims (YCD)", update=FlagPropertyGroup.update_flag
+    )
     flag21: bpy.props.BoolProperty(
-        name="Unknown 21", update=FlagPropertyGroup.update_flag)
+        name="Unknown 21", update=FlagPropertyGroup.update_flag
+    )
     flag22: bpy.props.BoolProperty(
-        name="Unknown 22", update=FlagPropertyGroup.update_flag)
+        name="Unknown 22", update=FlagPropertyGroup.update_flag
+    )
     flag23: bpy.props.BoolProperty(
-        name="Unknown 23", update=FlagPropertyGroup.update_flag)
+        name="Unknown 23", update=FlagPropertyGroup.update_flag
+    )
     flag24: bpy.props.BoolProperty(
-        name="Unknown 24", update=FlagPropertyGroup.update_flag)
+        name="Unknown 24", update=FlagPropertyGroup.update_flag
+    )
     flag25: bpy.props.BoolProperty(
-        name="Unknown 25", update=FlagPropertyGroup.update_flag)
+        name="Unknown 25", update=FlagPropertyGroup.update_flag
+    )
     flag26: bpy.props.BoolProperty(
-        name="Unknown 26", update=FlagPropertyGroup.update_flag)
+        name="Unknown 26", update=FlagPropertyGroup.update_flag
+    )
     flag27: bpy.props.BoolProperty(
-        name="Enables special attribute", update=FlagPropertyGroup.update_flag)
+        name="Enables special attribute", update=FlagPropertyGroup.update_flag
+    )
     flag28: bpy.props.BoolProperty(
-        name="Unknown 28", update=FlagPropertyGroup.update_flag)
+        name="Unknown 28", update=FlagPropertyGroup.update_flag
+    )
     flag29: bpy.props.BoolProperty(
-        name="Disable red vertex channel", update=FlagPropertyGroup.update_flag)
+        name="Disable red vertex channel", update=FlagPropertyGroup.update_flag
+    )
     flag30: bpy.props.BoolProperty(
-        name="Disable green vertex channel", update=FlagPropertyGroup.update_flag)
+        name="Disable green vertex channel", update=FlagPropertyGroup.update_flag
+    )
     flag31: bpy.props.BoolProperty(
-        name="Disable blue vertex channel", update=FlagPropertyGroup.update_flag)
+        name="Disable blue vertex channel", update=FlagPropertyGroup.update_flag
+    )
     flag32: bpy.props.BoolProperty(
-        name="Disable alpha vertex channel", update=FlagPropertyGroup.update_flag)
+        name="Disable alpha vertex channel", update=FlagPropertyGroup.update_flag
+    )
 
 
 class UnknownFlags(FlagPropertyGroup, bpy.types.PropertyGroup):
     flag1: bpy.props.BoolProperty(
-        name="Unknown 1", update=FlagPropertyGroup.update_flag)
+        name="Unknown 1", update=FlagPropertyGroup.update_flag
+    )
     flag2: bpy.props.BoolProperty(
-        name="Unknown 2", update=FlagPropertyGroup.update_flag)
+        name="Unknown 2", update=FlagPropertyGroup.update_flag
+    )
     flag3: bpy.props.BoolProperty(
-        name="Unknown 3", update=FlagPropertyGroup.update_flag)
+        name="Unknown 3", update=FlagPropertyGroup.update_flag
+    )
     flag4: bpy.props.BoolProperty(
-        name="Unknown 4", update=FlagPropertyGroup.update_flag)
+        name="Unknown 4", update=FlagPropertyGroup.update_flag
+    )
     flag5: bpy.props.BoolProperty(
-        name="Unknown 5", update=FlagPropertyGroup.update_flag)
+        name="Unknown 5", update=FlagPropertyGroup.update_flag
+    )
     flag6: bpy.props.BoolProperty(
-        name="Unknown 6", update=FlagPropertyGroup.update_flag)
+        name="Unknown 6", update=FlagPropertyGroup.update_flag
+    )
     flag7: bpy.props.BoolProperty(
-        name="Unknown 7", update=FlagPropertyGroup.update_flag)
+        name="Unknown 7", update=FlagPropertyGroup.update_flag
+    )
     flag8: bpy.props.BoolProperty(
-        name="Unknown 8", update=FlagPropertyGroup.update_flag)
+        name="Unknown 8", update=FlagPropertyGroup.update_flag
+    )
     flag9: bpy.props.BoolProperty(
-        name="Unknown 9", update=FlagPropertyGroup.update_flag)
+        name="Unknown 9", update=FlagPropertyGroup.update_flag
+    )
     flag10: bpy.props.BoolProperty(
-        name="Unknown 10", update=FlagPropertyGroup.update_flag)
+        name="Unknown 10", update=FlagPropertyGroup.update_flag
+    )
     flag11: bpy.props.BoolProperty(
-        name="Unknown 11", update=FlagPropertyGroup.update_flag)
+        name="Unknown 11", update=FlagPropertyGroup.update_flag
+    )
     flag12: bpy.props.BoolProperty(
-        name="Unknown 12", update=FlagPropertyGroup.update_flag)
+        name="Unknown 12", update=FlagPropertyGroup.update_flag
+    )
     flag13: bpy.props.BoolProperty(
-        name="Unknown 13", update=FlagPropertyGroup.update_flag)
+        name="Unknown 13", update=FlagPropertyGroup.update_flag
+    )
     flag14: bpy.props.BoolProperty(
-        name="Unknown 14", update=FlagPropertyGroup.update_flag)
+        name="Unknown 14", update=FlagPropertyGroup.update_flag
+    )
     flag15: bpy.props.BoolProperty(
-        name="Unknown 15", update=FlagPropertyGroup.update_flag)
+        name="Unknown 15", update=FlagPropertyGroup.update_flag
+    )
     flag16: bpy.props.BoolProperty(
-        name="Unknown 16", update=FlagPropertyGroup.update_flag)
+        name="Unknown 16", update=FlagPropertyGroup.update_flag
+    )
     flag17: bpy.props.BoolProperty(
-        name="Unknown 17", update=FlagPropertyGroup.update_flag)
+        name="Unknown 17", update=FlagPropertyGroup.update_flag
+    )
     flag18: bpy.props.BoolProperty(
-        name="Unknown 18", update=FlagPropertyGroup.update_flag)
+        name="Unknown 18", update=FlagPropertyGroup.update_flag
+    )
     flag19: bpy.props.BoolProperty(
-        name="Unknown 19", update=FlagPropertyGroup.update_flag)
+        name="Unknown 19", update=FlagPropertyGroup.update_flag
+    )
     flag20: bpy.props.BoolProperty(
-        name="Unknown 20", update=FlagPropertyGroup.update_flag)
+        name="Unknown 20", update=FlagPropertyGroup.update_flag
+    )
     flag21: bpy.props.BoolProperty(
-        name="Unknown 21", update=FlagPropertyGroup.update_flag)
+        name="Unknown 21", update=FlagPropertyGroup.update_flag
+    )
     flag22: bpy.props.BoolProperty(
-        name="Unknown 22", update=FlagPropertyGroup.update_flag)
+        name="Unknown 22", update=FlagPropertyGroup.update_flag
+    )
     flag23: bpy.props.BoolProperty(
-        name="Unknown 23", update=FlagPropertyGroup.update_flag)
+        name="Unknown 23", update=FlagPropertyGroup.update_flag
+    )
     flag24: bpy.props.BoolProperty(
-        name="Unknown 24", update=FlagPropertyGroup.update_flag)
+        name="Unknown 24", update=FlagPropertyGroup.update_flag
+    )
     flag25: bpy.props.BoolProperty(
-        name="Unknown 25", update=FlagPropertyGroup.update_flag)
+        name="Unknown 25", update=FlagPropertyGroup.update_flag
+    )
     flag26: bpy.props.BoolProperty(
-        name="Unknown 26", update=FlagPropertyGroup.update_flag)
+        name="Unknown 26", update=FlagPropertyGroup.update_flag
+    )
     flag27: bpy.props.BoolProperty(
-        name="Unknown 27", update=FlagPropertyGroup.update_flag)
+        name="Unknown 27", update=FlagPropertyGroup.update_flag
+    )
     flag28: bpy.props.BoolProperty(
-        name="Unknown 28", update=FlagPropertyGroup.update_flag)
+        name="Unknown 28", update=FlagPropertyGroup.update_flag
+    )
     flag29: bpy.props.BoolProperty(
-        name="Unknown 29", update=FlagPropertyGroup.update_flag)
+        name="Unknown 29", update=FlagPropertyGroup.update_flag
+    )
     flag30: bpy.props.BoolProperty(
-        name="Unknown 30", update=FlagPropertyGroup.update_flag)
+        name="Unknown 30", update=FlagPropertyGroup.update_flag
+    )
     flag31: bpy.props.BoolProperty(
-        name="Unknown 31", update=FlagPropertyGroup.update_flag)
+        name="Unknown 31", update=FlagPropertyGroup.update_flag
+    )
     flag32: bpy.props.BoolProperty(
-        name="Unknown 32", update=FlagPropertyGroup.update_flag)
+        name="Unknown 32", update=FlagPropertyGroup.update_flag
+    )

--- a/ytyp/properties/mlo.py
+++ b/ytyp/properties/mlo.py
@@ -57,7 +57,9 @@ def get_portal_items_for_selected_archetype(self, context: Optional[bpy.types.Co
     return get_portal_items_for_archetype(archetype)
 
 
-def get_entityset_items_for_selected_archetype(self, context: Optional[bpy.types.Context]):
+def get_entityset_items_for_selected_archetype(
+    self, context: Optional[bpy.types.Context]
+):
     archetype = get_selected_archetype(context)
     return get_entityset_items_for_archetype(archetype)
 
@@ -92,14 +94,13 @@ class RoomProperties(bpy.types.PropertyGroup, MloArchetypeChild):
     bb_min: bpy.props.FloatVectorProperty(name="Bounds Min", subtype="XYZ")
     bb_max: bpy.props.FloatVectorProperty(name="Bounds Max", subtype="XYZ")
     blend: bpy.props.FloatProperty(name="Blend", default=1)
-    timecycle: bpy.props.StringProperty(
-        name="Timecycle", default="int_gasstation")
-    secondary_timecycle: bpy.props.StringProperty(
-        name="Secondary Timecycle")
+    timecycle: bpy.props.StringProperty(name="Timecycle", default="int_gasstation")
+    secondary_timecycle: bpy.props.StringProperty(name="Secondary Timecycle")
     flags: bpy.props.PointerProperty(type=RoomFlags, name="Flags")
     floor_id: bpy.props.IntProperty(name="Floor ID")
     exterior_visibility_depth: bpy.props.IntProperty(
-        name="Exterior Visibility Depth", default=-1)
+        name="Exterior Visibility Depth", default=-1
+    )
 
     # Blender usage only
     id: bpy.props.IntProperty(name="Id")
@@ -189,22 +190,31 @@ class PortalProperties(bpy.types.PropertyGroup, MloArchetypeChild):
     corner4: bpy.props.FloatVectorProperty(name="Corner 4", subtype="XYZ")
 
     room_from_id: bpy.props.EnumProperty(
-        name="Room From", items=MloArchetypeChild.get_room_items, update=update_room_names, default=-1)
+        name="Room From",
+        items=MloArchetypeChild.get_room_items,
+        update=update_room_names,
+        default=-1,
+    )
     room_from_index: bpy.props.IntProperty(
-        name="Room From Index", get=get_room_from_index)
+        name="Room From Index", get=get_room_from_index
+    )
     room_from_name: bpy.props.StringProperty(name="Room From")
 
     room_to_id: bpy.props.EnumProperty(
-        name="Room To", items=MloArchetypeChild.get_room_items, update=update_room_names, default=-1)
-    room_to_index: bpy.props.IntProperty(
-        name="Room To Index", get=get_room_to_index)
+        name="Room To",
+        items=MloArchetypeChild.get_room_items,
+        update=update_room_names,
+        default=-1,
+    )
+    room_to_index: bpy.props.IntProperty(name="Room To Index", get=get_room_to_index)
     room_to_name: bpy.props.StringProperty(name="Room To")
 
     flags: bpy.props.PointerProperty(type=PortalFlags, name="Flags")
     mirror_priority: bpy.props.IntProperty(name="Mirror Priority")
     opacity: bpy.props.IntProperty(name="Opacity")
     audio_occlusion: bpy.props.StringProperty(
-        name="Audio Occlusion", update=update_audio_occlusion, default="0")
+        name="Audio Occlusion", update=update_audio_occlusion, default="0"
+    )
 
     # Blender use only
     name: bpy.props.StringProperty(name="Name", default="Portal", get=get_name)
@@ -213,15 +223,16 @@ class PortalProperties(bpy.types.PropertyGroup, MloArchetypeChild):
 
 class TimecycleModifierProperties(bpy.types.PropertyGroup, MloArchetypeChild):
     name: bpy.props.StringProperty(name="Name")
-    sphere: bpy.props.FloatVectorProperty(
-        name="Sphere", subtype="QUATERNION", size=4)
+    sphere: bpy.props.FloatVectorProperty(name="Sphere", subtype="QUATERNION", size=4)
     percentage: bpy.props.IntProperty(name="Percentage")
     range: bpy.props.FloatProperty(name="Range")
     start_hour: bpy.props.IntProperty(name="Start Hour")
     end_hour: bpy.props.IntProperty(name="End Hour")
 
 
-class MloEntityProperties(bpy.types.PropertyGroup, EntityProperties, MloArchetypeChild, ExtensionsContainer):
+class MloEntityProperties(
+    bpy.types.PropertyGroup, EntityProperties, MloArchetypeChild, ExtensionsContainer
+):
     def get_portal_index(self):
         selected_archetype = self.get_mlo_archetype()
         attached_portal_id = self.attached_portal_id
@@ -238,8 +249,7 @@ class MloEntityProperties(bpy.types.PropertyGroup, EntityProperties, MloArchetyp
 
     def get_portal_name(self):
         selected_archetype = self.get_mlo_archetype()
-        portal = get_list_item(selected_archetype.portals,
-                               self.portal_index)
+        portal = get_list_item(selected_archetype.portals, self.portal_index)
 
         if selected_archetype is None:
             return -1
@@ -264,8 +274,9 @@ class MloEntityProperties(bpy.types.PropertyGroup, EntityProperties, MloArchetyp
 
     def get_entityset_name(self):
         selected_archetype = self.get_mlo_archetype()
-        entity_set = get_list_item(selected_archetype.entity_sets,
-                                   self.entity_set_index)
+        entity_set = get_list_item(
+            selected_archetype.entity_sets, self.entity_set_index
+        )
         if entity_set and selected_archetype is not None:
             return entity_set.name
         return ""
@@ -283,8 +294,7 @@ class MloEntityProperties(bpy.types.PropertyGroup, EntityProperties, MloArchetyp
 
     def get_room_name(self):
         selected_archetype = self.get_mlo_archetype()
-        room = get_list_item(selected_archetype.rooms,
-                             self.room_index)
+        room = get_list_item(selected_archetype.rooms, self.room_index)
         if room and selected_archetype is not None:
             return room.name
         return ""
@@ -292,33 +302,39 @@ class MloEntityProperties(bpy.types.PropertyGroup, EntityProperties, MloArchetyp
     # Transforms unused if no linked object
     position: bpy.props.FloatVectorProperty(name="Position")
     rotation: bpy.props.FloatVectorProperty(
-        name="Rotation", subtype="QUATERNION", size=4, default=(1, 0, 0, 0))
+        name="Rotation", subtype="QUATERNION", size=4, default=(1, 0, 0, 0)
+    )
     scale_xy: bpy.props.FloatProperty(name="Scale XY", default=1)
     scale_z: bpy.props.FloatProperty(name="Scale Z", default=1)
 
     attached_portal_id: bpy.props.EnumProperty(
-        name="Portal", items=MloArchetypeChild.get_portal_items, default=-1)
+        name="Portal", items=MloArchetypeChild.get_portal_items, default=-1
+    )
     portal_index: bpy.props.IntProperty(
-        name="Attached Portal Index", get=get_portal_index)
+        name="Attached Portal Index", get=get_portal_index
+    )
     portal_name: bpy.props.StringProperty(
-        name="Attached Portal Name", get=get_portal_name)
+        name="Attached Portal Name", get=get_portal_name
+    )
 
     attached_room_id: bpy.props.EnumProperty(
-        name="Room", items=MloArchetypeChild.get_room_items, default=-1)
-    room_index: bpy.props.IntProperty(
-        name="Attached Room Index", get=get_room_index)
-    room_name: bpy.props.StringProperty(
-        name="Attached Room Name", get=get_room_name)
+        name="Room", items=MloArchetypeChild.get_room_items, default=-1
+    )
+    room_index: bpy.props.IntProperty(name="Attached Room Index", get=get_room_index)
+    room_name: bpy.props.StringProperty(name="Attached Room Name", get=get_room_name)
 
     attached_entity_set_id: bpy.props.EnumProperty(
-        name="EntitySet", items=MloArchetypeChild.get_entityset_items, default=-1)
+        name="EntitySet", items=MloArchetypeChild.get_entityset_items, default=-1
+    )
     entity_set_index: bpy.props.IntProperty(
-        name="Attached EntitySet Index", get=get_entityset_index)
+        name="Attached EntitySet Index", get=get_entityset_index
+    )
 
     flags: bpy.props.PointerProperty(type=EntityFlags, name="Flags")
 
     linked_object: bpy.props.PointerProperty(
-        type=bpy.types.Object, name="Linked Object")
+        type=bpy.types.Object, name="Linked Object"
+    )
 
     # Blender usage only
     id: bpy.props.IntProperty(name="Id")
@@ -338,7 +354,8 @@ class EntitySetProperties(bpy.types.PropertyGroup, MloArchetypeChild):
 
     name: bpy.props.StringProperty(name="Name")
     entities: bpy.props.CollectionProperty(
-        type=MloEntityProperties, name="EntitySet Entities")
+        type=MloEntityProperties, name="EntitySet Entities"
+    )
 
     # Blender use obly
     id: bpy.props.IntProperty(name="Id")
@@ -346,34 +363,55 @@ class EntitySetProperties(bpy.types.PropertyGroup, MloArchetypeChild):
 
 def register():
     bpy.types.Scene.sollumz_add_entity_portal = bpy.props.EnumProperty(
-        name="Portal", items=get_portal_items_for_selected_archetype, default=-1)
+        name="Portal", items=get_portal_items_for_selected_archetype, default=-1
+    )
     bpy.types.Scene.sollumz_add_entity_room = bpy.props.EnumProperty(
-        name="Room", items=get_room_items_for_selected_archetype, default=-1)
+        name="Room", items=get_room_items_for_selected_archetype, default=-1
+    )
     bpy.types.Scene.sollumz_add_entity_entityset = bpy.props.EnumProperty(
-        name="EntitySet", items=get_entityset_items_for_selected_archetype, default=-1)
+        name="EntitySet", items=get_entityset_items_for_selected_archetype, default=-1
+    )
 
     bpy.types.Scene.sollumz_add_portal_room_from = bpy.props.EnumProperty(
-        name="Room From", description="Room From", items=get_room_items_for_selected_archetype, default=-1)
+        name="Room From",
+        description="Room From",
+        items=get_room_items_for_selected_archetype,
+        default=-1,
+    )
     bpy.types.Scene.sollumz_add_portal_room_to = bpy.props.EnumProperty(
-        name="Room To", description="Room To", items=get_room_items_for_selected_archetype, default=-1)
+        name="Room To",
+        description="Room To",
+        items=get_room_items_for_selected_archetype,
+        default=-1,
+    )
 
-    bpy.types.Scene.sollumz_entity_filter_type = bpy.props.EnumProperty(name="Filter By", items=(
-        ("all", "All", ""),
-        ("room", "Room", ""),
-        ("portal", "Portal", ""),
-        ("entity_set", "EntitySet", "")
-    ))
+    bpy.types.Scene.sollumz_entity_filter_type = bpy.props.EnumProperty(
+        name="Filter By",
+        items=(
+            ("all", "All", ""),
+            ("room", "Room", ""),
+            ("portal", "Portal", ""),
+            ("entity_set", "EntitySet", ""),
+        ),
+    )
 
     bpy.types.Scene.sollumz_entity_filter_room = bpy.props.EnumProperty(
-        items=get_room_items_for_selected_archetype, default=-1, description="Room")
+        items=get_room_items_for_selected_archetype, default=-1, description="Room"
+    )
     bpy.types.Scene.sollumz_entity_filter_portal = bpy.props.EnumProperty(
-        items=get_portal_items_for_selected_archetype, default=-1, description="Portal")
+        items=get_portal_items_for_selected_archetype, default=-1, description="Portal"
+    )
     bpy.types.Scene.sollumz_entity_filter_entity_set = bpy.props.EnumProperty(
-        items=get_entityset_items_for_selected_archetype, default=-1, description="EntitySet")
+        items=get_entityset_items_for_selected_archetype,
+        default=-1,
+        description="EntitySet",
+    )
     bpy.types.Scene.sollumz_entity_filter_entity_set_room = bpy.props.EnumProperty(
-        items=get_room_items_for_selected_archetype, default=-1, description="Room")
+        items=get_room_items_for_selected_archetype, default=-1, description="Room"
+    )
     bpy.types.Scene.sollumz_do_entity_filter_entity_set_room = bpy.props.BoolProperty(
-        name="Filter EntitySet Room")
+        name="Filter EntitySet Room"
+    )
 
 
 def unregister():

--- a/ytyp/properties/ytyp.py
+++ b/ytyp/properties/ytyp.py
@@ -1,9 +1,22 @@
 from typing import Union
 import bpy
 from ...tools.blenderhelper import get_children_recursive
-from ...sollumz_properties import SollumType, items_from_enums, ArchetypeType, AssetType, TimeFlags, SOLLUMZ_UI_NAMES
+from ...sollumz_properties import (
+    SollumType,
+    items_from_enums,
+    ArchetypeType,
+    AssetType,
+    TimeFlags,
+    SOLLUMZ_UI_NAMES,
+)
 from ...tools.utils import get_list_item
-from .mlo import EntitySetProperties, RoomProperties, PortalProperties, MloEntityProperties, TimecycleModifierProperties
+from .mlo import (
+    EntitySetProperties,
+    RoomProperties,
+    PortalProperties,
+    MloEntityProperties,
+    TimecycleModifierProperties,
+)
 from .flags import ArchetypeFlags, UnknownFlags
 from .extensions import ExtensionsContainer, ExtensionProperties
 
@@ -21,7 +34,11 @@ class ArchetypeProperties(bpy.types.PropertyGroup, ExtensionsContainer):
             elif self.asset.sollum_type == SollumType.DRAWABLE:
                 self.asset_type = AssetType.DRAWABLE
                 # Check if in a drawable dictionary
-                if self.asset.parent and hasattr(self.asset.parent, "sollum_type") and self.asset.parent.sollum_type == SollumType.DRAWABLE_DICTIONARY:
+                if (
+                    self.asset.parent
+                    and hasattr(self.asset.parent, "sollum_type")
+                    and self.asset.parent.sollum_type == SollumType.DRAWABLE_DICTIONARY
+                ):
                     self.drawable_dictionary = self.asset.parent.name
             elif self.asset.sollum_type == SollumType.DRAWABLE_DICTIONARY:
                 self.asset_type = AssetType.DRAWABLE_DICTIONARY
@@ -134,39 +151,38 @@ class ArchetypeProperties(bpy.types.PropertyGroup, ExtensionsContainer):
     bb_max: bpy.props.FloatVectorProperty(name="Bound Max")
     bs_center: bpy.props.FloatVectorProperty(name="Bound Center")
     bs_radius: bpy.props.FloatProperty(name="Bound Radius")
-    type: bpy.props.EnumProperty(
-        items=items_from_enums(ArchetypeType), name="Type")
+    type: bpy.props.EnumProperty(items=items_from_enums(ArchetypeType), name="Type")
     lod_dist: bpy.props.FloatProperty(name="Lod Distance", default=60, min=-1)
-    flags: bpy.props.PointerProperty(
-        type=ArchetypeFlags, name="Flags")
+    flags: bpy.props.PointerProperty(type=ArchetypeFlags, name="Flags")
     special_attribute: bpy.props.IntProperty(name="Special Attribute")
     hd_texture_dist: bpy.props.FloatProperty(
-        name="HD Texture Distance", default=40, min=0)
+        name="HD Texture Distance", default=40, min=0
+    )
     name: bpy.props.StringProperty(name="Name")
     texture_dictionary: bpy.props.StringProperty(name="Texture Dictionary")
     clip_dictionary: bpy.props.StringProperty(name="Clip Dictionary")
     drawable_dictionary: bpy.props.StringProperty(name="Drawable Dictionary")
-    physics_dictionary: bpy.props.StringProperty(
-        name="Physics Dictionary")
+    physics_dictionary: bpy.props.StringProperty(name="Physics Dictionary")
     asset_type: bpy.props.EnumProperty(
-        items=items_from_enums(AssetType), name="Asset Type")
+        items=items_from_enums(AssetType), name="Asset Type"
+    )
     asset: bpy.props.PointerProperty(
-        name="Asset", type=bpy.types.Object, update=update_asset)
-    asset_name: bpy.props.StringProperty(
-        name="Asset Name")
+        name="Asset", type=bpy.types.Object, update=update_asset
+    )
+    asset_name: bpy.props.StringProperty(name="Asset Name")
     # Time archetype
     time_flags: bpy.props.PointerProperty(type=TimeFlags, name="Time Flags")
     # Mlo archetype
     mlo_flags: bpy.props.PointerProperty(type=UnknownFlags, name="MLO Flags")
     rooms: bpy.props.CollectionProperty(type=RoomProperties, name="Rooms")
-    portals: bpy.props.CollectionProperty(
-        type=PortalProperties, name="Portals")
-    entities: bpy.props.CollectionProperty(
-        type=MloEntityProperties, name="Entities")
+    portals: bpy.props.CollectionProperty(type=PortalProperties, name="Portals")
+    entities: bpy.props.CollectionProperty(type=MloEntityProperties, name="Entities")
     timecycle_modifiers: bpy.props.CollectionProperty(
-        type=TimecycleModifierProperties, name="Timecycle Modifiers")
+        type=TimecycleModifierProperties, name="Timecycle Modifiers"
+    )
     entity_sets: bpy.props.CollectionProperty(
-        type=EntitySetProperties, name="EntitySets")
+        type=EntitySetProperties, name="EntitySets"
+    )
 
     # Selected room index
     room_index: bpy.props.IntProperty(name="Room")
@@ -175,11 +191,9 @@ class ArchetypeProperties(bpy.types.PropertyGroup, ExtensionsContainer):
     # Selected entity index
     entity_index: bpy.props.IntProperty(name="Entity")
     # Selected timecycle modifier index
-    tcm_index: bpy.props.IntProperty(
-        name="Timecycle Modifier")
+    tcm_index: bpy.props.IntProperty(name="Timecycle Modifier")
     # Selected entityset
-    entity_set_index: bpy.props.IntProperty(
-        name="Entity Set")
+    entity_set_index: bpy.props.IntProperty(name="Entity Set")
 
     all_entity_lod_dist: bpy.props.FloatProperty(name="Entity Lod Distance: ")
 
@@ -187,7 +201,9 @@ class ArchetypeProperties(bpy.types.PropertyGroup, ExtensionsContainer):
 
     @property
     def non_entity_set_entities(self) -> list[MloEntityProperties]:
-        return [entity for entity in self.entities if entity.attached_entity_set_id == "-1"]
+        return [
+            entity for entity in self.entities if entity.attached_entity_set_id == "-1"
+        ]
 
     @property
     def selected_room(self) -> Union[RoomProperties, None]:
@@ -244,17 +260,16 @@ class CMapTypesProperties(bpy.types.PropertyGroup):
         return item
 
     name: bpy.props.StringProperty(name="Name")
-    all_texture_dictionary: bpy.props.StringProperty(
-        name="Texture Dictionary: ")
+    all_texture_dictionary: bpy.props.StringProperty(name="Texture Dictionary: ")
     all_lod_dist: bpy.props.FloatProperty(name="Lod Distance: ")
     all_hd_tex_dist: bpy.props.FloatProperty(name="HD Texture Distance: ")
     all_flags: bpy.props.IntProperty(name="Flags: ")
     # extensions
     archetypes: bpy.props.CollectionProperty(
-        type=ArchetypeProperties, name="Archetypes")
+        type=ArchetypeProperties, name="Archetypes"
+    )
     # Selected archetype index
-    archetype_index: bpy.props.IntProperty(
-        name="Archetype Index")
+    archetype_index: bpy.props.IntProperty(name="Archetype Index")
     # Unique archetype id
     last_archetype_id: bpy.props.IntProperty()
 
@@ -265,18 +280,24 @@ class CMapTypesProperties(bpy.types.PropertyGroup):
 
 def register():
     bpy.types.Scene.ytyps = bpy.props.CollectionProperty(
-        type=CMapTypesProperties, name="YTYPs")
+        type=CMapTypesProperties, name="YTYPs"
+    )
     bpy.types.Scene.ytyp_index = bpy.props.IntProperty(name="YTYP")
     bpy.types.Scene.show_room_gizmo = bpy.props.BoolProperty(
-        name="Show Room Gizmo", default=True)
+        name="Show Room Gizmo", default=True
+    )
     bpy.types.Scene.show_portal_gizmo = bpy.props.BoolProperty(
-        name="Show Portal Gizmo", default=True)
+        name="Show Portal Gizmo", default=True
+    )
 
     bpy.types.Scene.create_archetype_type = bpy.props.EnumProperty(
-        items=items_from_enums(ArchetypeType), name="Type")
+        items=items_from_enums(ArchetypeType), name="Type"
+    )
 
     bpy.types.Scene.ytyp_apply_transforms = bpy.props.BoolProperty(
-        name="Apply Parent Transforms", description="Apply transforms to all assets when calculating Archetype extents")
+        name="Apply Parent Transforms",
+        description="Apply transforms to all assets when calculating Archetype extents",
+    )
 
 
 def unregister():

--- a/ytyp/tools/__init__.py
+++ b/ytyp/tools/__init__.py
@@ -1,6 +1,9 @@
 import bpy
 from ..gizmos.extensions import SOLLUMZ_GGT_archetype_extensions
-from ..operators.extensions import SOLLUMZ_OT_delete_archetype_extension, SOLLUMZ_OT_duplicate_archetype_extension
+from ..operators.extensions import (
+    SOLLUMZ_OT_delete_archetype_extension,
+    SOLLUMZ_OT_duplicate_archetype_extension,
+)
 from ..utils import get_selected_extension
 from ...icons import ICON_GEOM_TOOL
 
@@ -16,10 +19,16 @@ class ArchetypeExtensionTool(bpy.types.WorkSpaceTool):
 
     bl_widget = SOLLUMZ_GGT_archetype_extensions.bl_idname
     bl_keymap = (
-        (SOLLUMZ_OT_delete_archetype_extension.bl_idname,
-         {"type": "DEL", "value": "PRESS"}, {"properties": []}),
-        (SOLLUMZ_OT_duplicate_archetype_extension.bl_idname,
-         {"type": "D", "value": "PRESS", "shift": True}, {"properties": []}),
+        (
+            SOLLUMZ_OT_delete_archetype_extension.bl_idname,
+            {"type": "DEL", "value": "PRESS"},
+            {"properties": []},
+        ),
+        (
+            SOLLUMZ_OT_duplicate_archetype_extension.bl_idname,
+            {"type": "D", "value": "PRESS", "shift": True},
+            {"properties": []},
+        ),
     )
 
     def draw_settings(context, layout, tool):

--- a/ytyp/ui/entities.py
+++ b/ytyp/ui/entities.py
@@ -1,6 +1,11 @@
 import bpy
 from ...tabbed_panels import TabbedPanelHelper, TabPanel
-from ...sollumz_ui import BasicListHelper, FlagsPanel, FilterListHelper, draw_list_with_add_remove
+from ...sollumz_ui import (
+    BasicListHelper,
+    FlagsPanel,
+    FilterListHelper,
+    draw_list_with_add_remove,
+)
 from ..properties.ytyp import ArchetypeType
 from ..properties.mlo import EntityProperties, MloEntityProperties
 from ..utils import get_selected_archetype, get_selected_entity
@@ -26,8 +31,12 @@ class SOLLUMZ_UL_ENTITIES_LIST(BasicListHelper, FilterListHelper, bpy.types.UILi
         elif filter_type == "portal":
             return scene.sollumz_entity_filter_portal == item.attached_portal_id
         elif filter_type == "entity_set":
-            in_entity_set = scene.sollumz_entity_filter_entity_set == item.attached_entity_set_id
-            in_room = scene.sollumz_entity_filter_entity_set_room == item.attached_room_id
+            in_entity_set = (
+                scene.sollumz_entity_filter_entity_set == item.attached_entity_set_id
+            )
+            in_room = (
+                scene.sollumz_entity_filter_entity_set_room == item.attached_room_id
+            )
 
             if scene.sollumz_do_entity_filter_entity_set_room:
                 return in_entity_set and in_room
@@ -60,8 +69,17 @@ class SOLLUMZ_PT_MLO_ENTITY_LIST_PANEL(TabPanel, bpy.types.Panel):
         layout.use_property_decorate = False
         selected_archetype = get_selected_archetype(context)
 
-        list_col, _ = draw_list_with_add_remove(self.layout, "sollumz.createmloentity", "sollumz.deletemloentity",
-                                                SOLLUMZ_UL_ENTITIES_LIST.bl_idname, "", selected_archetype, "entities", selected_archetype, "entity_index")
+        list_col, _ = draw_list_with_add_remove(
+            self.layout,
+            "sollumz.createmloentity",
+            "sollumz.deletemloentity",
+            SOLLUMZ_UL_ENTITIES_LIST.bl_idname,
+            "",
+            selected_archetype,
+            "entities",
+            selected_archetype,
+            "entity_index",
+        )
 
         filter_type = context.scene.sollumz_entity_filter_type
 
@@ -84,16 +102,14 @@ class SOLLUMZ_PT_MLO_ENTITY_LIST_PANEL(TabPanel, bpy.types.Panel):
             row.separator()
             col = row.column()
             col.enabled = context.scene.sollumz_do_entity_filter_entity_set_room
-            col.prop(context.scene,
-                     "sollumz_entity_filter_entity_set_room", text="")
+            col.prop(context.scene, "sollumz_entity_filter_entity_set_room", text="")
             list_col.separator()
 
         list_col.separator(factor=2)
         row = list_col.row(align=True)
         row.operator("sollumz.addobjasentity", icon="OUTLINER_OB_MESH")
 
-        list_col.operator("sollumz.setobjentitytransforms",
-                          icon="OUTLINER_DATA_EMPTY")
+        list_col.operator("sollumz.setobjentitytransforms", icon="OUTLINER_DATA_EMPTY")
 
         layout.separator()
 
@@ -169,7 +185,9 @@ class SOLLUMZ_UL_ENTITY_EXTENSIONS_LIST(bpy.types.UIList, ExtensionsListHelper):
     bl_idname = "SOLLUMZ_UL_ENTITY_EXTENSIONS_LIST"
 
 
-class SOLLUMZ_PT_ENTITY_EXTENSIONS_PANEL(TabPanel, ExtensionsPanelHelper, bpy.types.Panel):
+class SOLLUMZ_PT_ENTITY_EXTENSIONS_PANEL(
+    TabPanel, ExtensionsPanelHelper, bpy.types.Panel
+):
     bl_label = "Entity Extensions"
     bl_idname = "SOLLUMZ_PT_ENTITY_EXTENSIONS_PANEL"
     bl_space_type = "VIEW_3D"

--- a/ytyp/ui/entitysets.py
+++ b/ytyp/ui/entitysets.py
@@ -37,5 +37,14 @@ class SOLLUMZ_PT_ENTITY_SETS_PANEL(TabPanel, bpy.types.Panel):
         selected_archetype = get_selected_archetype(context)
 
         layout.label(text="Entity Sets")
-        draw_list_with_add_remove(self.layout, "sollumz.createentityset", "sollumz.deleteentityset",
-                                  SOLLUMZ_UL_ENTITY_SETS_LIST.bl_idname, "", selected_archetype, "entity_sets", selected_archetype, "entity_set_index")
+        draw_list_with_add_remove(
+            self.layout,
+            "sollumz.createentityset",
+            "sollumz.deleteentityset",
+            SOLLUMZ_UL_ENTITY_SETS_LIST.bl_idname,
+            "",
+            selected_archetype,
+            "entity_sets",
+            selected_archetype,
+            "entity_set_index",
+        )

--- a/ytyp/ui/extensions.py
+++ b/ytyp/ui/extensions.py
@@ -27,8 +27,7 @@ class ExtensionsListHelper:
             row.label(text=item.name, icon="CON_TRACKTO")
         elif self.layout_type in {"GRID"}:
             layout.alignment = "CENTER"
-            layout.prop(item, "name",
-                        text=item.name, emboss=False, icon="CON_TRACKTO")
+            layout.prop(item, "name", text=item.name, emboss=False, icon="CON_TRACKTO")
 
 
 class ExtensionsPanelHelper:
@@ -52,15 +51,22 @@ class ExtensionsPanelHelper:
         layout.use_property_decorate = False
         extensions_container = self.get_extensions_container(context)
 
-        _, side_col = draw_list_with_add_remove(layout, self.ADD_OPERATOR_ID, self.DELETE_OPERATOR_ID,
-                                             self.EXTENSIONS_LIST_ID, "", extensions_container, "extensions",
-                                             extensions_container, "extension_index")
+        _, side_col = draw_list_with_add_remove(
+            layout,
+            self.ADD_OPERATOR_ID,
+            self.DELETE_OPERATOR_ID,
+            self.EXTENSIONS_LIST_ID,
+            "",
+            extensions_container,
+            "extensions",
+            extensions_container,
+            "extension_index",
+        )
         side_col.separator()
         side_col.operator(self.DUPLICATE_OPERATOR_ID, text="", icon="DUPLICATE")
 
         selected_extension = extensions_container.selected_extension
         if selected_extension is not None:
-
             layout.separator()
 
             row = layout.row()
@@ -72,8 +78,7 @@ class ExtensionsPanelHelper:
 
             if selected_extension.extension_type == ExtensionType.LIGHT_SHAFT:
                 row = layout.row()
-                row.operator(
-                    SOLLUMZ_OT_update_light_shaft_offeset_location.bl_idname)
+                row.operator(SOLLUMZ_OT_update_light_shaft_offeset_location.bl_idname)
                 row = layout.row()
                 row.operator(SOLLUMZ_OT_update_corner_a_location.bl_idname)
                 row.operator(SOLLUMZ_OT_update_corner_b_location.bl_idname)
@@ -85,15 +90,18 @@ class ExtensionsPanelHelper:
                 layout.separator()
                 row = layout.row()
                 row.operator(
-                    SOLLUMZ_OT_calculate_light_shaft_center_offset_location.bl_idname)
+                    SOLLUMZ_OT_calculate_light_shaft_center_offset_location.bl_idname
+                )
                 layout.separator()
 
             extension_properties = selected_extension.get_properties()
 
             row = layout.row()
             row.prop(extension_properties, "offset_position")
-            for prop_name in selected_extension.get_properties().__class__.__annotations__:
-                if prop_name in {'direction_amount', 'cornerA'}:
+            for (
+                prop_name
+            ) in selected_extension.get_properties().__class__.__annotations__:
+                if prop_name in {"direction_amount", "cornerA"}:
                     layout.separator()
                 row = layout.row()
                 row.prop(extension_properties, prop_name)
@@ -104,7 +112,9 @@ class SOLLUMZ_UL_ARCHETYPE_EXTENSIONS_LIST(BasicListHelper, bpy.types.UIList):
     icon = "CON_TRACKTO"
 
 
-class SOLLUMZ_PT_ARCHETYPE_EXTENSIONS_PANEL(TabPanel, ExtensionsPanelHelper, bpy.types.Panel):
+class SOLLUMZ_PT_ARCHETYPE_EXTENSIONS_PANEL(
+    TabPanel, ExtensionsPanelHelper, bpy.types.Panel
+):
     bl_label = "Extensions"
     bl_idname = "SOLLUMZ_PT_ARCHETYPE_EXTENSIONS_PANEL"
     bl_space_type = "VIEW_3D"
@@ -138,8 +148,7 @@ class SOLLUMZ_PT_ARCHETYPE_EXTENSIONS_PANEL(TabPanel, ExtensionsPanelHelper, bpy
 
         if selected_extension.extension_type == ExtensionType.LADDER:
             row = layout.row()
-            row.operator(
-                SOLLUMZ_OT_update_offset_and_top_from_selected.bl_idname)
+            row.operator(SOLLUMZ_OT_update_offset_and_top_from_selected.bl_idname)
             row.operator(SOLLUMZ_OT_update_bottom_from_selected.bl_idname)
 
         if selected_extension.extension_type == ExtensionType.PARTICLE:

--- a/ytyp/ui/mlo.py
+++ b/ytyp/ui/mlo.py
@@ -2,8 +2,17 @@ import bpy
 from ...tabbed_panels import TabbedPanelHelper, TabPanel
 from ...sollumz_ui import BasicListHelper, FlagsPanel, draw_list_with_add_remove
 from ..properties.ytyp import ArchetypeType
-from ..properties.mlo import RoomProperties, PortalProperties, TimecycleModifierProperties
-from ..utils import get_selected_archetype, get_selected_room, get_selected_portal, get_selected_tcm
+from ..properties.mlo import (
+    RoomProperties,
+    PortalProperties,
+    TimecycleModifierProperties,
+)
+from ..utils import (
+    get_selected_archetype,
+    get_selected_room,
+    get_selected_portal,
+    get_selected_tcm,
+)
 from .archetype import SOLLUMZ_PT_ARCHETYPE_TABS_PANEL
 
 
@@ -22,7 +31,10 @@ class SOLLUMZ_PT_MLO_PANEL(TabbedPanelHelper, bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         selected_archetype = get_selected_archetype(context)
-        return selected_archetype is not None and selected_archetype.type == ArchetypeType.MLO
+        return (
+            selected_archetype is not None
+            and selected_archetype.type == ArchetypeType.MLO
+        )
 
     def draw_before(self, context: bpy.types.Context):
         self.layout.label(text="MLO")
@@ -57,8 +69,17 @@ class SOLLUMZ_PT_ROOM_PANEL(TabPanel, bpy.types.Panel):
         layout.use_property_decorate = False
         selected_archetype = get_selected_archetype(context)
 
-        list_col, _ = draw_list_with_add_remove(self.layout, "sollumz.createroom", "sollumz.deleteroom",
-                                                SOLLUMZ_UL_ROOM_LIST.bl_idname, "", selected_archetype, "rooms", selected_archetype, "room_index")
+        list_col, _ = draw_list_with_add_remove(
+            self.layout,
+            "sollumz.createroom",
+            "sollumz.deleteroom",
+            SOLLUMZ_UL_ROOM_LIST.bl_idname,
+            "",
+            selected_archetype,
+            "rooms",
+            selected_archetype,
+            "room_index",
+        )
 
         list_col.operator("sollumz.createlimboroom")
 
@@ -69,8 +90,7 @@ class SOLLUMZ_PT_ROOM_PANEL(TabPanel, bpy.types.Panel):
         if not selected_archetype.asset and context.scene.show_room_gizmo:
             row = layout.row()
             row.alert = True
-            row.label(
-                text="Gizmo will not appear when no object is linked.")
+            row.label(text="Gizmo will not appear when no object is linked.")
 
         selected_room = get_selected_room(context)
         if not selected_room:
@@ -82,8 +102,7 @@ class SOLLUMZ_PT_ROOM_PANEL(TabPanel, bpy.types.Panel):
                 continue
             layout.prop(selected_room, prop_name)
 
-        list_col.operator(
-            "sollumz.setroomboundsfromselection", icon="GROUP_VERTEX")
+        list_col.operator("sollumz.setroomboundsfromselection", icon="GROUP_VERTEX")
 
 
 class SOLLUMZ_PT_ROOM_FLAGS_PANEL(FlagsPanel, bpy.types.Panel):
@@ -131,27 +150,39 @@ class SOLLUMZ_PT_PORTAL_PANEL(TabPanel, bpy.types.Panel):
         layout.use_property_decorate = False
         selected_archetype = get_selected_archetype(context)
 
-        list_col, _ = draw_list_with_add_remove(self.layout, "sollumz.createportal", "sollumz.deleteportal",
-                                                SOLLUMZ_UL_PORTAL_LIST.bl_idname, "", selected_archetype, "portals", selected_archetype, "portal_index")
+        list_col, _ = draw_list_with_add_remove(
+            self.layout,
+            "sollumz.createportal",
+            "sollumz.deleteportal",
+            SOLLUMZ_UL_PORTAL_LIST.bl_idname,
+            "",
+            selected_archetype,
+            "portals",
+            selected_archetype,
+            "portal_index",
+        )
 
         row = list_col.row()
-        row.operator("sollumz.createportalfromselection",
-                     text="Create From Vertices", icon="GROUP_VERTEX")
-        row.prop(context.scene, "sollumz_add_portal_room_from",
-                 icon="CUBE", text="")
+        row.operator(
+            "sollumz.createportalfromselection",
+            text="Create From Vertices",
+            icon="GROUP_VERTEX",
+        )
+        row.prop(context.scene, "sollumz_add_portal_room_from", icon="CUBE", text="")
 
         row.label(text="", icon="FORWARD")
 
-        row.prop(context.scene, "sollumz_add_portal_room_to",
-                 icon="CUBE", text="")
+        row.prop(context.scene, "sollumz_add_portal_room_to", icon="CUBE", text="")
 
         list_col.separator(factor=2)
 
         row = list_col.row(align=True)
-        row.operator("sollumz.updateportalfromselection",
-                     text="Update From Vertices", icon="GROUP_VERTEX")
-        row.operator("sollumz.flipportal",
-                     text="Flip Direction", icon="LOOP_FORWARDS")
+        row.operator(
+            "sollumz.updateportalfromselection",
+            text="Update From Vertices",
+            icon="GROUP_VERTEX",
+        )
+        row.operator("sollumz.flipportal", text="Flip Direction", icon="LOOP_FORWARDS")
 
         row = layout.row()
         row.use_property_split = False
@@ -178,8 +209,7 @@ class SOLLUMZ_PT_PORTAL_PANEL(TabPanel, bpy.types.Panel):
 
         row = layout.row()
         row.prop(selected_portal, "room_from_id")
-        row.operator("sollumz.search_portal_room_from",
-                     text="", icon="VIEWZOOM")
+        row.operator("sollumz.search_portal_room_from", text="", icon="VIEWZOOM")
         row = layout.row()
         row.prop(selected_portal, "room_to_id")
         row.operator("sollumz.search_portal_room_to", text="", icon="VIEWZOOM")
@@ -248,8 +278,17 @@ class SOLLUMZ_PT_TIMECYCLE_MODIFIER_PANEL(TabPanel, bpy.types.Panel):
         layout.use_property_decorate = False
         selected_archetype = get_selected_archetype(context)
 
-        draw_list_with_add_remove(self.layout, "sollumz.createtimecyclemodifier", "sollumz.deletetimecyclemodifier",
-                                  SOLLUMZ_UL_TIMECYCLE_MODIFIER_LIST.bl_idname, "", selected_archetype, "timecycle_modifiers", selected_archetype, "tcm_index")
+        draw_list_with_add_remove(
+            self.layout,
+            "sollumz.createtimecyclemodifier",
+            "sollumz.deletetimecyclemodifier",
+            SOLLUMZ_UL_TIMECYCLE_MODIFIER_LIST.bl_idname,
+            "",
+            selected_archetype,
+            "timecycle_modifiers",
+            selected_archetype,
+            "tcm_index",
+        )
 
         selected_tcm = get_selected_tcm(context)
 

--- a/ytyp/ui/ytyp.py
+++ b/ytyp/ui/ytyp.py
@@ -1,12 +1,13 @@
 import bpy
-from ...sollumz_ui import BasicListHelper, SollumzFileSettingsPanel, draw_list_with_add_remove
+from ...sollumz_ui import (
+    BasicListHelper,
+    SollumzFileSettingsPanel,
+    draw_list_with_add_remove,
+)
 from ...sollumz_properties import ArchetypeType
 from ...sollumz_preferences import get_export_settings, SollumzExportSettings
 
-from ..utils import (
-    get_selected_ytyp,
-    get_selected_archetype
-)
+from ..utils import get_selected_ytyp, get_selected_archetype
 
 
 class SOLLUMZ_UL_YTYP_LIST(BasicListHelper, bpy.types.UIList):
@@ -41,8 +42,18 @@ class SOLLUMZ_PT_YTYP_LIST_PANEL(bpy.types.Panel):
     bl_order = 0
 
     def draw(self, context):
-        list_col, _ = draw_list_with_add_remove(self.layout, "sollumz.createytyp", "sollumz.deleteytyp",
-                                                SOLLUMZ_UL_YTYP_LIST.bl_idname, "", context.scene, "ytyps", context.scene, "ytyp_index", rows=3)
+        list_col, _ = draw_list_with_add_remove(
+            self.layout,
+            "sollumz.createytyp",
+            "sollumz.deleteytyp",
+            SOLLUMZ_UL_YTYP_LIST.bl_idname,
+            "",
+            context.scene,
+            "ytyps",
+            context.scene,
+            "ytyp_index",
+            rows=3,
+        )
         row = list_col.row()
         row.operator("sollumz.importytyp", icon="IMPORT")
         row.operator("sollumz.exportytyp", icon="EXPORT")
@@ -55,7 +66,9 @@ class SOLLUMZ_PT_export_ytyp(bpy.types.Panel, SollumzFileSettingsPanel):
     def get_settings(self, context: bpy.types.Context) -> SollumzExportSettings:
         return get_export_settings(context)
 
-    def draw_settings(self, layout: bpy.types.UILayout, settings: SollumzExportSettings):
+    def draw_settings(
+        self, layout: bpy.types.UILayout, settings: SollumzExportSettings
+    ):
         layout.use_property_split = False
         layout.prop(settings, "apply_transforms")
 
@@ -91,11 +104,20 @@ class SOLLUMZ_PT_ARCHETYPE_LIST_PANEL(bpy.types.Panel):
     def draw(self, context):
         selected_ytyp = get_selected_ytyp(context)
 
-        list_col, _ = draw_list_with_add_remove(self.layout, "sollumz.createarchetype", "sollumz.deletearchetype", SOLLUMZ_UL_ARCHETYPE_LIST.bl_idname, "", selected_ytyp, "archetypes",
-                                                selected_ytyp, "archetype_index", rows=3)
+        list_col, _ = draw_list_with_add_remove(
+            self.layout,
+            "sollumz.createarchetype",
+            "sollumz.deletearchetype",
+            SOLLUMZ_UL_ARCHETYPE_LIST.bl_idname,
+            "",
+            selected_ytyp,
+            "archetypes",
+            selected_ytyp,
+            "archetype_index",
+            rows=3,
+        )
         row = list_col.row()
-        row.operator("sollumz.createarchetypefromselected",
-                     icon="FILE_REFRESH")
+        row.operator("sollumz.createarchetypefromselected", icon="FILE_REFRESH")
         row.prop(context.scene, "create_archetype_type", text="")
 
 

--- a/ytyp/utils.py
+++ b/ytyp/utils.py
@@ -4,7 +4,13 @@ from typing import Union, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .properties.ytyp import CMapTypesProperties, ArchetypeProperties
-    from .properties.mlo import RoomProperties, PortalProperties, MloEntityProperties, TimecycleModifierProperties, EntitySetProperties
+    from .properties.mlo import (
+        RoomProperties,
+        PortalProperties,
+        MloEntityProperties,
+        TimecycleModifierProperties,
+        EntitySetProperties,
+    )
     from .properties.extensions import ExtensionProperties
 
 import bpy
@@ -76,7 +82,11 @@ def get_selected_entity_set_id(context):
             return str(archetype.selected_entity_set_id + 1)
 
 
-def validate_dynamic_enum(data_block: bpy.types.ID, prop_name: str, enum_collection: bpy.types.bpy_prop_collection):
+def validate_dynamic_enum(
+    data_block: bpy.types.ID,
+    prop_name: str,
+    enum_collection: bpy.types.bpy_prop_collection,
+):
     """Hack to esnure the EnumProperty ``data_block.prop_name`` has a valid enum value."""
     ids = {str(item.id) for item in enum_collection}
     current_value = getattr(data_block, prop_name)
@@ -87,7 +97,11 @@ def validate_dynamic_enum(data_block: bpy.types.ID, prop_name: str, enum_collect
     setattr(data_block, prop_name, "-1")
 
 
-def validate_dynamic_enums(collection: bpy.types.bpy_prop_collection, prop_name: str, enum_collection: bpy.types.bpy_prop_collection):
+def validate_dynamic_enums(
+    collection: bpy.types.bpy_prop_collection,
+    prop_name: str,
+    enum_collection: bpy.types.bpy_prop_collection,
+):
     """Hack to ensure the EnumProperty ``data_block.prop_name`` for all items in ``collection`` has a valid enum value."""
     for item in collection:
         validate_dynamic_enum(item, prop_name, enum_collection)

--- a/ytyp/ytypexport.py
+++ b/ytyp/ytypexport.py
@@ -3,21 +3,43 @@ import bpy
 from mathutils import Euler, Vector, Quaternion, Matrix
 
 from ..cwxml import ytyp as ytypxml, ymap as ymapxml
-from ..sollumz_properties import ArchetypeType, AssetType, EntityLodLevel, EntityPriorityLevel
+from ..sollumz_properties import (
+    ArchetypeType,
+    AssetType,
+    EntityLodLevel,
+    EntityPriorityLevel,
+)
 from ..tools import jenkhash
-from ..tools.meshhelper import get_combined_bound_box, get_bound_center_from_bounds, get_sphere_radius
-from .properties.ytyp import ArchetypeProperties, TimecycleModifierProperties, RoomProperties, PortalProperties, MloEntityProperties, EntitySetProperties
+from ..tools.meshhelper import (
+    get_combined_bound_box,
+    get_bound_center_from_bounds,
+    get_sphere_radius,
+)
+from .properties.ytyp import (
+    ArchetypeProperties,
+    TimecycleModifierProperties,
+    RoomProperties,
+    PortalProperties,
+    MloEntityProperties,
+    EntitySetProperties,
+)
 from .properties.extensions import ExtensionProperties
 
 
-def set_room_attached_objects(room_xml: ytypxml.Room, room_index: int, entities: Iterable[MloEntityProperties]):
+def set_room_attached_objects(
+    room_xml: ytypxml.Room, room_index: int, entities: Iterable[MloEntityProperties]
+):
     """Set attached objects of room from the mlo archetype entities collection provided."""
     for i, entity in enumerate(entities):
         if entity.room_index == room_index:
             room_xml.attached_objects.append(i)
 
 
-def set_portal_attached_objects(portal_xml: ytypxml.Portal, portal_index: int, entities: Iterable[MloEntityProperties]):
+def set_portal_attached_objects(
+    portal_xml: ytypxml.Portal,
+    portal_index: int,
+    entities: Iterable[MloEntityProperties],
+):
     """Set attached objects of portal from the mlo archetype entities collection provided."""
     for i, entity in enumerate(entities):
         if entity.portal_index == portal_index:
@@ -35,7 +57,9 @@ def get_portal_count(room: RoomProperties, portals: Iterable[PortalProperties]) 
     return count
 
 
-def set_entity_xml_transforms_from_object(entity_obj: bpy.types.Object, entity_xml: ymapxml.Entity):
+def set_entity_xml_transforms_from_object(
+    entity_obj: bpy.types.Object, entity_xml: ymapxml.Entity
+):
     """Set the transforms of an entity xml based on a Blender mesh object."""
 
     entity_xml.position = entity_obj.location
@@ -63,7 +87,9 @@ def set_portal_xml_corners(portal: PortalProperties, portal_xml: ytypxml.Portal)
         portal_xml.corners.append(corner_xml)
 
 
-def create_entity_set_xml(entityset: EntitySetProperties, entities: list[MloEntityProperties]) -> ytypxml.EntitySet:
+def create_entity_set_xml(
+    entityset: EntitySetProperties, entities: list[MloEntityProperties]
+) -> ytypxml.EntitySet:
     """Create xml mlo entity sets from an entityset data-block"""
     entity_set = ytypxml.EntitySet()
     entity_set.name = entityset.name
@@ -97,10 +123,16 @@ def create_entity_xml(entity: MloEntityProperties) -> ymapxml.Entity:
     entity_xml.artificial_ambient_occlusion = entity.artificial_ambient_occlusion
     entity_xml.tint_value = entity.tint_value
 
-    lod_level = next(name for name, value in vars(
-        EntityLodLevel).items() if value == (entity.lod_level))
-    priority_level = next(name for name, value in vars(
-        EntityPriorityLevel).items() if value == (entity.priority_level))
+    lod_level = next(
+        name
+        for name, value in vars(EntityLodLevel).items()
+        if value == (entity.lod_level)
+    )
+    priority_level = next(
+        name
+        for name, value in vars(EntityPriorityLevel).items()
+        if value == (entity.priority_level)
+    )
     entity_xml.lod_level = lod_level
     entity_xml.priority_level = priority_level
 
@@ -111,7 +143,9 @@ def create_entity_xml(entity: MloEntityProperties) -> ymapxml.Entity:
     return entity_xml
 
 
-def create_room_xml(room: RoomProperties, room_index: int, archetype: ArchetypeProperties) -> ytypxml.Room:
+def create_room_xml(
+    room: RoomProperties, room_index: int, archetype: ArchetypeProperties
+) -> ytypxml.Room:
     """Create xml room from a room data-block."""
 
     room_xml = ytypxml.Room()
@@ -124,16 +158,16 @@ def create_room_xml(room: RoomProperties, room_index: int, archetype: ArchetypeP
     room_xml.flags = room.flags.total
     room_xml.floor_id = room.floor_id
     room_xml.exterior_visibility_depth = room.exterior_visibility_depth
-    room_xml.portal_count = get_portal_count(
-        room, archetype.portals)
+    room_xml.portal_count = get_portal_count(room, archetype.portals)
 
-    set_room_attached_objects(room_xml, room_index,
-                              archetype.non_entity_set_entities)
+    set_room_attached_objects(room_xml, room_index, archetype.non_entity_set_entities)
 
     return room_xml
 
 
-def create_portal_xml(portal: PortalProperties, portal_index: int, archetype: ArchetypeProperties) -> ytypxml.Portal:
+def create_portal_xml(
+    portal: PortalProperties, portal_index: int, archetype: ArchetypeProperties
+) -> ytypxml.Portal:
     """Create xml portal from a portal data-block."""
 
     portal_xml = ytypxml.Portal()
@@ -145,11 +179,11 @@ def create_portal_xml(portal: PortalProperties, portal_index: int, archetype: Ar
     portal_xml.flags = portal.flags.total
     portal_xml.mirror_priority = portal.mirror_priority
     portal_xml.opacity = portal.opacity
-    portal_xml.audio_occlusion = int(
-        portal.audio_occlusion)
+    portal_xml.audio_occlusion = int(portal.audio_occlusion)
 
     set_portal_attached_objects(
-        portal_xml, portal_index, archetype.non_entity_set_entities)
+        portal_xml, portal_index, archetype.non_entity_set_entities
+    )
 
     return portal_xml
 
@@ -168,19 +202,19 @@ def create_tcm_xml(tcm: TimecycleModifierProperties) -> ytypxml.TimeCycleModifie
     return tcm_xml
 
 
-def set_extension_xml_props(extension: ExtensionProperties, extension_xml: ymapxml.Extension):
+def set_extension_xml_props(
+    extension: ExtensionProperties, extension_xml: ymapxml.Extension
+):
     """Automatically set extension xml properties based on BaseExtensionProperties data-block."""
     extension_xml.name = extension.name
     extension_properties = extension.get_properties()
 
-    extension_xml.offset_position = Vector(
-        extension_properties.offset_position)
+    extension_xml.offset_position = Vector(extension_properties.offset_position)
 
     for prop_name in extension_properties.__class__.__annotations__:
         if not hasattr(extension_xml, prop_name):
             # Unknown prop name. Need warning
-            print(
-                f"Unknown {extension.extension_type} prop name '{prop_name}'.")
+            print(f"Unknown {extension.extension_type} prop name '{prop_name}'.")
             continue
 
         prop_value = getattr(extension_properties, prop_name)
@@ -207,7 +241,8 @@ def create_extension_xml(extension: ExtensionProperties):
 
     extension_type = extension.extension_type
     extension_xml_class = ymapxml.ExtensionsList.get_extension_xml_class_from_type(
-        extension_type)
+        extension_type
+    )
 
     if extension_xml_class is None:
         # Warning needed here. Unknown extension type
@@ -221,31 +256,38 @@ def create_extension_xml(extension: ExtensionProperties):
     return extension_xml
 
 
-def set_archetype_xml_bounds_from_asset(archetype: ArchetypeProperties, archetype_xml: ytypxml.BaseArchetype, apply_transforms: bool = False):
+def set_archetype_xml_bounds_from_asset(
+    archetype: ArchetypeProperties,
+    archetype_xml: ytypxml.BaseArchetype,
+    apply_transforms: bool = False,
+):
     """Calculate bounds from the archetype asset."""
 
     if apply_transforms:
         # Unapply only translation
-        matrix = Matrix.Translation(
-            archetype.asset.matrix_world.translation).inverted()
+        matrix = Matrix.Translation(archetype.asset.matrix_world.translation).inverted()
     else:
         # Unapply all transforms
         matrix = archetype.asset.matrix_world.inverted()
 
     bbmin, bbmax = get_combined_bound_box(
-        archetype.asset, use_world=True, matrix=matrix)
+        archetype.asset, use_world=True, matrix=matrix
+    )
     archetype_xml.bb_min = bbmin
     archetype_xml.bb_max = bbmax
     archetype_xml.bs_center = get_bound_center_from_bounds(bbmin, bbmax)
     archetype_xml.bs_radius = get_sphere_radius(bbmax, archetype_xml.bs_center)
 
 
-def set_archetype_xml_bounds(archetype: ArchetypeProperties, archetype_xml: ytypxml.BaseArchetype, apply_transforms: bool = False):
+def set_archetype_xml_bounds(
+    archetype: ArchetypeProperties,
+    archetype_xml: ytypxml.BaseArchetype,
+    apply_transforms: bool = False,
+):
     """Set archetype xml bounds from archetype data-block bounds."""
 
     if archetype.asset:
-        set_archetype_xml_bounds_from_asset(
-            archetype, archetype_xml, apply_transforms)
+        set_archetype_xml_bounds_from_asset(archetype, archetype_xml, apply_transforms)
         return
 
     archetype_xml.bb_min = Vector(archetype.bb_min)
@@ -269,7 +311,9 @@ def get_xml_asset_type(asset_type: AssetType) -> str:
         return "ASSET_TYPE_ASSETLESS"
 
 
-def create_mlo_archetype_children_xml(archetype: ArchetypeProperties, archetype_xml: ytypxml.MloArchetype):
+def create_mlo_archetype_children_xml(
+    archetype: ArchetypeProperties, archetype_xml: ytypxml.MloArchetype
+):
     """Create all mlo children from an archetype data-block for the provided archetype xml."""
     for entity in archetype.entities:
         if entity.attached_entity_set_id != "-1":
@@ -277,22 +321,23 @@ def create_mlo_archetype_children_xml(archetype: ArchetypeProperties, archetype_
         archetype_xml.entities.append(create_entity_xml(entity))
 
     for room_index, room in enumerate(archetype.rooms):
-        archetype_xml.rooms.append(
-            create_room_xml(room, room_index, archetype))
+        archetype_xml.rooms.append(create_room_xml(room, room_index, archetype))
 
     for portal_index, portal in enumerate(archetype.portals):
-        archetype_xml.portals.append(
-            create_portal_xml(portal, portal_index, archetype))
+        archetype_xml.portals.append(create_portal_xml(portal, portal_index, archetype))
 
     for tcm in archetype.timecycle_modifiers:
         archetype_xml.timecycle_modifiers.append(create_tcm_xml(tcm))
 
     for entityset in archetype.entity_sets:
         archetype_xml.entity_sets.append(
-            create_entity_set_xml(entityset, archetype.entities))
+            create_entity_set_xml(entityset, archetype.entities)
+        )
 
 
-def create_archetype_xml(archetype: ArchetypeProperties, apply_transforms: bool = False) -> ytypxml.BaseArchetype:
+def create_archetype_xml(
+    archetype: ArchetypeProperties, apply_transforms: bool = False
+) -> ytypxml.BaseArchetype:
     """Create archetype xml from an archetype data block"""
 
     archetype_xml = None

--- a/ytyp/ytypimport.py
+++ b/ytyp/ytypimport.py
@@ -4,12 +4,31 @@ from typing import Union
 from mathutils import Vector, Quaternion
 
 from ..cwxml import ytyp as ytypxml, ymap as ymapxml
-from ..sollumz_properties import ArchetypeType, AssetType, EntityLodLevel, EntityPriorityLevel
-from .properties.ytyp import CMapTypesProperties, ArchetypeProperties, TimecycleModifierProperties, RoomProperties, PortalProperties, MloEntityProperties, EntitySetProperties
-from .properties.extensions import ExtensionProperties, ExtensionType, ExtensionsContainer
+from ..sollumz_properties import (
+    ArchetypeType,
+    AssetType,
+    EntityLodLevel,
+    EntityPriorityLevel,
+)
+from .properties.ytyp import (
+    CMapTypesProperties,
+    ArchetypeProperties,
+    TimecycleModifierProperties,
+    RoomProperties,
+    PortalProperties,
+    MloEntityProperties,
+    EntitySetProperties,
+)
+from .properties.extensions import (
+    ExtensionProperties,
+    ExtensionType,
+    ExtensionsContainer,
+)
 
 
-def create_mlo_entity_set(entity_set_xml: ytypxml.EntitySet, archetype: ArchetypeProperties):
+def create_mlo_entity_set(
+    entity_set_xml: ytypxml.EntitySet, archetype: ArchetypeProperties
+):
     """Create an mlo entity sets from an xml for the provided archetype data-block."""
 
     entity_set: EntitySetProperties = archetype.new_entity_set()
@@ -25,7 +44,9 @@ def create_mlo_entity_set(entity_set_xml: ytypxml.EntitySet, archetype: Archetyp
         entity.attached_room_id = str(entity_room.id)
 
 
-def create_entity_set_entity(entity_xml: ymapxml.Entity, entity_set: EntitySetProperties):
+def create_entity_set_entity(
+    entity_xml: ymapxml.Entity, entity_set: EntitySetProperties
+):
     """Create an mlo entity from an xml for the provided archetype data-block."""
 
     entity: MloEntityProperties = entity_set.new_entity_set_entity()
@@ -76,8 +97,7 @@ def create_mlo_portal(portal_xml: ytypxml.Portal, archetype: ArchetypeProperties
     portal.flags.total = str(portal_xml.flags)
     portal.mirror_priority = portal_xml.mirror_priority
     portal.opacity = portal_xml.opacity
-    portal.audio_occlusion = str(
-        portal_xml.audio_occlusion)
+    portal.audio_occlusion = str(portal_xml.audio_occlusion)
     for index in portal_xml.attached_objects:
         archetype.entities[index].attached_portal_id = str(portal.id)
 
@@ -99,16 +119,20 @@ def create_mlo_room(room_xml: ytypxml.Room, archetype: ArchetypeProperties):
         archetype.entities[index].attached_room_id = str(room.id)
 
 
-def find_and_link_entity_object(entity_xml: ymapxml.Entity, entity: MloEntityProperties):
+def find_and_link_entity_object(
+    entity_xml: ymapxml.Entity, entity: MloEntityProperties
+):
     """Atempt to find an existing entity object in the scene and link it to the entity data-block."""
 
     for obj in bpy.context.collection.all_objects:
-        if entity_xml.archetype_name == obj.name and obj.name in bpy.context.view_layer.objects:
+        if (
+            entity_xml.archetype_name == obj.name
+            and obj.name in bpy.context.view_layer.objects
+        ):
             entity.linked_object = obj
             obj.location = entity.position
             obj.rotation_euler = entity.rotation.to_euler()
-            obj.scale = Vector(
-                (entity.scale_xy, entity.scale_xy, entity.scale_z))
+            obj.scale = Vector((entity.scale_xy, entity.scale_xy, entity.scale_z))
 
 
 def create_mlo_entity(entity_xml: ymapxml.Entity, archetype: ArchetypeProperties):
@@ -141,7 +165,9 @@ def create_mlo_entity(entity_xml: ymapxml.Entity, archetype: ArchetypeProperties
     return entity
 
 
-def set_extension_props(extension_xml: ymapxml.Extension, extension: ExtensionProperties):
+def set_extension_props(
+    extension_xml: ymapxml.Extension, extension: ExtensionProperties
+):
     """Set extension data-block properties to the provided extension xml props."""
     extension.name = extension_xml.name
     extension_properties = extension.get_properties()
@@ -151,8 +177,7 @@ def set_extension_props(extension_xml: ymapxml.Extension, extension: ExtensionPr
     for prop_name in extension_properties.__class__.__annotations__:
         if not hasattr(extension_xml, prop_name):
             # Unknown prop name. Need warning
-            print(
-                f"Unknown {extension.extension_type} prop name '{prop_name}'.")
+            print(f"Unknown {extension.extension_type} prop name '{prop_name}'.")
             continue
 
         prop_value = getattr(extension_xml, prop_name)
@@ -172,11 +197,12 @@ def set_extension_props(extension_xml: ymapxml.Extension, extension: ExtensionPr
                 prop_value_int = 0
             prop_value = f"hash_{prop_value_int:08X}" if prop_value_int != 0 else ""
 
-
         setattr(extension_properties, prop_name, prop_value)
 
 
-def create_extension(extension_xml: ymapxml.Extension, extensions_container: ExtensionsContainer) -> Union[ExtensionProperties, None]:
+def create_extension(
+    extension_xml: ymapxml.Extension, extensions_container: ExtensionsContainer
+) -> Union[ExtensionProperties, None]:
     """Create an entity extension from the given extension xml."""
 
     extension_type = extension_xml.type
@@ -192,7 +218,9 @@ def create_extension(extension_xml: ymapxml.Extension, extensions_container: Ext
     return extension
 
 
-def create_mlo_archetype_children(archetype_xml: ytypxml.MloArchetype, archetype: ArchetypeProperties):
+def create_mlo_archetype_children(
+    archetype_xml: ytypxml.MloArchetype, archetype: ArchetypeProperties
+):
     """Create entities, rooms, portals, and timecylce modifiers for an mlo archetype."""
 
     for entity_xml in archetype_xml.entities:


### PR DESCRIPTION
we've used PEP8 formatting standard for the longest time, but in my opinion it isnt very good and often makes code harder to read.

that being said, pythons black formatter makes everything incredibly easy to read and formats everything in a very neat and tidy way.