### PR TITLE
fix(yft): pack shattermaps into the current blend file

### DIFF
--- a/yft/yftimport.py
+++ b/yft/yftimport.py
@@ -431,6 +431,7 @@ def shattermap_to_image(shattermap, name):
 
 def shattermap_to_material(shattermap, name):
     img = shattermap_to_image(shattermap, name)
+    bpy.data.images[img.name].pack()
     mat = material_from_image(img, name, "ShatterMap")
     mat.sollum_type = MaterialType.SHATTER_MAP
 

--- a/yft/yftimport.py
+++ b/yft/yftimport.py
@@ -431,7 +431,7 @@ def shattermap_to_image(shattermap, name):
 
 def shattermap_to_material(shattermap, name):
     img = shattermap_to_image(shattermap, name)
-    bpy.data.images[img.name].pack()
+    img.pack()
     mat = material_from_image(img, name, "ShatterMap")
     mat.sollum_type = MaterialType.SHATTER_MAP
 


### PR DESCRIPTION
this is done to preserve the shattermap data, as otherwise if the user does not manually save the shattermap images themselves and then close blender, the data will be lost.