### PR TITLE
tweak(ymap): select ymap group object on creation and prevent X/Y rotation on Box Occluders and Car Generators

### DIFF
--- a/tools/ymaphelper.py
+++ b/tools/ymaphelper.py
@@ -26,7 +26,6 @@ def create_ymap(name="ymap", sollum_type=SollumType.YMAP):
     empty.empty_display_size = 0
     empty.sollum_type = sollum_type
     empty.name = name
-    empty.ymap_properties.name = name
     bpy.context.collection.objects.link(empty)
     return empty
 

--- a/tools/ymaphelper.py
+++ b/tools/ymaphelper.py
@@ -30,7 +30,7 @@ def create_ymap(name="ymap", sollum_type=SollumType.YMAP):
     return empty
 
 
-def create_ymap_group(sollum_type=None, selected_ymap=None, empty_name=None):
+def create_ymap_group(sollum_type=None, selected_ymap=None, empty_name=None, select=True):
     empty = bpy.data.objects.new(SOLLUMZ_UI_NAMES[sollum_type], None)
     empty.empty_display_size = 0
     empty.sollum_type = sollum_type
@@ -43,6 +43,12 @@ def create_ymap_group(sollum_type=None, selected_ymap=None, empty_name=None):
         selected_ymap.ymap_properties.content_flags_toggle.has_occl = True
     empty.parent = selected_ymap
     calculate_ymap_content_flags(selected_ymap, sollum_type)
+
+    if select:
+        bpy.ops.object.select_all(action='DESELECT')
+        empty.select_set(True)
+        bpy.context.view_layer.objects.active = empty
+
     return empty
 
 

--- a/ymap/operators.py
+++ b/ymap/operators.py
@@ -12,9 +12,11 @@ class SOLLUMZ_OT_create_ymap(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         ymap_obj = create_ymap()
-        context.view_layer.objects.active = bpy.data.objects[ymap_obj.name]
-        ymap_obj.select_set(True)
-        return True
+        if ymap_obj:
+            bpy.ops.object.select_all(action='DESELECT')
+            ymap_obj.select_set(True)
+            context.view_layer.objects.active = ymap_obj
+        return {"FINISHED"}
 
 
 class SOLLUMZ_OT_create_entity_group(SOLLUMZ_OT_base, bpy.types.Operator):
@@ -37,7 +39,13 @@ class SOLLUMZ_OT_create_entity_group(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         ymap_obj = context.active_object
-        create_ymap_group(sollum_type=SollumType.YMAP_ENTITY_GROUP, selected_ymap=ymap_obj, empty_name='Entities')
+        ymap_group = create_ymap_group(sollum_type=SollumType.YMAP_ENTITY_GROUP, selected_ymap=ymap_obj, empty_name='Entities')
+        if ymap_group:
+            bpy.ops.object.select_all(action='DESELECT')
+            ymap_group.select_set(True)
+            context.view_layer.objects.active = ymap_group
+            # TODO: Find a way to use "bpy.ops.outliner.show_active()" to show the new object in outliner. But we are in wrong context here.
+
         return True
 
 
@@ -61,7 +69,11 @@ class SOLLUMZ_OT_create_model_occluder_group(SOLLUMZ_OT_base, bpy.types.Operator
 
     def run(self, context):
         ymap_obj = context.active_object
-        create_ymap_group(sollum_type=SollumType.YMAP_MODEL_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Model Occluders')
+        ymap_group = create_ymap_group(sollum_type=SollumType.YMAP_MODEL_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Model Occluders')
+        if ymap_group:
+            bpy.ops.object.select_all(action='DESELECT')
+            ymap_group.select_set(True)
+            context.view_layer.objects.active = ymap_group
         return True
 
 
@@ -85,7 +97,11 @@ class SOLLUMZ_OT_create_box_occluder_group(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         ymap_obj = context.active_object
-        create_ymap_group(sollum_type=SollumType.YMAP_BOX_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Box Occluders')
+        ymap_group = create_ymap_group(sollum_type=SollumType.YMAP_BOX_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Box Occluders')
+        if ymap_group:
+            bpy.ops.object.select_all(action='DESELECT')
+            ymap_group.select_set(True)
+            context.view_layer.objects.active = ymap_group
         return True
 
 
@@ -108,7 +124,11 @@ class SOLLUMZ_OT_create_car_generator_group(SOLLUMZ_OT_base, bpy.types.Operator)
 
     def run(self, context):
         ymap_obj = context.active_object
-        create_ymap_group(sollum_type=SollumType.YMAP_CAR_GENERATOR_GROUP, selected_ymap=ymap_obj, empty_name='Car Generators')
+        ymap_group = create_ymap_group(sollum_type=SollumType.YMAP_CAR_GENERATOR_GROUP, selected_ymap=ymap_obj, empty_name='Car Generators')
+        if ymap_group:
+            bpy.ops.object.select_all(action='DESELECT')
+            ymap_group.select_set(True)
+            context.view_layer.objects.active = ymap_group
         return True
 
 
@@ -176,5 +196,10 @@ class SOLLUMZ_OT_create_car_generator(SOLLUMZ_OT_base, bpy.types.Operator):
         bpy.context.collection.objects.link(cargen_obj)
         bpy.context.view_layer.objects.active = cargen_obj
         cargen_obj.parent = group_obj
+
+        # Select the cargen object
+        bpy.ops.object.select_all(action='DESELECT')
+        cargen_obj.select_set(True)
+        context.view_layer.objects.active = cargen_obj
 
         return True

--- a/ymap/operators.py
+++ b/ymap/operators.py
@@ -39,13 +39,8 @@ class SOLLUMZ_OT_create_entity_group(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         ymap_obj = context.active_object
-        ymap_group = create_ymap_group(sollum_type=SollumType.YMAP_ENTITY_GROUP, selected_ymap=ymap_obj, empty_name='Entities')
-        if ymap_group:
-            bpy.ops.object.select_all(action='DESELECT')
-            ymap_group.select_set(True)
-            context.view_layer.objects.active = ymap_group
-            # TODO: Find a way to use "bpy.ops.outliner.show_active()" to show the new object in outliner. But we are in wrong context here.
-
+        create_ymap_group(sollum_type=SollumType.YMAP_ENTITY_GROUP, selected_ymap=ymap_obj, empty_name='Entities')
+        # TODO: Find a way to use "bpy.ops.outliner.show_active()" to show the new object in outliner. But we are in wrong context here.
         return True
 
 
@@ -69,11 +64,7 @@ class SOLLUMZ_OT_create_model_occluder_group(SOLLUMZ_OT_base, bpy.types.Operator
 
     def run(self, context):
         ymap_obj = context.active_object
-        ymap_group = create_ymap_group(sollum_type=SollumType.YMAP_MODEL_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Model Occluders')
-        if ymap_group:
-            bpy.ops.object.select_all(action='DESELECT')
-            ymap_group.select_set(True)
-            context.view_layer.objects.active = ymap_group
+        create_ymap_group(sollum_type=SollumType.YMAP_MODEL_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Model Occluders')
         return True
 
 
@@ -97,11 +88,7 @@ class SOLLUMZ_OT_create_box_occluder_group(SOLLUMZ_OT_base, bpy.types.Operator):
 
     def run(self, context):
         ymap_obj = context.active_object
-        ymap_group = create_ymap_group(sollum_type=SollumType.YMAP_BOX_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Box Occluders')
-        if ymap_group:
-            bpy.ops.object.select_all(action='DESELECT')
-            ymap_group.select_set(True)
-            context.view_layer.objects.active = ymap_group
+        create_ymap_group(sollum_type=SollumType.YMAP_BOX_OCCLUDER_GROUP, selected_ymap=ymap_obj, empty_name='Box Occluders')
         return True
 
 
@@ -124,11 +111,7 @@ class SOLLUMZ_OT_create_car_generator_group(SOLLUMZ_OT_base, bpy.types.Operator)
 
     def run(self, context):
         ymap_obj = context.active_object
-        ymap_group = create_ymap_group(sollum_type=SollumType.YMAP_CAR_GENERATOR_GROUP, selected_ymap=ymap_obj, empty_name='Car Generators')
-        if ymap_group:
-            bpy.ops.object.select_all(action='DESELECT')
-            ymap_group.select_set(True)
-            context.view_layer.objects.active = ymap_group
+        create_ymap_group(sollum_type=SollumType.YMAP_CAR_GENERATOR_GROUP, selected_ymap=ymap_obj, empty_name='Car Generators')
         return True
 
 

--- a/ymap/operators.py
+++ b/ymap/operators.py
@@ -147,6 +147,10 @@ class SOLLUMZ_OT_create_box_occluder(SOLLUMZ_OT_base, bpy.types.Operator):
         box_obj.active_material = add_occluder_material(SollumType.YMAP_BOX_OCCLUDER)
         box_obj.parent = group_obj
 
+        # Prevent rotation on X and Y axis, since only Z axis is supported on Box Occluders
+        box_obj.lock_rotation[0] = True
+        box_obj.lock_rotation[1] = True
+
         return True
 
 
@@ -196,6 +200,10 @@ class SOLLUMZ_OT_create_car_generator(SOLLUMZ_OT_base, bpy.types.Operator):
         bpy.context.collection.objects.link(cargen_obj)
         bpy.context.view_layer.objects.active = cargen_obj
         cargen_obj.parent = group_obj
+
+        # Prevent rotation on X and Y axis, since only Z axis is supported on Box Occluders
+        cargen_obj.lock_rotation[0] = True
+        cargen_obj.lock_rotation[1] = True
 
         # Select the cargen object
         bpy.ops.object.select_all(action='DESELECT')

--- a/ymap/properties.py
+++ b/ymap/properties.py
@@ -96,7 +96,6 @@ class YmapBlockProperties(bpy.types.PropertyGroup):
 
 
 class YmapProperties(bpy.types.PropertyGroup):
-    name: StringProperty(name="Name", default="untitled_ymap")
     parent: StringProperty(name="Parent", default="")
     flags: IntProperty(name="Flags", default=0, min=0, max=3,
                        update=FlagPropertyGroup.update_flags_total)

--- a/ymap/ui.py
+++ b/ymap/ui.py
@@ -11,7 +11,6 @@ def draw_ymap_properties(self, context):
         layout = self.layout
         layout.use_property_split = True
         layout.use_property_decorate = False
-        layout.prop(obj.ymap_properties, "name")
         layout.prop(obj.ymap_properties, "parent")
 
         layout.label(text="Map Flags")

--- a/ymap/ui.py
+++ b/ymap/ui.py
@@ -2,7 +2,6 @@ import bpy
 
 from ..sollumz_properties import SollumType
 from ..sollumz_ui import SOLLUMZ_PT_OBJECT_PANEL
-from ..ymap.operators import SOLLUMZ_OT_create_ymap
 
 
 def draw_ymap_properties(self, context):

--- a/ymap/ymapexport.py
+++ b/ymap/ymapexport.py
@@ -50,7 +50,7 @@ def triangulate_obj(obj):
 def get_verts_from_obj(obj):
     """
     For each vertex get its coordinates in global space (this way we don't need to apply transfroms)
-    then get their bytes hex representation and append. After that for each face get its indices, 
+    then get their bytes hex representation and append. After that for each face get its indices,
     get their bytes hex representation and append.
 
     :return verts: String if vertex coordinates and face indices in hex representation
@@ -164,42 +164,48 @@ def ymap_from_object(obj):
     for child in obj.children:
         # Entities
         if export_settings.ymap_exclude_entities == False and child.sollum_type == SollumType.YMAP_ENTITY_GROUP:
-            for entity in child.children:
-                if entity.sollum_type == SollumType.DRAWABLE:
-                    ymap.entities.append(entity_from_obj(entity))
+            for entity_obj in child.children:
+                if entity_obj.sollum_type == SollumType.DRAWABLE:
+                    ymap.entities.append(entity_from_obj(entity_obj))
                 else:
                     logger.warning(
-                        f"Object {entity.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.DRAWABLE]} type.")
+                        f"Object {entity_obj.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.DRAWABLE]} type.")
 
         # Box occluders
         if export_settings.ymap_box_occluders == False and child.sollum_type == SollumType.YMAP_BOX_OCCLUDER_GROUP:
             obj.ymap_properties.content_flags_toggle.has_occl = True
 
-            for cargen in child.children:
-                if cargen.sollum_type == SollumType.YMAP_BOX_OCCLUDER:
-                    ymap.box_occluders.append(box_from_obj(cargen))
-                    calculate_extents(ymap, cargen)
+            for box_obj in child.children:
+                rotation = box_obj.rotation_euler
+                if rotation.x > 0.01 or rotation.y > 0.01:
+                    logger.error(
+                        f"Box occluders only support Z-axis rotation. Skipping {box_obj.name} due to X/Y rotation.")
+                    continue
+
+                if box_obj.sollum_type == SollumType.YMAP_BOX_OCCLUDER:
+                    ymap.box_occluders.append(box_from_obj(box_obj))
+                    calculate_extents(ymap, box_obj)
                 else:
                     logger.warning(
-                        f"Object {cargen.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_BOX_OCCLUDER]} type.")
+                        f"Object {box_obj.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_BOX_OCCLUDER]} type.")
 
         # Model occluders
         if export_settings.ymap_model_occluders == False and child.sollum_type == SollumType.YMAP_MODEL_OCCLUDER_GROUP:
             obj.ymap_properties.content_flags_toggle.has_occl = True
 
-            for model in child.children:
-                if model.sollum_type == SollumType.YMAP_MODEL_OCCLUDER:
-                    if len(model.data.vertices) > 256:
+            for model_obj in child.children:
+                if model_obj.sollum_type == SollumType.YMAP_MODEL_OCCLUDER:
+                    if len(model_obj.data.vertices) > 256:
                         logger.warning(
-                            f"Object {model.name} has too many vertices and will be skipped. It can not have more than 256 vertices.")
+                            f"Object {model_obj.name} has too many vertices and will be skipped. It can not have more than 256 vertices.")
                         continue
 
                     ymap.occlude_models.append(
-                        model_from_obj(model))
-                    calculate_extents(ymap, model)
+                        model_from_obj(model_obj))
+                    calculate_extents(ymap, model_obj)
                 else:
                     logger.warning(
-                        f"Object {model.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_MODEL_OCCLUDER]} type.")
+                        f"Object {model_obj.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_MODEL_OCCLUDER]} type.")
 
         # TODO: physics_dictionaries
 
@@ -207,12 +213,17 @@ def ymap_from_object(obj):
 
         # Car generators
         if export_settings.ymap_car_generators == False and child.sollum_type == SollumType.YMAP_CAR_GENERATOR_GROUP:
-            for cargen in child.children:
-                if cargen.sollum_type == SollumType.YMAP_CAR_GENERATOR:
-                    ymap.car_generators.append(cargen_from_obj(cargen))
+            for cargen_obj in child.children:
+                rotation = cargen_obj.rotation_euler
+                if rotation.x > 0.01 or rotation.y > 0.01:
+                    logger.error(
+                        f"Car generators only support Z-axis rotation. Skipping {cargen_obj.name} due to X/Y rotation.")
+                    continue
+                if cargen_obj.sollum_type == SollumType.YMAP_CAR_GENERATOR:
+                    ymap.car_generators.append(cargen_from_obj(cargen_obj))
                 else:
                     logger.warning(
-                        f"Object {cargen.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_CAR_GENERATOR]} type.")
+                        f"Object {cargen_obj.name} will be skipped because it is not a {SOLLUMZ_UI_NAMES[SollumType.YMAP_CAR_GENERATOR]} type.")
 
         # TODO: lod ligths
 

--- a/ymap/ymapexport.py
+++ b/ymap/ymapexport.py
@@ -218,7 +218,7 @@ def ymap_from_object(obj):
 
         # TODO: distant lod lights
 
-    ymap.name = obj.name if not "." in obj.name else obj.name.split(".")[0]
+    ymap.name = remove_number_suffix(obj.name)
     ymap.parent = obj.ymap_properties.parent
     ymap.flags = obj.ymap_properties.flags
     ymap.content_flags = obj.ymap_properties.content_flags

--- a/ymap/ymapexport.py
+++ b/ymap/ymapexport.py
@@ -177,7 +177,7 @@ def ymap_from_object(obj):
 
             for box_obj in child.children:
                 rotation = box_obj.rotation_euler
-                if rotation.x > 0.01 or rotation.y > 0.01:
+                if abs(rotation.x) > 0.01 or abs(rotation.y) > 0.01:
                     logger.error(
                         f"Box occluders only support Z-axis rotation. Skipping {box_obj.name} due to X/Y rotation.")
                     continue
@@ -215,7 +215,7 @@ def ymap_from_object(obj):
         if export_settings.ymap_car_generators == False and child.sollum_type == SollumType.YMAP_CAR_GENERATOR_GROUP:
             for cargen_obj in child.children:
                 rotation = cargen_obj.rotation_euler
-                if rotation.x > 0.01 or rotation.y > 0.01:
+                if abs(rotation.x) > 0.01 or abs(rotation.y) > 0.01:
                     logger.error(
                         f"Car generators only support Z-axis rotation. Skipping {cargen_obj.name} due to X/Y rotation.")
                     continue

--- a/ymap/ymapimport.py
+++ b/ymap/ymapimport.py
@@ -241,7 +241,6 @@ def ymap_to_obj(ymap: CMapData):
     bpy.context.collection.objects.link(ymap_obj)
     bpy.context.view_layer.objects.active = ymap_obj
 
-    ymap_obj.ymap_properties.name = ymap.name
     ymap_obj.ymap_properties.parent = ymap.parent
     ymap_obj.ymap_properties.flags = ymap.flags
     ymap_obj.ymap_properties.content_flags = ymap.content_flags


### PR DESCRIPTION
I know the whole ymap thing should be entirely refactored, but here is some small QOL fixes/tweaks.
See commits descriptions for more info