### PR TITLE
fixing .ydr wheel imports not detecting mapped paint layers correctly.

### DIFF
--- a/ydr/ydrimport.py
+++ b/ydr/ydrimport.py
@@ -53,6 +53,11 @@ def create_drawable_obj(drawable_xml: Drawable, filepath: str, name: Optional[st
     name = name or drawable_xml.name
     materials = materials or shadergroup_to_materials(drawable_xml.shader_group, filepath)
 
+    for mat in materials:
+        if "matDiffuseColor" in mat.node_tree.nodes:
+            from ..yft.properties import _update_mat_paint_name
+            _update_mat_paint_name(mat)
+
     has_skeleton = len(drawable_xml.skeleton.bones) > 0
 
     if external_bones:

--- a/ydr/ydrimport_io.py
+++ b/ydr/ydrimport_io.py
@@ -71,6 +71,12 @@ def create_drawable(
     materials = materials or shader_group_to_materials(drawable.shader_group)
     hi_materials = hi_materials or []
 
+    for mat in set(materials) | set(hi_materials):
+        if "matDiffuseColor" in mat.node_tree.nodes:
+            from ..yft.properties import _update_mat_paint_name
+            _update_mat_paint_name(mat)
+
+
     skeleton = drawable.skeleton
     has_skeleton = skeleton and len(skeleton.bones) > 0
 

--- a/yft/ui.py
+++ b/yft/ui.py
@@ -542,9 +542,10 @@ class SOLLUMZ_PT_FRAGMENT_MAT_PANEL(bpy.types.Panel):
             return False
 
         has_frag_parent = find_sollumz_parent(aobj, parent_type=SollumType.FRAGMENT) is not None
+        has_drawable_parent = find_sollumz_parent(aobj, parent_type=SollumType.DRAWABLE) is not None
         mat = aobj.active_material
 
-        return mat is not None and mat.sollum_type == MaterialType.SHADER and has_frag_parent
+        return mat is not None and mat.sollum_type == MaterialType.SHADER and (has_frag_parent or has_drawable_parent)
 
     def draw(self, context):
         layout = self.layout


### PR DESCRIPTION
when importing .ydr, it did not correctly detect the paint types assigned to meshes (for example on independent wheel files). I think it was because it would only work if you import a parent fragment, and completely skipped drawables. this used to work in 2.6.1 (i tested) so this just fixes for 2.8.
I used claude opus 4.6 to edit the code.