### PR TITLE
tweak(mlo/ui): Dont display unused mlo flags in UI

### DIFF
--- a/ytyp/ui/mlo.py
+++ b/ytyp/ui/mlo.py
@@ -382,3 +382,17 @@ class SOLLUMZ_PT_MLO_FLAGS_PANEL(MloChildTabPanel, MultiSelectUIFlagsPanel, bpy.
     def get_flags_selection(self, context):
         selected_ytyp = get_selected_ytyp(context)
         return selected_ytyp.archetypes.selection.mlo_flags
+
+    def draw(self, context):
+        active = self.get_flags_active(context)
+        selection = self.get_flags_selection(context)
+        self.layout.prop(selection.owner, selection.propnames.total)
+        self.layout.separator()
+        grid = self.layout.grid_flow(columns=2)
+        active_props = active.bl_rna.properties
+        for index, prop_name in enumerate(active.get_flag_names()):
+            if index > active.size - 1:
+                break
+            if active_props[prop_name].name == "Unused":
+                continue
+            grid.prop(selection.owner, getattr(selection.propnames, prop_name))


### PR DESCRIPTION
<img width="678" height="227" alt="image" src="https://github.com/user-attachments/assets/912e77c0-25ce-408f-9722-7712706b71cf" />

no point in showing these flags to the user