### PR TITLE
tweak(ymapimport): Import order

### DIFF
--- a/sollumz_operators.py
+++ b/sollumz_operators.py
@@ -204,8 +204,8 @@ class ImportAssetsOperatorImpl(ImportSettingsBase, TimedOperator):
             self.directory = bpy.path.abspath(self.directory)
 
             filenames = [f.name for f in self.files]
-            filenames, ytyp_filenames = self._separate_ytyp_filenames(filenames)
-            filenames = self._dedupe_hi_yft_filenames(filenames)
+            asset_filenames, ytyp_filenames, ymap_filenames = self._separate_asset_filenames(filenames)
+            asset_filenames = self._dedupe_hi_yft_filenames(asset_filenames)
 
             from pathlib import Path
             from szio.gta5 import try_load_asset, AssetType, AssetWithDependencies
@@ -301,12 +301,16 @@ class ImportAssetsOperatorImpl(ImportSettingsBase, TimedOperator):
                     logger.error(f"Error importing: {filepath} \n {traceback.format_exc()}")
                     return False
 
-            for filename in filenames:
+            for filename in asset_filenames:
                 _import_asset(filename)
 
             # Import the .ytyps after all the assets to ensure that the archetypes get linked to their object in case
             # they are imported together
             for filename in ytyp_filenames:
+                _import_asset(filename)
+
+            # Import the .ymaps at the end to ensure all the assets get instantiated correctly
+            for filename in ymap_filenames:
                 _import_asset(filename)
 
             logger.info(f"Imported in {self.time_elapsed} seconds")
@@ -334,13 +338,18 @@ class ImportAssetsOperatorImpl(ImportSettingsBase, TimedOperator):
             )
         ]
 
-    def _separate_ytyp_filenames(self, filenames: list[str]) -> tuple[list[str], list[str]]:
-        """Separate the filenames list into two lists, one with all the assets and another one only with .ytyps."""
-        asset_filenames, ytyp_filenames = [], []
+    def _separate_asset_filenames(self, filenames: list[str]) -> tuple[list[str], list[str], list[str]]:
+        """Separate the filenames list into three lists, one with all the assets, one with only .ymaps and another one only with .ytyps."""
+        asset_filenames, ytyp_filenames, ymap_filenames = [], [], []
         for f in filenames:
-            dest = ytyp_filenames if f.endswith(".ytyp") or f.endswith(".ytyp.xml") else asset_filenames
-            dest.append(f)
-        return asset_filenames, ytyp_filenames
+            if f.endswith((".ytyp", ".ytyp.xml")):
+                ytyp_filenames.append(f)
+            elif f.endswith((".ymap", ".ymap.xml")):
+                ymap_filenames.append(f)
+            else:
+                asset_filenames.append(f)
+
+        return asset_filenames, ytyp_filenames, ymap_filenames
 
 
 class SOLLUMZ_OT_import_assets(ImportAssetsOperatorImpl, Operator):

--- a/ymap/ymapimport.py
+++ b/ymap/ymapimport.py
@@ -16,6 +16,7 @@ from ..tools.blenderhelper import create_blender_object, create_empty_object
 from ..tools.meshhelper import create_box
 from .. import logger
 
+from szio.gta5.jenkhash import try_resolve_maybe_hashed_name
 # TODO: Make better?
 
 
@@ -33,7 +34,7 @@ def occlude_model_to_mesh_data(model: OccludeModel) -> tuple[NDArray, NDArray]:
 
 
 def apply_entity_properties(obj, entity):
-    obj.entity_properties.archetype_name = entity.archetype_name
+    obj.entity_properties.archetype_name = try_resolve_maybe_hashed_name(entity.archetype_name)
     obj.entity_properties.flags = entity.flags
     obj.entity_properties.guid = entity.guid
     obj.entity_properties.parent_index = entity.parent_index
@@ -67,7 +68,9 @@ def entity_to_obj(ymap_obj: bpy.types.Object, ymap: CMapData):
     if ymap.entities:
         for obj in bpy.context.collection.all_objects:
             for entity in ymap.entities:
-                if entity.archetype_name == obj.name and obj.name in bpy.context.view_layer.objects:
+                resolved_archetype_name = try_resolve_maybe_hashed_name(entity.archetype_name)
+
+                if resolved_archetype_name == obj.name and obj.name in bpy.context.view_layer.objects:
                     found = True
                     apply_entity_properties(obj, entity)
         if found:
@@ -97,7 +100,9 @@ def instanced_entity_to_obj(ymap_obj: bpy.types.Object, ymap: CMapData):
         count = 0
 
         for entity in ymap.entities:
-            obj = bpy.data.objects.get(entity.archetype_name, None)
+            resolved_archetype_name = try_resolve_maybe_hashed_name(entity.archetype_name)
+
+            obj = bpy.data.objects.get(resolved_archetype_name, None)
             if obj is None:
                 # No object with the given archetype name found
                 continue
@@ -119,14 +124,16 @@ def instanced_entity_to_obj(ymap_obj: bpy.types.Object, ymap: CMapData):
 
         if not import_settings.ymap_skip_missing_entities:
             for entity in ymap.entities:
+                resolved_archetype_name = try_resolve_maybe_hashed_name(entity.archetype_name)
+
                 if entity.found is None:
                     empty_obj = bpy.data.objects.new(
-                        entity.archetype_name + " (not found)", None)
+                        resolved_archetype_name + " (not found)", None)
                     empty_obj.parent = group_obj
                     apply_entity_properties(empty_obj, entity)
                     empty_obj.sollum_type = SollumType.DRAWABLE
                     logger.error(
-                        f"'{entity.archetype_name}' is missing in scene, creating an empty drawable instead.")
+                        f"'{resolved_archetype_name}' is missing in scene, creating an empty drawable instead.")
         if count > 0:
             logger.info(
                 f"Succesfully placed {count}/{entities_amount} entities from scene!")


### PR DESCRIPTION
Sometimes YMAPs get imported before the assets, needing to be reimported before they can be placed correctly. This ensures the YMAPs properly detect and link to the assets they were imported with.