### PR TITLE
tweak(light): drastically improved light creation

### DIFF
--- a/ydr/properties.py
+++ b/ydr/properties.py
@@ -595,6 +595,10 @@ def register():
         default=LightType.POINT,
         options={"HIDDEN"}
     )
+    bpy.types.Scene.create_light_with_selected_preset = bpy.props.BoolProperty(
+        name="Use Selected Preset", description="Applies the selected preset when creating a light", default=False)
+    bpy.types.Scene.ignore_light_preset_color = bpy.props.BoolProperty(
+        name="Ignore Preset Color", description="Ignores the color from the selected preset", default=False)
     bpy.types.Light.time_flags = bpy.props.PointerProperty(type=TimeFlags)
     bpy.types.Light.light_flags = bpy.props.PointerProperty(type=LightFlags)
 
@@ -628,6 +632,8 @@ def unregister():
     del bpy.types.Bone.bone_properties
     del bpy.types.Light.light_properties
     del bpy.types.Scene.create_light_type
+    del bpy.types.Scene.create_light_with_selected_preset
+    del bpy.types.Scene.ignore_light_preset_color
     del bpy.types.Light.time_flags
     del bpy.types.Light.light_flags
     del bpy.types.Light.is_capsule

--- a/ydr/ui.py
+++ b/ydr/ui.py
@@ -1,5 +1,9 @@
 import bpy
 from bpy.types import Context
+
+from ..ydr.properties import light_presets, load_light_presets
+
+from ..cwxml.light_preset import LightPreset
 from . import operators as ydr_ops
 from .shader_materials import shadermats
 from ..cwxml.shader import ShaderManager
@@ -414,6 +418,9 @@ class SOLLUMZ_PT_CREATE_LIGHT_PANEL(bpy.types.Panel):
         row = layout.row(align=True)
         row.operator(ydr_ops.SOLLUMZ_OT_create_light.bl_idname)
         row.prop(context.scene, "create_light_type", text="")
+        row = layout.row()
+        row.prop(context.scene, "create_light_with_selected_preset")
+        row.prop(context.scene, "ignore_light_preset_color")
 
 
 class SOLLUMZ_UL_LIGHT_PRESET_LIST(bpy.types.UIList):


### PR DESCRIPTION
This PR adds some QoL improvements to the light creation process:
* Always creates the light at the 3D cursor's position.
* If a Sollum object is selected, the light will be attached to it properly.
* Allows creating a light with the selected preset.
* An option to ignore the light's color from the preset.