### PR TITLE
fix(ydr): spec_decal shader not being created properly

### DIFF
--- a/ydr/shader_materials.py
+++ b/ydr/shader_materials.py
@@ -1062,7 +1062,7 @@ def create_basic_shader_nodes(b: ShaderBuilder):
             decalflag = 2
         elif filename in {"decal_normal_only.sps", "mirror_decal.sps", "reflect_decal.sps"}:
             decalflag = 3
-        elif filename in {"decal_spec_only.sps", "spec_decal.sps"}:
+        elif filename in {"decal_spec_only.sps"}:
             decalflag = 4
         elif filename == "decal_amb_only.sps":
             decalflag = 5


### PR DESCRIPTION
before the material would look like this, 
<img width="1084" height="359" alt="image" src="https://github.com/user-attachments/assets/fe16f19f-a5b6-4308-99ce-3c1113e4af8d" />

now the material has its vertex colour alpha used correctly,
<img width="1458" height="407" alt="image" src="https://github.com/user-attachments/assets/7e17d1da-f048-419b-b04f-858e699a6102" />
