### PR TITLE
tweak(ydr): refactor how vertex groups are processed

### DIFF
--- a/ydr/vertex_buffer_builder.py
+++ b/ydr/vertex_buffer_builder.py
@@ -183,10 +183,6 @@ class VertexBufferBuilder:
             vertex_group = vgroups[element.group]
             bone_index = bone_by_vgroup[element.group]
 
-            # skip the locked vertex group
-            if vertex_group.lock_weight is True:
-                continue
-
             # skip the group that doesn't have a corresponding bone
             if bone_index == -1:
                 continue

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -251,7 +251,7 @@ def create_geometries_xml(mesh_eval: bpy.types.Mesh, materials: list[bpy.types.M
     bone_by_vgroup = get_bone_by_vgroup(
         vertex_groups, bones) if bones and vertex_groups else None
 
-    total_vert_buffer = VertexBufferBuilder(mesh_eval, bone_by_vgroup, vertex_groups).build()
+    total_vert_buffer = VertexBufferBuilder(mesh_eval, bone_by_vgroup).build()
 
     for mat_index, loop_inds in loop_inds_by_mat.items():
         material = materials[mat_index]

--- a/ydr/ydrexport.py
+++ b/ydr/ydrexport.py
@@ -251,7 +251,7 @@ def create_geometries_xml(mesh_eval: bpy.types.Mesh, materials: list[bpy.types.M
     bone_by_vgroup = get_bone_by_vgroup(
         vertex_groups, bones) if bones and vertex_groups else None
 
-    total_vert_buffer = VertexBufferBuilder(mesh_eval, bone_by_vgroup).build()
+    total_vert_buffer = VertexBufferBuilder(mesh_eval, bone_by_vgroup, vertex_groups).build()
 
     for mat_index, loop_inds in loop_inds_by_mat.items():
         material = materials[mat_index]


### PR DESCRIPTION
This PR fixes #845 and adds some QoL improvements on the process of weights.

- Vertex groups for each vertex are sorted by weights. Before the patch the default behavior simply ignores any group with an index greater than 3 and will be likely to accidentially prevent some groups with significant influence from exporting when there are lots of groups per vertex.
- get_bone_by_vgroup() now uses -1 for the vertex group without a corresponding bone. Before the patch it uses 0 but there is always an actual bone with 0 index (e.g. SKEL_Root).