### PR TITLE
tweak(prefs): default ytyp export to selected only

### DIFF
--- a/sollumz_preferences.py
+++ b/sollumz_preferences.py
@@ -162,7 +162,7 @@ class ExportSettingsBase:
     )
     export_ytyps_include: EnumProperty(
         name="Include YTYPs",
-        default="ALL",
+        default="SELECTED",
         items=(
             ("ALL", "All", "Export all YTYPs in the scene"),
             ("SELECTED", "Selected", "Export the selected YTYP"),


### PR DESCRIPTION
after recent changes, sollumz now automatically defaults to export all ytyps when exporting, this changes it back to original behaviour by default