### PR TITLE
tweak(properties): Change default color for Vertex Painter color 1

### DIFF
--- a/sollumz_properties.py
+++ b/sollumz_properties.py
@@ -541,7 +541,7 @@ def register():
     bpy.types.Scene.vert_paint_color1 = bpy.props.FloatVectorProperty(
         name="Vert Color 1",
         subtype="COLOR_GAMMA",
-        default=(1.0, 1.0, 1.0, 1.0),
+        default=(0.0, 1.0, 1.0, 1.0),
         min=0,
         max=1,
         size=4


### PR DESCRIPTION
Currently its default to white, which is sort of misleading as the others are set to ones for terrain, which might lead to people using white for terrain painting, leading to the issue where some terrain appears black in game but looks fine everywhere else