### PR TITLE
tweak(gizmo): Only allow selection in object mode

### DIFF
--- a/ydr/gizmos/lights.py
+++ b/ydr/gizmos/lights.py
@@ -26,6 +26,9 @@ class SOLLUMZ_OT_object_select(Operator):
         if obj is None:
             return {"CANCELLED"}
 
+        if context.mode != 'OBJECT':
+            return {"CANCELLED"}
+
         if not self.extend:
             bpy.ops.object.select_all(action="DESELECT")
         obj.select_set(True)


### PR DESCRIPTION
this fixes an issue when selecting a light gizmo while in edit mode (or other modes), it would give an error because of incorrect context.